### PR TITLE
feat: 時間制限の残り時間通知機能を追加 (#16)

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1482,5 +1482,57 @@
   "sat": {
     "message": "Sat",
     "description": "Saturday abbreviation"
+  },
+  "notificationSettings": {
+    "message": "Notification Settings",
+    "description": "Notification settings section title"
+  },
+  "notificationTimeLimitEnabled": {
+    "message": "Time Limit Notifications",
+    "description": "Enable time limit notifications toggle"
+  },
+  "notificationTimeLimitEnabledDescription": {
+    "message": "Get notified when you're running low on time for a site",
+    "description": "Time limit notification description"
+  },
+  "notificationTimeLimitMinutes": {
+    "message": "Notify before limit",
+    "description": "Notification timing selection label"
+  },
+  "notificationMinutesOption": {
+    "message": "$COUNT$ minute(s) before",
+    "description": "Minutes before option",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
+  },
+  "notificationTimeLimitTitle": {
+    "message": "⏰ Time Running Low",
+    "description": "Time limit notification title"
+  },
+  "notificationTimeLimitMessage": {
+    "message": "$DOMAIN$ has $REMAINING$ min left of your $TOTAL$ min$TYPE$ limit",
+    "description": "Time limit notification message",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      },
+      "remaining": {
+        "content": "$2",
+        "example": "5"
+      },
+      "total": {
+        "content": "$3",
+        "example": "30"
+      },
+      "type": {
+        "content": "$4",
+        "example": "/day"
+      }
+    }
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1482,5 +1482,57 @@
   "sat": {
     "message": "土",
     "description": "土曜日の略称"
+  },
+  "notificationSettings": {
+    "message": "通知設定",
+    "description": "通知設定セクションタイトル"
+  },
+  "notificationTimeLimitEnabled": {
+    "message": "時間制限の通知",
+    "description": "時間制限通知の有効化トグル"
+  },
+  "notificationTimeLimitEnabledDescription": {
+    "message": "サイトの残り時間が少なくなったら通知を受け取る",
+    "description": "時間制限通知の説明"
+  },
+  "notificationTimeLimitMinutes": {
+    "message": "通知タイミング",
+    "description": "通知タイミング選択ラベル"
+  },
+  "notificationMinutesOption": {
+    "message": "$COUNT$分前",
+    "description": "通知タイミングオプション",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
+  },
+  "notificationTimeLimitTitle": {
+    "message": "⏰ 残り時間わずか",
+    "description": "時間制限通知タイトル"
+  },
+  "notificationTimeLimitMessage": {
+    "message": "$DOMAIN$ はあと$REMAINING$分で今日の制限（$TOTAL$分$TYPE$）に達します",
+    "description": "時間制限通知メッセージ",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      },
+      "remaining": {
+        "content": "$2",
+        "example": "5"
+      },
+      "total": {
+        "content": "$3",
+        "example": "30"
+      },
+      "type": {
+        "content": "$4",
+        "example": "/日"
+      }
+    }
   }
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -14,6 +14,7 @@ import { isWithinSchedule } from '~/lib/time';
 import { updateBlockRules } from './blocker';
 import { startTracking } from './tracker';
 import { resetExpiredUsage } from './time-limit';
+import { clearExpiredNotifications } from './notifications';
 
 // Initialize ExtensionPay at top level (required for Manifest V3)
 startExtPayBackgroundListener();
@@ -57,6 +58,8 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name === 'time-limit-reset') {
     // Reset expired time limit usage
     await resetExpiredUsage();
+    // Clear notification state for domains that have reset
+    clearExpiredNotifications();
   }
 });
 

--- a/src/background/messages/tracker-heartbeat.ts
+++ b/src/background/messages/tracker-heartbeat.ts
@@ -12,6 +12,7 @@ import { getTodayKey } from '~/lib/time';
 import { TRACKER_CONFIG } from '~/constants/limits';
 import type { DailyStat, SiteTime } from '~/types/storage';
 import { recordTimeLimitUsage, findBlockItemForDomain } from '../time-limit';
