### PR TITLE
設定画面の名称を「ダッシュボード」に変更

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -236,8 +236,8 @@
     }
   },
   "settingsTitle": {
-    "message": "VisionFocus Settings",
-    "description": "Settings page title"
+    "message": "VisionFocus Dashboard",
+    "description": "Dashboard page title"
   },
   "saveChanges": {
     "message": "Save Changes",

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -236,8 +236,8 @@
     }
   },
   "settingsTitle": {
-    "message": "VisionFocus 設定",
-    "description": "設定ページタイトル"
+    "message": "VisionFocus ダッシュボード",
+    "description": "ダッシュボードページタイトル"
   },
   "saveChanges": {
     "message": "変更を保存",


### PR DESCRIPTION
## Summary
- Options画面の名称を「設定」から「ダッシュボード」に変更
- 英語・日本語の多言語ファイルを更新

## Changes
- `assets/_locales/ja/messages.json`: "settingsTitle" を「VisionFocus ダッシュボード」に変更
- `assets/_locales/en/messages.json`: "settingsTitle" を「VisionFocus Dashboard」に変更

## Test plan
- [ ] ブラウザでOptions画面を開き、タイトルが「VisionFocus ダッシュボード」になっていることを確認
- [ ] 英語環境で「VisionFocus Dashboard」と表示されることを確認

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)