### PR TITLE
プレミアムステータスのAPIキャッシュを導入

### DIFF
--- a/src/lib/license.ts
+++ b/src/lib/license.ts
@@ -1,34 +1,63 @@
 import { isExtPayPremium } from './extpay';
+import { storage } from './storage';
 import {
   FEATURE_LIMITS,
   type FeatureLimits,
   type PremiumFeature
 } from '~/types/storage';
 
+/** Cache duration: 1 hour */
+const CACHE_DURATION = 60 * 60 * 1000;
+
+interface PremiumCache {
+  status: {
+    isPremium: boolean;
+    source: 'extpay' | null;
+  };
+  timestamp: number;
+}
+
 /**
  * Check if user has premium access (via ExtensionPay)
+ * Results are cached for 1 hour to reduce API calls
  */
 export async function checkPremiumStatus(): Promise<{
   isPremium: boolean;
   source: 'extpay' | null;
 }> {
+  // Check cache first
+  const cached = (await storage.get('premiumCache')) as
+    | PremiumCache
+    | undefined;
+  if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
+    return cached.status;
+  }
+
   // Check ExtensionPay subscription status
   try {
     const isPaid = await isExtPayPremium();
-    if (isPaid) {
-      return {
-        isPremium: true,
-        source: 'extpay'
-      };
-    }
-  } catch {
-    // Assume not premium if check fails
-  }
+    const status = {
+      isPremium: isPaid,
+      source: (isPaid ? 'extpay' : null) as 'extpay' | null
+    };
 
-  return {
-    isPremium: false,
-    source: null
-  };
+    // Save to cache
+    await storage.set('premiumCache', {
+      status,
+      timestamp: Date.now()
+    });
+
+    return status;
+  } catch {
+    // On error, use previous cache if available (even if expired)
+    if (cached) {
+      return cached.status;
+    }
+    return {
+      isPremium: false,
+      source: null
+    };
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- ExtensionPayのAPI呼び出しに1時間のキャッシュを導入
- 過剰なAPI呼び出しを防ぎ、レートリミット対策を実施

## Background
- popup.tsx, newtab.tsx, options.tsx それぞれで usePremiumStatus() を使用
- 各画面を開くたびに ext.getUser() でAPIを呼び出していた
- ExtPayのレートリミットでブロックされるリスクがあった

## Changes
- `src/lib/license.ts`:
  - checkPremiumStatus 関数にキャッシュロジックを追加
  - キャッシュ期間: 1時間
  - エラー時は期限切れのキャッシュも利用可能

## Test plan
- [ ] 初回アクセス時にAPIが呼び出されることを確認
- [ ] 1時間以内の再アクセスでキャッシュが使用されることを確認
- [ ] プレミアムステータスが正しく反映されることを確認

Closes #18

🤖 Generated with [Claude Code](https://claude.ai/code)