### PR TITLE
feat: newtabのブロックサイト表示を改善

### DIFF
--- a/src/components/newtab/BlockedSitesList.tsx
+++ b/src/components/newtab/BlockedSitesList.tsx
@@ -17,49 +17,58 @@ export function BlockedSitesList({
 }: BlockedSitesListProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  if (blockList.length === 0) {
+  // Filter to only show enabled blocked sites
+  const enabledBlockList = blockList.filter((item) => item.enabled !== false);
+
+  if (enabledBlockList.length === 0) {
     return null;
   }
 
-  const visibleSites = isExpanded ? blockList : blockList.slice(0, maxVisible);
-  const hasMore = blockList.length > maxVisible;
+  const visibleSites = isExpanded
+    ? enabledBlockList
+    : enabledBlockList.slice(0, maxVisible);
+  const hasMore = enabledBlockList.length > maxVisible;
 
   return (
-    <div className="w-full max-w-sm mx-auto mt-6">
+    <div className="w-full max-w-md mx-auto mt-8">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center justify-between px-4 py-2 bg-white/30 hover:bg-white/40 rounded-lg transition-colors"
+        className="w-full flex items-center justify-between px-5 py-3 bg-white/10 hover:bg-white/15 backdrop-blur-sm rounded-xl border border-white/10 transition-all duration-200"
       >
-        <div className="flex items-center gap-2">
-          <Shield className="w-4 h-4 text-amber-500" />
-          <span className="text-sm font-medium text-gray-800">
-            {getMessage('blockedSites')} ({blockList.length})
+        <div className="flex items-center gap-3">
+          <div className="p-1.5 bg-red-500/20 rounded-lg">
+            <Shield className="w-4 h-4 text-red-400" />
+          </div>
+          <span className="text-sm font-medium text-white/90">
+            {getMessage('blockedSites')} ({enabledBlockList.length})
           </span>
         </div>
         {hasMore &&
           (isExpanded ? (
-            <ChevronUp className="w-4 h-4 text-gray-600" />
+            <ChevronUp className="w-5 h-5 text-white/60" />
           ) : (
-            <ChevronDown className="w-4 h-4 text-gray-600" />
+            <ChevronDown className="w-5 h-5 text-white/60" />
           ))}
       </button>
 
       {isExpanded && (
-        <div className="mt-2 bg-white/25 rounded-lg overflow-hidden">
-          <ul className="divide-y divide-gray-300/30">
+        <div className="mt-3 bg-white/5 backdrop-blur-sm rounded-xl border border-white/10 overflow-hidden">
+          <ul className="divide-y divide-white/5">
             {visibleSites.map((item) => {
               const count = blockCounts[item.domain]?.count ?? 0;
               return (
                 <li
                   key={item.id}
-                  className="px-4 py-2 text-sm text-gray-700 flex items-center justify-between"
+                  className="px-5 py-3 flex items-center justify-between hover:bg-white/5 transition-colors"
                 >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="w-2 h-2 rounded-full bg-red-500 flex-shrink-0" />
-                    <span className="truncate">{item.domain}</span>
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 shadow-[0_0_6px_rgba(248,113,113,0.5)]" />
+                    <span className="text-sm text-white/80 truncate font-medium">
+                      {item.domain}
+                    </span>
                   </div>
                   {count > 0 && (
-                    <span className="text-xs text-gray-500 flex-shrink-0 ml-2">
+                    <span className="text-xs text-white/50 flex-shrink-0 ml-3 bg-white/10 px-2 py-0.5 rounded-full">
                       {getMessage('blockedTimesShort', count.toString())}
                     </span>
                   )}


### PR DESCRIPTION
## Summary
- newtabのブロック中サイト一覧の表示を改善し視認性を向上
- 背景色をダーク系に統一しbackdrop-blurを追加
- テキスト色・間隔・アイコンスタイルを調整

## Changes
- `BlockedSitesList.tsx`: UIの視認性改善
  - 背景色を`bg-white/30`から`bg-white/10`に変更（ダーク背景対応）
  - パディングとgapを拡大（px-4 py-2 -> px-5 py-3）
  - テキスト色を白系に変更しコントラスト改善
  - シールドアイコンに背景を追加
  - ブロック回数をバッジスタイルに変更
  - 無効化されたサイトを非表示に変更
  - コンポーネント幅を`max-w-sm`から`max-w-md`に拡大

## Test plan
- [ ] newtabページでブロック中サイト一覧が正しく表示される
- [ ] 展開/折りたたみが動作する
- [ ] ブロック回数がバッジで表示される
- [ ] 無効化されたサイトが一覧に表示されない

Closes #46