+import { checkTimeLimitNotification } from '../notifications';
 
 // Track active pages and their last heartbeat
 interface ActivePage {
@@ -121,6 +122,8 @@ async function recordTime(domain: string, seconds: number): Promise<void> {
   const blockItem = await findBlockItemForDomain(domain);
   if (blockItem && blockItem.timeLimit) {
     await recordTimeLimitUsage(domain, seconds);
+    // Check if we need to send a notification about time running low
+    await checkTimeLimitNotification(domain);
     // Don't return here - also track in analytics if it's an unblocked site
   }
 

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -1,0 +1,118 @@
+import { getSettings } from '~/lib/storage';
+import { findBlockItemForDomain, getRemainingTime } from './time-limit';
+import { getMessage } from '~/lib/i18n';
+
+// In-memory state to track which domains have been notified
+// Key: domain, Value: reset key (YYYY-MM-DD for daily, YYYY-MM-DD-HH for hourly)
+const notifiedDomains = new Map<string, string>();
+
+// Get the reset key for a domain based on its time limit type
+function getResetKey(type: 'daily' | 'hourly'): string {
+  const now = new Date();
+  const dateKey = now.toISOString().split('T')[0];
+
+  if (type === 'hourly') {
+    const hour = now.getHours().toString().padStart(2, '0');
+    return `${dateKey}-${hour}`;
+  }
+
+  return dateKey;
+}
+
+// Check if a domain has already been notified in the current period
+function hasBeenNotified(domain: string, type: 'daily' | 'hourly'): boolean {
+  const resetKey = getResetKey(type);
+  const notifiedKey = notifiedDomains.get(domain);
+  return notifiedKey === resetKey;
+}
+
+// Mark a domain as notified for the current period
+function markAsNotified(domain: string, type: 'daily' | 'hourly'): void {
+  const resetKey = getResetKey(type);
+  notifiedDomains.set(domain, resetKey);
+}
+
+// Clear notification state for domains that have reset
+export function clearExpiredNotifications(): void {
+  const dailyKey = getResetKey('daily');
+  const hourlyKey = getResetKey('hourly');
+
+  for (const [domain, resetKey] of notifiedDomains.entries()) {
+    // If the stored key doesn't match current daily or hourly key, remove it
+    if (resetKey !== dailyKey && resetKey !== hourlyKey) {
+      notifiedDomains.delete(domain);
+    }
+  }
+}
+
+// Show a time limit notification
+async function showTimeLimitNotification(
+  domain: string,
+  remainingMinutes: number,
+  totalMinutes: number,
+  type: 'daily' | 'hourly'
+): Promise<void> {
+  const typeLabel =
+    type === 'daily' ? getMessage('perDay') : getMessage('perHour');
+
+  await chrome.notifications.create(`time-limit-${domain}-${Date.now()}`, {
+    type: 'basic',
+    iconUrl: chrome.runtime.getURL('assets/icon-128.png'),
+    title: getMessage('notificationTimeLimitTitle'),
+    message: getMessage('notificationTimeLimitMessage', [
+      domain,
+      remainingMinutes.toString(),
+      totalMinutes.toString(),
+      typeLabel
+    ]),
+    priority: 2
+  });
+}
+
+// Check and potentially send notification for a domain
+export async function checkTimeLimitNotification(
+  domain: string
+): Promise<void> {
+  const settings = await getSettings();
+
+  // Check if notifications are enabled
+  if (!settings.notifications?.timeLimitEnabled) {
+    return;
+  }
+
+  const blockItem = await findBlockItemForDomain(domain);
+
+  // Only process domains with time limits
+  if (!blockItem || !blockItem.timeLimit) {
+    return;
+  }
+
+  const { type, limitSeconds } = blockItem.timeLimit;
+
+  // Check if already notified in this period
+  if (hasBeenNotified(domain, type)) {
+    return;
+  }
+
+  const remainingSeconds = await getRemainingTime(domain);
+
+  // If no remaining time info or already exceeded, skip
+  if (remainingSeconds === null || remainingSeconds <= 0) {
+    return;
+  }
+
+  const remainingMinutes = Math.ceil(remainingSeconds / 60);
+  const notifyAtMinutes = settings.notifications.timeLimitMinutes;
+
+  // Check if we should notify
+  if (remainingMinutes <= notifyAtMinutes) {
+    const totalMinutes = Math.round(limitSeconds / 60);
+    await showTimeLimitNotification(domain, remainingMinutes, totalMinutes, type);
+    markAsNotified(domain, type);
+  }
+}
+
+// Reset notification state (useful for testing or when user changes settings)
+export function resetNotificationState(): void {
+  notifiedDomains.clear();
+}

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react';
-import { Plus, Trash2, Shield, Clock, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, Trash2, Shield, Clock, ChevronDown, ChevronUp, Bell } from 'lucide-react';
 
 import { Button, Card, Input, Toggle, Select } from '~/components/ui';
 import { TimeLimitBadge } from '~/components/features';
@@ -11,7 +11,9 @@ import type {
   BlockItem,
   TimeLimit,
   TimeLimitType,
-  TimeLimitUsage
+  TimeLimitUsage,
+  NotificationSettings,
+  NotificationMinutes
 } from '~/types/storage';
 
 interface BlocklistTabProps {
@@ -23,6 +25,7 @@ interface BlocklistTabProps {
   onRemoveDomain: (id: string) => void;
   onToggleDomain: (id: string, enabled: boolean) => void;
   onUpdateTimeLimit: (id: string, timeLimit: TimeLimit | null) => void;
+  onUpdateNotifications: (notifications: NotificationSettings) => void;
   siteBlockCounts?: Record<string, SiteBlockCount>;
   timeLimitUsage?: Record<string, TimeLimitUsage>;
 }
@@ -187,6 +190,97 @@ function TimeLimitEditor({ item, onUpdate, usage }: TimeLimitEditorProps) {
   );
 }
 
+// Notification settings section component
+interface NotificationSettingsProps {
+  notifications: NotificationSettings | undefined;
+  onUpdate: (notifications: NotificationSettings) => void;
+  hasTimeLimitSites: boolean;
+}
+
+function NotificationSettingsSection({
+  notifications,
+  onUpdate,
+  hasTimeLimitSites
+}: NotificationSettingsProps) {
+  const timeLimitEnabled = notifications?.timeLimitEnabled ?? true;
+  const timeLimitMinutes = notifications?.timeLimitMinutes ?? 5;
+
+  const minuteOptions: Array<{ value: string; label: string }> = [
+    { value: '1', label: getMessage('notificationMinutesOption', '1') },
+    { value: '3', label: getMessage('notificationMinutesOption', '3') },
+    { value: '5', label: getMessage('notificationMinutesOption', '5') },
+    { value: '10', label: getMessage('notificationMinutesOption', '10') }
+  ];
+
+  const handleToggle = useCallback(
+    (enabled: boolean) => {
+      onUpdate({
+        timeLimitEnabled: enabled,
+        timeLimitMinutes
+      });
+    },
+    [onUpdate, timeLimitMinutes]
+  );
+
+  const handleMinutesChange = useCallback(
+    (value: string) => {
+      const minutes = parseInt(value, 10) as NotificationMinutes;
+      onUpdate({
+        timeLimitEnabled,
+        timeLimitMinutes: minutes
+      });
+    },
+    [onUpdate, timeLimitEnabled]
+  );
+
+  // Only show if there are sites with time limits
+  if (!hasTimeLimitSites) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-4">
+        <Bell className="w-5 h-5 text-blue-500" />
+        <h2 className="text-lg font-semibold text-gray-900">
+          {getMessage('notificationSettings')}
+        </h2>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="font-medium text-gray-900">
+              {getMessage('notificationTimeLimitEnabled')}
+            </p>
+            <p className="text-sm text-gray-500">
+              {getMessage('notificationTimeLimitEnabledDescription')}
+            </p>
+          </div>
+          <Toggle
+            checked={timeLimitEnabled}
+            onChange={handleToggle}
+          />
+        </div>
+
+        {timeLimitEnabled && (
+          <div>
+            <label className="block text-sm font-medium text-gray-600 mb-2">
+              {getMessage('notificationTimeLimitMinutes')}
+            </label>
+            <Select
+              value={timeLimitMinutes.toString()}
+              onChange={handleMinutesChange}
+              options={minuteOptions}
+              className="w-48"
+            />
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
 export function BlocklistTab({
   settings,
   newDomain,
@@ -196,11 +290,24 @@ export function BlocklistTab({
   onRemoveDomain,
   onToggleDomain,
   onUpdateTimeLimit,
+  onUpdateNotifications,
   siteBlockCounts = {},
   timeLimitUsage = {}
 }: BlocklistTabProps) {
+  // Check if any sites have time limits configured
+  const hasTimeLimitSites =
+    settings?.blockList.some((item) => item.timeLimit !== null && item.timeLimit !== undefined) ??
+    false;
+
   return (
     <div className="space-y-6">
+      {/* Notification Settings - only show if time limit sites exist */}
+      <NotificationSettingsSection
+        notifications={settings?.notifications}
+        onUpdate={onUpdateNotifications}
+        hasTimeLimitSites={hasTimeLimitSites}
+      />
+
       <Card>
         <h2 className="text-lg font-semibold text-gray-900 mb-4">
           {getMessage('addSiteToBlock')}

--- a/src/hooks/useBlocklist.ts
+++ b/src/hooks/useBlocklist.ts
@@ -4,7 +4,7 @@ import { sendToBackground } from '@plasmohq/messaging';
 import { parseDomainInput } from '~/lib/domain';
 import { storage } from '~/lib/storage';
 import { canAddToBlocklist } from '~/lib/license';
-import type { AppSettings, TimeLimit } from '~/types/storage';
+import type { AppSettings, TimeLimit, NotificationSettings } from '~/types/storage';
 
 interface UseBlocklistOptions {
   settings: AppSettings | undefined;
@@ -19,6 +19,7 @@ interface UseBlocklistReturn {
   handleRemoveDomain: (id: string) => Promise<void>;
   handleToggleDomain: (id: string, enabled: boolean) => Promise<void>;
   handleUpdateTimeLimit: (id: string, timeLimit: TimeLimit | null) => Promise<void>;
+  handleUpdateNotifications: (notifications: NotificationSettings) => Promise<void>;
 }
 
 export function useBlocklist({
@@ -119,6 +120,24 @@ export function useBlocklist({
     [setSettings]
   );
 
+  const handleUpdateNotifications = useCallback(
+    async (notifications: NotificationSettings) => {
+      if (!settings) return;
+
+      try {
+        const updatedSettings: AppSettings = {
+          ...settings,
+          notifications
+        };
+        await storage.set('settings', updatedSettings);
+        setSettings(updatedSettings);
+      } catch {
+        // Silently handle error
+      }
+    },
+    [settings, setSettings]
+  );
+
   return {
     newDomain,
     setNewDomain,
@@ -126,6 +145,7 @@ export function useBlocklist({
     handleAddDomain,
     handleRemoveDomain,
     handleToggleDomain,
-    handleUpdateTimeLimit
+    handleUpdateTimeLimit,
+    handleUpdateNotifications
   };
 }

--- a/src/lib/settingsExport.ts
+++ b/src/lib/settingsExport.ts
@@ -16,9 +16,10 @@ import type {
   VisionSettings,
   BlockItem,
   Schedule,
-  DashboardPreset
+  DashboardPreset,
+  NotificationSettings
 } from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_VISION } from '~/types/storage';
+import { DEFAULT_SETTINGS, DEFAULT_VISION, DEFAULT_NOTIFICATION_SETTINGS } from '~/types/storage';
 
 // Export data version for future compatibility
 const EXPORT_VERSION = 1;
@@ -42,6 +43,7 @@ export interface ExportedSettings {
     defaultDisplaySettings: VisionSettings['defaultSettings'];
     activePresetId: string | null;
     language: AppSettings['language'];
+    notifications?: NotificationSettings;
   };
 }
 
@@ -105,6 +107,11 @@ const presetSchema = displaySettingsSchema.extend({
   createdAt: z.string()
 });
 
+const notificationSettingsSchema = z.object({
+  timeLimitEnabled: z.boolean(),
+  timeLimitMinutes: z.union([z.literal(1), z.literal(3), z.literal(5), z.literal(10)])
+});
+
 const exportDataSchema = z.object({
   version: z.number(),
   exportedAt: z.string(),
@@ -114,7 +121,8 @@ const exportDataSchema = z.object({
     presets: z.array(presetSchema),
     defaultDisplaySettings: displaySettingsSchema,
     activePresetId: z.string().nullable(),
-    language: z.enum(['en', 'ja']).nullable()
+    language: z.enum(['en', 'ja']).nullable(),
+    notifications: notificationSettingsSchema.optional()
   })
 });
 
@@ -157,7 +165,8 @@ export function exportSettings(
       presets: vision.presets,
       defaultDisplaySettings: vision.defaultSettings,
       activePresetId: vision.activePresetId,
-      language: settings.language
+      language: settings.language,
+      notifications: settings.notifications
     }
   };
 
@@ -300,7 +309,8 @@ export function applyImportedSettings(
     ...currentSettings,
     blockList: mergedBlockList,
     schedules: mergedSchedules,
-    language: data.language ?? currentSettings.language
+    language: data.language ?? currentSettings.language,
+    notifications: data.notifications ?? currentSettings.notifications ?? DEFAULT_NOTIFICATION_SETTINGS
   };
 
   const newVision: VisionSettings = {
@@ -326,7 +336,8 @@ export function createDefaultExportData(): ExportedSettings {
       presets: DEFAULT_VISION.presets,
       defaultDisplaySettings: DEFAULT_VISION.defaultSettings,
       activePresetId: DEFAULT_VISION.activePresetId,
-      language: DEFAULT_SETTINGS.language
+      language: DEFAULT_SETTINGS.language,
+      notifications: DEFAULT_SETTINGS.notifications
     }
   };
 }

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -178,6 +178,7 @@ function OptionsApp() {
             onRemoveDomain={blocklist.handleRemoveDomain}
             onToggleDomain={blocklist.handleToggleDomain}
             onUpdateTimeLimit={blocklist.handleUpdateTimeLimit}
+            onUpdateNotifications={blocklist.handleUpdateNotifications}
             siteBlockCounts={analytics.analyticsData.siteBlockCounts}
             timeLimitUsage={analytics.analyticsData.timeLimitUsage}
           />

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -128,11 +128,20 @@ export interface VisionSettings {
 // Supported languages
 export type SupportedLanguage = 'en' | 'ja';
 
+// Notification settings
+export type NotificationMinutes = 1 | 3 | 5 | 10;
+
+export interface NotificationSettings {
+  timeLimitEnabled: boolean; // Enable/disable time limit notifications
+  timeLimitMinutes: NotificationMinutes; // Minutes before limit to notify (1, 3, 5, 10)
+}
+
 export interface AppSettings {
   blockList: BlockItem[];
   schedules: Schedule[];
   paused: boolean; // Global pause for all blocking
   language: SupportedLanguage | null; // null = use browser language
+  notifications: NotificationSettings; // Notification preferences
 }
 
 // Analytics data
@@ -170,12 +179,19 @@ export interface StorageSchema {
   unblockHistory: UnblockHistory;
 }
 
+// Default notification settings
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  timeLimitEnabled: true, // Enabled by default
+  timeLimitMinutes: 5 // Notify 5 minutes before limit
+};
+
 // Default values
 export const DEFAULT_SETTINGS: AppSettings = {
   blockList: [],
   schedules: [],
   paused: false,
-  language: null // Use browser language by default
+  language: null, // Use browser language by default
+  notifications: DEFAULT_NOTIFICATION_SETTINGS
 };
 
 export const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {


### PR DESCRIPTION
## Summary
- 時間制限付きサイトの残り時間が少なくなった時にデスクトップ通知を送る機能を追加
- Issue #25（時間制限機能）への追加機能として実装

## Changes
- `NotificationSettings`型を`AppSettings`に追加
  - `timeLimitEnabled`: 通知の有効/無効
  - `timeLimitMinutes`: 通知タイミング（1, 3, 5, 10分前）
- `src/background/notifications.ts`を新規作成
  - 残り時間チェックと通知送信ロジック
  - 重複通知防止のメモリ内フラグ管理
  - 日次/時次でのフラグリセット
- ブロックリストタブに通知設定セクションを追加
  - 時間制限サイトがある場合のみ表示
- i18nメッセージを追加（英語・日本語）
- settingsExport.tsに通知設定を追加

## Test Plan
- [ ] 時間制限付きサイトを設定し、残り時間が通知タイミング以下になったら通知が表示されることを確認
- [ ] 通知設定を無効にした場合、通知が表示されないことを確認
- [ ] 日次/時次リセット後に再度通知が送信されることを確認
- [ ] 設定のエクスポート/インポートで通知設定が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)