### PR TITLE
GeneralTabをStylesTabにリネーム、legacyマッピング削除

### DIFF
--- a/src/components/options/StylesTab.tsx
+++ b/src/components/options/StylesTab.tsx
@@ -19,7 +19,7 @@ import type { FontSettings } from '~/types/font';
 import type { FeatureLimits } from '~/types/premium';
 import { DEFAULT_FONT_SETTINGS, getFontDefinition } from '~/types/font';
 
-interface GeneralTabProps {
+interface StylesTabProps {
   // Vision data
   vision: VisionSettings | undefined;
   draftPresets: DashboardPreset[];
@@ -52,7 +52,7 @@ interface GeneralTabProps {
   onFontSettingsChange: (fontSettings: FontSettings) => void;
 }
 
-export function GeneralTab({
+export function StylesTab({
   vision,
   draftPresets,
   selectedPresetId,
@@ -76,7 +76,7 @@ export function GeneralTab({
   onBackgroundColorChange,
   onCustomBackgroundChange,
   onFontSettingsChange
-}: GeneralTabProps) {
+}: StylesTabProps) {
   const selectedPreset = draftPresets.find((p) => p.id === selectedPresetId);
 
   // Determine if we're in editing mode

--- a/src/components/options/index.ts
+++ b/src/components/options/index.ts
@@ -1,4 +1,4 @@
-export * from './GeneralTab';
+export * from './StylesTab';
 export * from './BlocklistTab';
 export * from './SchedulesTab';
 export * from './AnalyticsTab';

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -33,13 +33,6 @@ export const TAB_ORDER: TabName[] = [
 export const DEFAULT_TAB: TabName = TABS.BLOCKLIST;
 
 /**
- * Legacy tab mapping (for backward compatibility)
- */
-export const LEGACY_TAB_MAP: Partial<Record<string, TabName>> = {
-  general: TABS.STYLES
-} as const;
-
-/**
  * Check if a string is a valid tab name
  */
 export function isValidTab(tab: string): tab is TabName {
@@ -47,16 +40,9 @@ export function isValidTab(tab: string): tab is TabName {
 }
 
 /**
- * Get the tab name from URL hash, handling legacy mappings
+ * Get the tab name from URL hash
  */
 export function getTabFromHash(hash: string): TabName {
   const tabName = hash.slice(1); // Remove #
-
-  // Check legacy mapping first
-  if (tabName in LEGACY_TAB_MAP) {
-    return LEGACY_TAB_MAP[tabName] as TabName;
-  }
-
-  // Return valid tab or default
   return isValidTab(tabName) ? tabName : DEFAULT_TAB;
 }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -13,7 +13,7 @@ import {
 
 import { Tabs } from '~/components/ui';
 import {
-  GeneralTab,
+  StylesTab,
   BlocklistTab,
   SchedulesTab,
   AnalyticsTab,
@@ -320,7 +320,7 @@ function OptionsApp() {
 
         {/* Styles Tab */}
         {activeTab === TABS.STYLES && (
-          <GeneralTab
+          <StylesTab
             vision={vision}
             draftPresets={presets.draftPresets}
             selectedPresetId={presets.selectedPresetId}


### PR DESCRIPTION
## Summary
- `GeneralTab.tsx` → `StylesTab.tsx` にリネーム（名前とタブ内容の不一致を解消）
- `tabs.ts` から `LEGACY_TAB_MAP` と関連コードを削除（リリース前のため後方互換性は不要）

## Test plan
- [ ] 設定画面のStylesタブが正常に表示されることを確認
- [ ] 他のタブも正常に動作することを確認
- [ ] ビルドが成功することを確認

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)