### PR TITLE
設定画面のタブ名を定数化

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from './backgrounds';
 export * from './fonts';
 export * from './limits';
+export * from './tabs';

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -1,37 +1,49 @@
 /**
  * Settings page tab names
  */
-export const TABS = [
-  'blocklist',
-  'styles',
-  'schedules',
-  'analytics',
-  'license',
-  'help'
-] as const;
+export const TABS = {
+  BLOCKLIST: 'blocklist',
+  STYLES: 'styles',
+  SCHEDULES: 'schedules',
+  ANALYTICS: 'analytics',
+  LICENSE: 'license',
+  HELP: 'help'
+} as const;
 
 /**
  * Type for tab names
  */
-export type TabName = (typeof TABS)[number];
+export type TabName = (typeof TABS)[keyof typeof TABS];
+
+/**
+ * Tab order for UI rendering
+ */
+export const TAB_ORDER: TabName[] = [
+  TABS.BLOCKLIST,
+  TABS.STYLES,
+  TABS.SCHEDULES,
+  TABS.ANALYTICS,
+  TABS.LICENSE,
+  TABS.HELP
+];
 
 /**
  * Default tab when no valid tab is specified
  */
-export const DEFAULT_TAB: TabName = 'blocklist';
+export const DEFAULT_TAB: TabName = TABS.BLOCKLIST;
 
 /**
  * Legacy tab mapping (for backward compatibility)
  */
