### PR TITLE
feat: ブロックリストの個別サイト無効化機能を追加 (#44)

### DIFF
--- a/src/background/blocker.ts
+++ b/src/background/blocker.ts
@@ -77,7 +77,7 @@ function getActiveBlockedDomains(
     return [];
   }
 
-  return blockList.map((item) => item.domain);
+  return blockList.filter((item) => item.enabled).map((item) => item.domain);
 }
 
 // Check if a specific URL should be blocked
@@ -90,9 +90,9 @@ export async function shouldBlockUrl(url: string): Promise<boolean> {
   // If paused, don't block
   if (settings.paused) return false;
 
-  // Check if domain is in block list
-  const isBlocked = settings.blockList.some((item) =>
-    matchesDomain(domain, item)
+  // Check if domain is in block list and enabled
+  const isBlocked = settings.blockList.some(
+    (item) => item.enabled && matchesDomain(domain, item)
   );
   if (!isBlocked) return false;
 

--- a/src/background/messages/add-block.ts
+++ b/src/background/messages/add-block.ts
@@ -63,7 +63,8 @@ const handler: PlasmoMessaging.MessageHandler<
     id: generateId(),
     domain: parsedDomain,
     isWildcard,
-    createdAt: now
+    createdAt: now,
+    enabled: true
   });
 
   await setSettings(settings);

--- a/src/background/messages/toggle-block.ts
+++ b/src/background/messages/toggle-block.ts
@@ -1,0 +1,50 @@
+import type { PlasmoMessaging } from '@plasmohq/messaging';
+
+import { getSettings, setSettings } from '~/lib/storage';
+import { updateBlockRules, blockExistingTabs } from '../blocker';
+import type { ToggleBlockRequest, ToggleBlockResponse } from '~/types/messages';
+
+export type { ToggleBlockRequest, ToggleBlockResponse };
+
+const handler: PlasmoMessaging.MessageHandler<
+  ToggleBlockRequest,
+  ToggleBlockResponse
+> = async (req, res) => {
+  const { id, enabled } = req.body;
+
+  // Validate input
+  if (!id || typeof id !== 'string' || id.length === 0 || id.length > 100) {
+    res.send({ success: false, error: 'Invalid id' });
+    return;
+  }
+
+  if (typeof enabled !== 'boolean') {
+    res.send({ success: false, error: 'Invalid enabled value' });
+    return;
+  }
+
+  const settings = await getSettings();
+
+  // Find the item to toggle
+  const itemIndex = settings.blockList.findIndex((item) => item.id === id);
+
+  if (itemIndex === -1) {
+    res.send({ success: false, error: 'Item not found' });
+    return;
+  }
+
+  // Update enabled state
+  settings.blockList[itemIndex].enabled = enabled;
+
+  await setSettings(settings);
+  await updateBlockRules();
+
+  // If re-enabling, block existing tabs that match
+  if (enabled) {
+    await blockExistingTabs();
+  }
+
+  res.send({ success: true });
+};
+
+export default handler;

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Plus, Trash2, Shield } from 'lucide-react';
 
-import { Button, Card, Input } from '~/components/ui';
+import { Button, Card, Input, Toggle } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
 import type { AppSettings, SiteBlockCount } from '~/types/storage';
 
@@ -12,6 +12,7 @@ interface BlocklistTabProps {
   blockError: string;
   onAddDomain: () => void;
   onRemoveDomain: (id: string) => void;
+  onToggleDomain: (id: string, enabled: boolean) => void;
   siteBlockCounts?: Record<string, SiteBlockCount>;
 }
 
@@ -22,6 +23,7 @@ export function BlocklistTab({
   blockError,
   onAddDomain,
   onRemoveDomain,
+  onToggleDomain,
   siteBlockCounts = {}
 }: BlocklistTabProps) {
   return (
@@ -71,10 +73,23 @@ export function BlocklistTab({
                   className="flex items-center justify-between py-3"
                 >
                   <div className="flex items-center gap-3">
+                    <Toggle
+                      checked={item.enabled}
+                      onChange={(checked) => onToggleDomain(item.id, checked)}
+                      size="sm"
+                    />
                     <div>
-                      <p className="font-medium text-gray-900">
+                      <p
+                        className={`font-medium ${item.enabled ? 'text-gray-900' : 'text-gray-400'}`}
+                      >
                         {item.isWildcard && (
-                          <span className="text-blue-600">*.</span>
+                          <span
+                            className={
+                              item.enabled ? 'text-blue-600' : 'text-blue-300'
+                            }
+                          >
+                            *.
+                          </span>
                         )}
                         {item.domain}
                       </p>

--- a/src/hooks/useBlocklist.ts
+++ b/src/hooks/useBlocklist.ts
@@ -17,6 +17,7 @@ interface UseBlocklistReturn {
   blockError: string;
   handleAddDomain: () => Promise<void>;
   handleRemoveDomain: (id: string) => Promise<void>;
+  handleToggleDomain: (id: string, enabled: boolean) => Promise<void>;
 }
 
 export function useBlocklist({
@@ -84,11 +85,27 @@ export function useBlocklist({
     [setSettings]
   );
 
+  const handleToggleDomain = useCallback(
+    async (id: string, enabled: boolean) => {
+      try {
+        await sendToBackground({ name: 'toggle-block', body: { id, enabled } });
+        const updatedSettings = await storage.get<AppSettings>('settings');
+        if (updatedSettings) {
+          setSettings(updatedSettings);
+        }
+      } catch {
+        // Silently handle error - list will refresh on next settings change
+      }
+    },
+    [setSettings]
+  );
+
   return {
     newDomain,
     setNewDomain,
     blockError,
     handleAddDomain,
-    handleRemoveDomain
+    handleRemoveDomain,
+    handleToggleDomain
   };
 }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -176,6 +176,7 @@ function OptionsApp() {
             blockError={blocklist.blockError}
             onAddDomain={blocklist.handleAddDomain}
             onRemoveDomain={blocklist.handleRemoveDomain}
+            onToggleDomain={blocklist.handleToggleDomain}
             siteBlockCounts={analytics.analyticsData.siteBlockCounts}
           />
         )}

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -46,6 +46,17 @@ export interface SetSiteCategoryResponse {
   error?: string;
 }
 
+// Toggle Block
+export interface ToggleBlockRequest {
+  id: string;
+  enabled: boolean;
+}
+
+export interface ToggleBlockResponse {
+  success: boolean;
+  error?: string;
+}
+
 // Tracker Heartbeat
 export interface TrackerHeartbeatRequest {
   url: string;

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -40,6 +40,7 @@ export interface BlockItem {
   domain: string;
   isWildcard: boolean;
   createdAt: string;
+  enabled: boolean; // Whether blocking is active for this item (default: true)
 }
 
 // Schedule for time-based blocking


### PR DESCRIPTION
## Summary
- ブロックリストに登録したサイトを削除せずに、トグルで一時的に無効化できる機能を追加
- BlockItem 型に enabled プロパティを追加し、ブロッカーロジックで enabled フィルタリングを実装
- BlocklistTab UI の各サイト行にトグルスイッチを追加

## Test plan
- [ ] ブロックリストにサイトを追加し、デフォルトでトグルがONになることを確認
- [ ] トグルをOFFにすると、そのサイトがブロックされなくなることを確認
- [ ] トグルをONに戻すと、そのサイトが再びブロックされることを確認
- [ ] ページをリロードしても enabled 状態が保持されることを確認

Generated with [Claude Code](https://claude.com/claude-code)
