### PR TITLE
feat: スタイル保存上限を増加（Free:2, Premium:10）

### DIFF
--- a/src/types/premium.ts
+++ b/src/types/premium.ts
@@ -27,12 +27,12 @@ export const FEATURE_LIMITS: {
   free: {
     maxBlockList: Infinity, // Unlimited for all users
     historyDays: 7,
-    maxPresets: 1
+    maxPresets: 2
   },
   premium: {
     maxBlockList: Infinity,
     historyDays: Infinity,
-    maxPresets: 5
+    maxPresets: 10
   }
 };
 

--- a/src/types/premium.ts
+++ b/src/types/premium.ts
@@ -27,7 +27,7 @@ export const FEATURE_LIMITS: {
   free: {
     maxBlockList: Infinity, // Unlimited for all users
     historyDays: 7,
-    maxPresets: 2
+    maxPresets: 3
   },
   premium: {
     maxBlockList: Infinity,


### PR DESCRIPTION
## Summary
- スタイル保存の上限を増加
  - Free: 1 -> 2
  - Premium: 5 -> 10

## Changes
- `src/types/premium.ts` の `FEATURE_LIMITS` 定数を変更

## Test plan
- [ ] Free ユーザーが 2 つまでスタイルを保存できることを確認
- [ ] Premium ユーザーが 10 つまでスタイルを保存できることを確認
- [ ] 上限を超えた場合に適切なエラーメッセージが表示されることを確認

Closes #13

---
Generated with [Claude Code](https://claude.com/claude-code)