-export const LEGACY_TAB_MAP: Record<string, TabName> = {
-  general: 'styles'
+export const LEGACY_TAB_MAP: Partial<Record<string, TabName>> = {
+  general: TABS.STYLES
 } as const;
 
 /**
  * Check if a string is a valid tab name
  */
 export function isValidTab(tab: string): tab is TabName {
-  return (TABS as readonly string[]).includes(tab);
+  return Object.values(TABS).includes(tab as TabName);
 }
 
 /**
@@ -42,7 +54,7 @@ export function getTabFromHash(hash: string): TabName {
 
   // Check legacy mapping first
   if (tabName in LEGACY_TAB_MAP) {
-    return LEGACY_TAB_MAP[tabName];
+    return LEGACY_TAB_MAP[tabName] as TabName;
   }
 
   // Return valid tab or default

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -1,0 +1,50 @@
+/**
+ * Settings page tab names
+ */
+export const TABS = [
+  'blocklist',
+  'styles',
+  'schedules',
+  'analytics',
+  'license',
+  'help'
+] as const;
+
+/**
+ * Type for tab names
+ */
+export type TabName = (typeof TABS)[number];
+
+/**
+ * Default tab when no valid tab is specified
+ */
+export const DEFAULT_TAB: TabName = 'blocklist';
+
+/**
+ * Legacy tab mapping (for backward compatibility)
+ */
+export const LEGACY_TAB_MAP: Record<string, TabName> = {
+  general: 'styles'
+} as const;
+
+/**
+ * Check if a string is a valid tab name
+ */
+export function isValidTab(tab: string): tab is TabName {
+  return (TABS as readonly string[]).includes(tab);
+}
+
+/**
+ * Get the tab name from URL hash, handling legacy mappings
+ */
+export function getTabFromHash(hash: string): TabName {
+  const tabName = hash.slice(1); // Remove #
+
+  // Check legacy mapping first
+  if (tabName in LEGACY_TAB_MAP) {
+    return LEGACY_TAB_MAP[tabName];
+  }
+
+  // Return valid tab or default
+  return isValidTab(tabName) ? tabName : DEFAULT_TAB;
+}

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -32,6 +32,7 @@ import { getMessage, setCurrentLanguage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { openPaymentPage, openManagementPage } from '~/lib/extpay';
 import { parseDomainInput, isValidDomain } from '~/lib/domain';
+import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
 import type {
   AppSettings,
   VisionSettings,
@@ -62,21 +63,9 @@ function OptionsApp() {
     DEFAULT_VISION
   );
   // Read initial tab from URL hash (e.g., #help)
-  const getInitialTab = () => {
-    const hash = window.location.hash.slice(1); // Remove #
-    const validTabs = [
-      'blocklist',
-      'styles',
-      'schedules',
-      'analytics',
-      'license',
-      'help'
-    ];
-    // Support legacy 'general' hash
-    if (hash === 'general') return 'styles';
-    return validTabs.includes(hash) ? hash : 'blocklist';
-  };
-  const [activeTab, setActiveTab] = useState(getInitialTab);
+  const [activeTab, setActiveTab] = useState<TabName>(() =>
+    getTabFromHash(window.location.hash)
+  );
 
   // Sync URL hash with active tab
   useEffect(() => {
@@ -130,35 +119,35 @@ function OptionsApp() {
     }
   }, [settings?.language]);
 
-  // Tabs configuration
-  const tabs = [
+  // Tabs configuration (using TABS constant for type safety)
+  const tabs: Array<{ id: TabName; label: string; icon: React.ReactNode }> = [
     {
-      id: 'blocklist',
+      id: TABS[0],
       label: getMessage('blockList'),
       icon: <Ban className="w-4 h-4" />
     },
     {
-      id: 'styles',
+      id: TABS[1],
       label: getMessage('styles'),
       icon: <Palette className="w-4 h-4" />
     },
     {
-      id: 'schedules',
+      id: TABS[2],
       label: getMessage('schedules'),
       icon: <Calendar className="w-4 h-4" />
     },
     {
-      id: 'analytics',
+      id: TABS[3],
       label: getMessage('analytics'),
       icon: <TrendingUp className="w-4 h-4" />
     },
     {
-      id: 'license',
+      id: TABS[4],
       label: getMessage('premium'),
       icon: <Crown className="w-4 h-4" />
     },
     {
-      id: 'help',
+      id: TABS[5],
       label: getMessage('help'),
       icon: <HelpCircle className="w-4 h-4" />
     }
@@ -321,7 +310,11 @@ function OptionsApp() {
         <Tabs
           tabs={tabs}
           activeTab={activeTab}
-          onChange={setActiveTab}
+          onChange={(tabId) => {
+            if (isValidTab(tabId)) {
+              setActiveTab(tabId);
+            }
+          }}
           className="mb-8"
         />
 

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -122,32 +122,32 @@ function OptionsApp() {
   // Tabs configuration (using TABS constant for type safety)
   const tabs: Array<{ id: TabName; label: string; icon: React.ReactNode }> = [
     {
-      id: TABS[0],
+      id: TABS.BLOCKLIST,
       label: getMessage('blockList'),
       icon: <Ban className="w-4 h-4" />
     },
     {
-      id: TABS[1],
+      id: TABS.STYLES,
       label: getMessage('styles'),
       icon: <Palette className="w-4 h-4" />
     },
     {
-      id: TABS[2],
+      id: TABS.SCHEDULES,
       label: getMessage('schedules'),
       icon: <Calendar className="w-4 h-4" />
     },
     {
-      id: TABS[3],
+      id: TABS.ANALYTICS,
       label: getMessage('analytics'),
       icon: <TrendingUp className="w-4 h-4" />
     },
     {
-      id: TABS[4],
+      id: TABS.LICENSE,
       label: getMessage('premium'),
       icon: <Crown className="w-4 h-4" />
     },
     {
-      id: TABS[5],
+      id: TABS.HELP,
       label: getMessage('help'),
       icon: <HelpCircle className="w-4 h-4" />
     }
@@ -319,7 +319,7 @@ function OptionsApp() {
         />
 
         {/* Styles Tab */}
-        {activeTab === 'styles' && (
+        {activeTab === TABS.STYLES && (
           <GeneralTab
             vision={vision}
             draftPresets={presets.draftPresets}
@@ -348,7 +348,7 @@ function OptionsApp() {
         )}
 
         {/* Block List Tab */}
-        {activeTab === 'blocklist' && (
+        {activeTab === TABS.BLOCKLIST && (
           <BlocklistTab
             settings={settings}
             newDomain={blocklist.newDomain}
@@ -361,7 +361,7 @@ function OptionsApp() {
         )}
 
         {/* Schedules Tab */}
-        {activeTab === 'schedules' && (
+        {activeTab === TABS.SCHEDULES && (
           <SchedulesTab
             settings={settings}
             vision={vision}
@@ -373,7 +373,7 @@ function OptionsApp() {
         )}
 
         {/* Analytics Tab */}
-        {activeTab === 'analytics' && (
+        {activeTab === TABS.ANALYTICS && (
           <AnalyticsTab
             unblockHistory={unblockHistory}
             analyticsData={analyticsData}
@@ -388,7 +388,7 @@ function OptionsApp() {
         )}
 
         {/* Premium Tab */}
-        {activeTab === 'license' && (
+        {activeTab === TABS.LICENSE && (
           <PremiumTab
             isPremium={isPremium}
             onUpgrade={handleUpgrade}
@@ -397,7 +397,7 @@ function OptionsApp() {
         )}
 
         {/* Help Tab */}
-        {activeTab === 'help' && <HelpTab />}
+        {activeTab === TABS.HELP && <HelpTab />}
       </main>
 
       {/* New Preset Modal */}


### PR DESCRIPTION
## Summary
- `src/constants/tabs.ts` を作成してタブ名定数を定義
- `TabName`型を追加し型安全性を向上
- レガシーマッピング（general -> styles）を定数化
- `isValidTab`型ガード関数と`getTabFromHash`ヘルパーを追加
- `options.tsx`でハードコードされたタブ名を定数に置き換え

## Test plan
- [ ] 設定画面の各タブが正常に切り替わることを確認
- [ ] URLハッシュ（#blocklist, #styles等）でタブが正しく選択されることを確認
- [ ] レガシーハッシュ（#general）が#stylesにリダイレクトされることを確認
- [ ] ビルドが成功することを確認

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)