### PR TITLE
feat: 設定のエクスポート・インポート機能を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1280,5 +1280,111 @@
   "noBlockedSitesYet": {
     "message": "None yet",
     "description": "No blocked sites yet message"
+  },
+  "dataBackup": {
+    "message": "Data Backup",
+    "description": "Data backup section title"
+  },
+  "dataBackupDescription": {
+    "message": "Export and import your settings to backup or transfer to another device",
+    "description": "Data backup description"
+  },
+  "exportSettings": {
+    "message": "Export Settings",
+    "description": "Export settings button"
+  },
+  "exportSettingsDescription": {
+    "message": "Download your block list, schedules, and dashboard styles as a JSON file",
+    "description": "Export settings description"
+  },
+  "importSettings": {
+    "message": "Import Settings",
+    "description": "Import settings button"
+  },
+  "importSettingsDescription": {
+    "message": "Restore settings from a previously exported backup file",
+    "description": "Import settings description"
+  },
+  "exportSuccess": {
+    "message": "Settings exported successfully!",
+    "description": "Export success message"
+  },
+  "exportError": {
+    "message": "Failed to export settings: $ERROR$",
+    "description": "Export error message",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "Unknown error"
+      }
+    }
+  },
+  "importSuccess": {
+    "message": "Settings imported: $BLOCKLIST$ sites, $SCHEDULES$ schedules, $PRESETS$ styles",
+    "description": "Import success message",
+    "placeholders": {
+      "blocklist": {
+        "content": "$1",
+        "example": "5"
+      },
+      "schedules": {
+        "content": "$2",
+        "example": "2"
+      },
+      "presets": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
+  "importError": {
+    "message": "Failed to import settings: $ERROR$",
+    "description": "Import error message",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "Invalid file format"
+      }
+    }
+  },
+  "selectFile": {
+    "message": "Select File",
+    "description": "Select file button"
+  },
+  "backupIncludes": {
+    "message": "Backup includes",
+    "description": "Backup includes heading"
+  },
+  "backupIncludesBlockList": {
+    "message": "Block list",
+    "description": "Backup includes: block list"
+  },
+  "backupIncludesSchedules": {
+    "message": "Schedules",
+    "description": "Backup includes: schedules"
+  },
+  "backupIncludesPresets": {
+    "message": "Dashboard styles & settings",
+    "description": "Backup includes: presets"
+  },
+  "backupExcludes": {
+    "message": "Not included",
+    "description": "Backup excludes heading"
+  },
+  "backupExcludesAnalytics": {
+    "message": "Analytics data",
+    "description": "Backup excludes: analytics"
+  },
+  "backupExcludesPremium": {
+    "message": "Premium subscription status",
+    "description": "Backup excludes: premium"
+  },
+  "importing": {
+    "message": "Importing...",
+    "description": "Import in progress text"
+  },
+  "exporting": {
+    "message": "Exporting...",
+    "description": "Export in progress text"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1280,5 +1280,111 @@
   "noBlockedSitesYet": {
     "message": "まだなし",
     "description": "ブロックサイトがまだない場合のメッセージ"
+  },
+  "dataBackup": {
+    "message": "データバックアップ",
+    "description": "データバックアップセクションタイトル"
+  },
+  "dataBackupDescription": {
+    "message": "設定をエクスポート・インポートして、バックアップや他のデバイスへの移行ができます",
+    "description": "データバックアップ説明"
+  },
+  "exportSettings": {
+    "message": "設定をエクスポート",
+    "description": "設定エクスポートボタン"
+  },
+  "exportSettingsDescription": {
+    "message": "ブロックリスト、スケジュール、ダッシュボードスタイルをJSONファイルとしてダウンロード",
+    "description": "設定エクスポート説明"
+  },
+  "importSettings": {
+    "message": "設定をインポート",
+    "description": "設定インポートボタン"
+  },
+  "importSettingsDescription": {
+    "message": "以前エクスポートしたバックアップファイルから設定を復元",
+    "description": "設定インポート説明"
+  },
+  "exportSuccess": {
+    "message": "設定をエクスポートしました！",
+    "description": "エクスポート成功メッセージ"
+  },
+  "exportError": {
+    "message": "エクスポートに失敗しました: $ERROR$",
+    "description": "エクスポートエラーメッセージ",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "不明なエラー"
+      }
+    }
+  },
+  "importSuccess": {
+    "message": "設定をインポートしました: サイト$BLOCKLIST$件、スケジュール$SCHEDULES$件、スタイル$PRESETS$件",
+    "description": "インポート成功メッセージ",
+    "placeholders": {
+      "blocklist": {
+        "content": "$1",
+        "example": "5"
+      },
+      "schedules": {
+        "content": "$2",
+        "example": "2"
+      },
+      "presets": {
+        "content": "$3",
+        "example": "3"
+      }
+    }
+  },
+  "importError": {
+    "message": "インポートに失敗しました: $ERROR$",
+    "description": "インポートエラーメッセージ",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "無効なファイル形式"
+      }
+    }
+  },
+  "selectFile": {
+    "message": "ファイルを選択",
+    "description": "ファイル選択ボタン"
+  },
+  "backupIncludes": {
+    "message": "バックアップに含まれるもの",
+    "description": "バックアップに含まれるもの見出し"
+  },
+  "backupIncludesBlockList": {
+    "message": "ブロックリスト",
+    "description": "バックアップに含まれるもの: ブロックリスト"
+  },
+  "backupIncludesSchedules": {
+    "message": "スケジュール",
+    "description": "バックアップに含まれるもの: スケジュール"
+  },
+  "backupIncludesPresets": {
+    "message": "ダッシュボードスタイル・設定",
+    "description": "バックアップに含まれるもの: プリセット"
+  },
+  "backupExcludes": {
+    "message": "含まれないもの",
+    "description": "バックアップに含まれないもの見出し"
+  },
+  "backupExcludesAnalytics": {
+    "message": "分析データ",
+    "description": "バックアップに含まれないもの: 分析"
+  },
+  "backupExcludesPremium": {
+    "message": "プレミアムサブスクリプション状態",
+    "description": "バックアップに含まれないもの: プレミアム"
+  },
+  "importing": {
+    "message": "インポート中...",
+    "description": "インポート中テキスト"
+  },
+  "exporting": {
+    "message": "エクスポート中...",
+    "description": "エクスポート中テキスト"
   }
 }

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -1,12 +1,96 @@
-import React from 'react';
-import { ExternalLink, MessageCircle, BookOpen, Mail } from 'lucide-react';
+import React, { useRef, useState } from 'react';
+import {
+  ExternalLink,
+  MessageCircle,
+  BookOpen,
+  Mail,
+  Download,
+  Upload,
+  Check,
+  X,
+  AlertCircle
+} from 'lucide-react';
 
