### PR TITLE
スタイルタブの名称を「カスタマイズ」に変更

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -98,8 +98,8 @@
     "description": "General settings tab"
   },
   "styles": {
-    "message": "Styles",
-    "description": "Styles settings tab"
+    "message": "Customize",
+    "description": "Customize settings tab"
   },
   "blockList": {
     "message": "Block List",

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -98,8 +98,8 @@
     "description": "一般設定タブ"
   },
   "styles": {
-    "message": "スタイル",
-    "description": "スタイル設定タブ"
+    "message": "カスタマイズ",
+    "description": "カスタマイズ設定タブ"
   },
   "blockList": {
     "message": "ブロックリスト",


### PR DESCRIPTION
## Summary
- スタイルタブの名称を「スタイル」から「カスタマイズ」に変更
- 英語・日本語の多言語ファイルを更新

## Changes
- `assets/_locales/ja/messages.json`: "styles" を「カスタマイズ」に変更
- `assets/_locales/en/messages.json`: "styles" を「Customize」に変更

## Test plan
- [ ] Options画面を開き、タブ名が「カスタマイズ」になっていることを確認
- [ ] 英語環境で「Customize」と表示されることを確認

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)