-import { Card } from '~/components/ui';
+import { Button, Card } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
+import { exportSettings, importSettings } from '~/lib/settingsBackup';
 
 const VERSION = '1.0.0';
 
+type FeedbackState = {
+  type: 'success' | 'error';
+  message: string;
+} | null;
+
 export function HelpTab() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [feedback, setFeedback] = useState<FeedbackState>(null);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    setFeedback(null);
+
+    try {
+      const result = await exportSettings();
+      if (result.success) {
+        setFeedback({
+          type: 'success',
+          message: getMessage('exportSuccess')
+        });
+      } else {
+        setFeedback({
+          type: 'error',
+          message: getMessage('exportError', result.error || 'Unknown error')
+        });
+      }
+    } finally {
+      setIsExporting(false);
+      // Clear feedback after 5 seconds
+      setTimeout(() => setFeedback(null), 5000);
+    }
+  };
+
+  const handleImport = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsImporting(true);
+    setFeedback(null);
+
+    try {
+      const result = await importSettings(file);
+      if (result.success && result.imported) {
+        setFeedback({
+          type: 'success',
+          message: getMessage('importSuccess', [
+            String(result.imported.blockList),
+            String(result.imported.schedules),
+            String(result.imported.presets)
+          ])
+        });
+        // Reload the page to reflect imported settings
+        setTimeout(() => window.location.reload(), 1500);
+      } else {
+        setFeedback({
+          type: 'error',
+          message: getMessage('importError', result.error || 'Unknown error')
+        });
+      }
+    } finally {
+      setIsImporting(false);
+      // Reset file input
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
   return (
     <div className="space-y-6">
       {/* Getting Started */}
@@ -120,6 +204,118 @@ export function HelpTab() {
           <p className="text-xs text-gray-400">
             {getMessage('helpComingSoon')}
           </p>
+        </div>
+      </Card>
+
+      {/* Data Backup */}
+      <Card>
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
+            <Download className="w-5 h-5 text-amber-600" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {getMessage('dataBackup')}
+            </h2>
+            <p className="text-sm text-gray-500">
+              {getMessage('dataBackupDescription')}
+            </p>
+          </div>
+        </div>
+
+        {/* Feedback Message */}
+        {feedback && (
+          <div
+            className={`flex items-center gap-2 p-3 rounded-lg mb-4 ${
+              feedback.type === 'success'
+                ? 'bg-green-50 text-green-700'
+                : 'bg-red-50 text-red-700'
+            }`}
+          >
+            {feedback.type === 'success' ? (
+              <Check className="w-4 h-4 flex-shrink-0" />
+            ) : (
+              <X className="w-4 h-4 flex-shrink-0" />
+            )}
+            <span className="text-sm">{feedback.message}</span>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {/* Export */}
+          <div className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg">
+            <div className="flex-1">
+              <h3 className="text-sm font-medium text-gray-900 mb-1">
+                {getMessage('exportSettings')}
+              </h3>
+              <p className="text-xs text-gray-500 mb-3">
+                {getMessage('exportSettingsDescription')}
+              </p>
+              <Button
+                onClick={handleExport}
+                disabled={isExporting}
+                size="sm"
+                variant="secondary"
+              >
+                <Download className="w-4 h-4" />
+                {isExporting
+                  ? getMessage('exporting')
+                  : getMessage('exportSettings')}
+              </Button>
+            </div>
+          </div>
+
+          {/* Import */}
+          <div className="flex items-start gap-4 p-4 bg-gray-50 rounded-lg">
+            <div className="flex-1">
+              <h3 className="text-sm font-medium text-gray-900 mb-1">
+                {getMessage('importSettings')}
+              </h3>
+              <p className="text-xs text-gray-500 mb-3">
+                {getMessage('importSettingsDescription')}
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,application/json"
+                onChange={handleImport}
+                className="hidden"
+              />
+              <Button
+                onClick={handleImportClick}
+                disabled={isImporting}
+                size="sm"
+                variant="secondary"
+              >
+                <Upload className="w-4 h-4" />
+                {isImporting
+                  ? getMessage('importing')
+                  : getMessage('selectFile')}
+              </Button>
+            </div>
+          </div>
+
+          {/* Info */}
+          <div className="flex items-start gap-2 p-3 bg-blue-50 rounded-lg">
+            <AlertCircle className="w-4 h-4 text-blue-500 flex-shrink-0 mt-0.5" />
+            <div className="text-xs text-blue-700">
+              <p className="font-medium mb-1">
+                {getMessage('backupIncludes')}:
+              </p>
+              <ul className="list-disc list-inside space-y-0.5">
+                <li>{getMessage('backupIncludesBlockList')}</li>
+                <li>{getMessage('backupIncludesSchedules')}</li>
+                <li>{getMessage('backupIncludesPresets')}</li>
+              </ul>
+              <p className="font-medium mt-2 mb-1">
+                {getMessage('backupExcludes')}:
+              </p>
+              <ul className="list-disc list-inside space-y-0.5">
+                <li>{getMessage('backupExcludesAnalytics')}</li>
+                <li>{getMessage('backupExcludesPremium')}</li>
+              </ul>
+            </div>
+          </div>
         </div>
       </Card>
 

--- a/src/lib/settingsBackup.ts
+++ b/src/lib/settingsBackup.ts
@@ -1,0 +1,259 @@
+/**
+ * Settings Export/Import utilities
+ * Exports and imports user settings (block list, schedules, presets)
+ * Does NOT include: premium status, analytics data
+ */
+
+import { z } from 'zod';
+import type {
+  AppSettings,
+  VisionSettings,
+  Schedule,
+  DashboardPreset
+} from '~/types/storage';
+import { getSettings, setSettings, getVision, setVision } from './storage';
+
+// Version for future compatibility
+const BACKUP_VERSION = 1;
+
+// Maximum file size for import (2MB to accommodate Base64 images)
+const MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+// Schema for validation
+const blockItemSchema = z.object({
+  id: z.string(),
+  domain: z.string(),
+  isWildcard: z.boolean(),
+  createdAt: z.string()
+});
+
+const scheduleSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  startTime: z.string(),
+  endTime: z.string(),
+  days: z.array(z.number()),
+  enabled: z.boolean(),
+  presetId: z.string().optional()
+});
+
+const fontSettingsSchema = z.object({
+  family: z.string(),
+  size: z.string(),
+  weight: z.string()
+});
+
+const displaySettingsSchema = z.object({
+  goalText: z.string(),
+  goalSubText: z.string(),
+  textColor: z.string(),
+  backgroundType: z.enum(['image', 'color']),
+  backgroundImage: z.string(),
+  backgroundColor: z.string(),
+  customBackgroundData: z.string().nullable(),
+  fontSettings: fontSettingsSchema
+});
+
+const presetSchema = displaySettingsSchema.extend({
+  id: z.string(),
+  name: z.string(),
+  createdAt: z.string()
+});
+
+const backupDataSchema = z.object({
+  version: z.number(),
+  exportedAt: z.string(),
+  settings: z.object({
+    blockList: z.array(blockItemSchema),
+    schedules: z.array(scheduleSchema),
+    paused: z.boolean(),
+    language: z.enum(['en', 'ja']).nullable()
+  }),
+  vision: z.object({
+    defaultSettings: displaySettingsSchema,
+    presets: z.array(presetSchema),
+    activePresetId: z.string().nullable()
+  })
+});
+
+export type BackupData = z.infer<typeof backupDataSchema>;
+
+export interface ExportResult {
+  success: boolean;
+  filename?: string;
+  error?: string;
+}
+
+export interface ImportResult {
+  success: boolean;
+  imported?: {
+    blockList: number;
+    schedules: number;
+    presets: number;
+  };
+  error?: string;
+}
+
+/**
+ * Export settings to JSON file
+ */
+export async function exportSettings(): Promise<ExportResult> {
+  try {
+    const [settings, vision] = await Promise.all([getSettings(), getVision()]);
+
+    const backupData: BackupData = {
+      version: BACKUP_VERSION,
+      exportedAt: new Date().toISOString(),
+      settings: {
+        blockList: settings.blockList,
+        schedules: settings.schedules,
+        paused: settings.paused,
+        language: settings.language
+      },
+      vision: {
+        defaultSettings: vision.defaultSettings,
+        presets: vision.presets,
+        activePresetId: vision.activePresetId
+      }
+    };
+
+    const jsonString = JSON.stringify(backupData, null, 2);
+    const blob = new Blob([jsonString], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const filename = `visionfocus-backup-${getDateString()}.json`;
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+
+    URL.revokeObjectURL(url);
+
+    return { success: true, filename };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}
+
+/**
+ * Import settings from JSON file
+ */
+export async function importSettings(file: File): Promise<ImportResult> {
+  try {
+    // Validate file size
+    if (file.size > MAX_FILE_SIZE) {
+      return {
+        success: false,
+        error: 'File too large. Maximum size is 2MB.'
+      };
+    }
+
+    // Validate file type
+    if (!file.type.includes('json') && !file.name.endsWith('.json')) {
+      return {
+        success: false,
+        error: 'Invalid file type. Please select a JSON file.'
+      };
+    }
+
+    // Read file
+    const text = await file.text();
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return {
+        success: false,
+        error: 'Invalid JSON format.'
+      };
+    }
+
+    // Validate schema
+    const result = backupDataSchema.safeParse(parsed);
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Invalid backup file format: ${result.error.issues[0]?.message || 'Unknown error'}`
+      };
+    }
+
+    const backupData = result.data;
+
+    // Get current settings to merge
+    const [currentSettings, currentVision] = await Promise.all([
+      getSettings(),
+      getVision()
+    ]);
+
+    // Merge block list (avoid duplicates by domain)
+    const existingDomains = new Set(
+      currentSettings.blockList.map((item) => item.domain)
+    );
+    const newBlockItems = backupData.settings.blockList.filter(
+      (item) => !existingDomains.has(item.domain)
+    );
+    const mergedBlockList = [...currentSettings.blockList, ...newBlockItems];
+
+    // Merge schedules (avoid duplicates by id)
+    const existingScheduleIds = new Set(
+      currentSettings.schedules.map((s) => s.id)
+    );
+    const newSchedules = backupData.settings.schedules.filter(
+      (s) => !existingScheduleIds.has(s.id)
+    );
+    const mergedSchedules = [...currentSettings.schedules, ...newSchedules];
+
+    // Merge presets (avoid duplicates by id)
+    const existingPresetIds = new Set(currentVision.presets.map((p) => p.id));
+    const newPresets = backupData.vision.presets.filter(
+      (p) => !existingPresetIds.has(p.id)
+    );
+    const mergedPresets = [...currentVision.presets, ...newPresets];
+
+    // Update settings
+    const updatedSettings: AppSettings = {
+      ...currentSettings,
+      blockList: mergedBlockList,
+      schedules: mergedSchedules as Schedule[],
+      paused: backupData.settings.paused,
+      language: backupData.settings.language
+    };
+
+    const updatedVision: VisionSettings = {
+      defaultSettings: backupData.vision.defaultSettings,
+      presets: mergedPresets as DashboardPreset[],
+      activePresetId: backupData.vision.activePresetId
+    };
+
+    await Promise.all([setSettings(updatedSettings), setVision(updatedVision)]);
+
+    return {
+      success: true,
+      imported: {
+        blockList: newBlockItems.length,
+        schedules: newSchedules.length,
+        presets: newPresets.length
+      }
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+}
+
+/**
+ * Get current date string for filename
+ */
+function getDateString(): string {
+  const now = new Date();
+  return now.toISOString().split('T')[0]; // YYYY-MM-DD
+}


### PR DESCRIPTION
## Summary

- 設定データ（ブロックリスト、スケジュール、プリセット）をJSONファイルでエクスポート/インポートできる機能を追加
- ヘルプタブに「Data Backup」セクションを追加してUIを提供
- Zodによるインポートファイルのバリデーションで安全性を確保

## Changes

- `src/lib/settingsBackup.ts`: エクスポート/インポートのユーティリティ関数
- `src/components/options/HelpTab.tsx`: UIコンポーネント追加
- `assets/_locales/*/messages.json`: 多言語対応（英語・日本語）

## Details

### エクスポート内容
- ブロックリスト
- スケジュール
- ダッシュボードスタイル（プリセット）
- カスタム背景画像（Base64形式、2MB制限）

### 除外データ
- 課金状態（ExtensionPayで管理）
- 分析データ（ローカルに保持）

## Test plan

- [ ] ヘルプタブで「設定をエクスポート」ボタンをクリックし、JSONファイルがダウンロードされることを確認
- [ ] エクスポートしたJSONファイルをインポートし、設定が復元されることを確認
- [ ] 不正なJSONファイルをインポートした際にエラーメッセージが表示されることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)