### PR TITLE
feat: YouTube内ブロック機能を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1534,5 +1534,73 @@
         "example": "/day"
       }
     }
+  },
+  "youtube": {
+    "message": "YouTube",
+    "description": "YouTube tab"
+  },
+  "youtubeBlockingTitle": {
+    "message": "YouTube In-App Blocking",
+    "description": "YouTube blocking section title"
+  },
+  "youtubeBlockingDescription": {
+    "message": "Hide distracting elements on YouTube without blocking the entire site. Watch educational content while avoiding the rabbit hole.",
+    "description": "YouTube blocking description"
+  },
+  "youtubeEnabled": {
+    "message": "Enable YouTube blocking",
+    "description": "Master switch for YouTube blocking"
+  },
+  "youtubeEnabledDescription": {
+    "message": "Turn on to hide distracting YouTube elements based on your settings below",
+    "description": "YouTube enabled description"
+  },
+  "youtubeHideShorts": {
+    "message": "Hide Shorts",
+    "description": "Hide Shorts option"
+  },
+  "youtubeHideShortsDescription": {
+    "message": "Hide the Shorts shelf, tab, and Shorts in search results",
+    "description": "Hide Shorts description"
+  },
+  "youtubeHideRecommendations": {
+    "message": "Hide Recommendations",
+    "description": "Hide recommendations option"
+  },
+  "youtubeHideRecommendationsDescription": {
+    "message": "Hide video recommendations at the end of videos",
+    "description": "Hide recommendations description"
+  },
+  "youtubeHideComments": {
+    "message": "Hide Comments",
+    "description": "Hide comments option"
+  },
+  "youtubeHideCommentsDescription": {
+    "message": "Hide the comment section below videos",
+    "description": "Hide comments description"
+  },
+  "youtubeHideSidebar": {
+    "message": "Hide Sidebar",
+    "description": "Hide sidebar option"
+  },
+  "youtubeHideSidebarDescription": {
+    "message": "Hide related videos sidebar when watching videos",
+    "description": "Hide sidebar description"
+  },
+  "youtubeHideHomeFeed": {
+    "message": "Hide Home Feed",
+    "description": "Hide home feed option"
+  },
+  "youtubeHideHomeFeedDescription": {
+    "message": "Hide the home page feed, allowing only search to find specific videos",
+    "description": "Hide home feed description"
+  },
+  "youtubeDisabledNote": {
+    "message": "Enable YouTube blocking above to configure these options",
+    "description": "Note shown when YouTube blocking is disabled"
+  },
+  "youtubePreviewTitle": {
+    "message": "What gets hidden",
+    "description": "Preview section title"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1534,5 +1534,73 @@
         "example": "/日"
       }
     }
+  },
+  "youtube": {
+    "message": "YouTube",
+    "description": "YouTubeタブ"
+  },
+  "youtubeBlockingTitle": {
+    "message": "YouTube内ブロック",
+    "description": "YouTubeブロックセクションタイトル"
+  },
+  "youtubeBlockingDescription": {
+    "message": "YouTube全体をブロックせずに、気が散る要素だけを非表示にします。教育コンテンツを見ながら、時間の無駄遣いを防ぎましょう。",
+    "description": "YouTubeブロック説明"
+  },
+  "youtubeEnabled": {
+    "message": "YouTubeブロックを有効にする",
+    "description": "YouTubeブロックのマスタースイッチ"
+  },
+  "youtubeEnabledDescription": {
+    "message": "オンにすると、下の設定に基づいてYouTubeの気が散る要素を非表示にします",
+    "description": "YouTube有効化の説明"
+  },
+  "youtubeHideShorts": {
+    "message": "Shortsを非表示",
+    "description": "Shorts非表示オプション"
+  },
+  "youtubeHideShortsDescription": {
+    "message": "Shortsシェルフ、タブ、検索結果のShortsを非表示にします",
+    "description": "Shorts非表示の説明"
+  },
+  "youtubeHideRecommendations": {
+    "message": "おすすめを非表示",
+    "description": "おすすめ非表示オプション"
+  },
+  "youtubeHideRecommendationsDescription": {
+    "message": "動画終了時のおすすめ動画を非表示にします",
+    "description": "おすすめ非表示の説明"
+  },
+  "youtubeHideComments": {
+    "message": "コメントを非表示",
+    "description": "コメント非表示オプション"
+  },
+  "youtubeHideCommentsDescription": {
+    "message": "動画下のコメント欄を非表示にします",
+    "description": "コメント非表示の説明"
+  },
+  "youtubeHideSidebar": {
+    "message": "サイドバーを非表示",
+    "description": "サイドバー非表示オプション"
+  },
+  "youtubeHideSidebarDescription": {
+    "message": "動画再生時の関連動画サイドバーを非表示にします",
+    "description": "サイドバー非表示の説明"
+  },
+  "youtubeHideHomeFeed": {
+    "message": "ホームフィードを非表示",
+    "description": "ホームフィード非表示オプション"
+  },
+  "youtubeHideHomeFeedDescription": {
+    "message": "ホームページのフィードを非表示にし、検索のみで動画を探せるようにします",
+    "description": "ホームフィード非表示の説明"
+  },
+  "youtubeDisabledNote": {
+    "message": "これらのオプションを設定するには、上のYouTubeブロックを有効にしてください",
+    "description": "YouTubeブロックが無効時の注記"
+  },
+  "youtubePreviewTitle": {
+    "message": "非表示になる要素",
+    "description": "プレビューセクションタイトル"
   }
 }

--- a/src/components/options/YouTubeTab.tsx
+++ b/src/components/options/YouTubeTab.tsx
@@ -1,0 +1,216 @@
+import React, { useCallback } from 'react';
+import {
+  Youtube,
+  PlaySquare,
+  ThumbsUp,
+  MessageSquare,
+  LayoutPanelLeft,
+  Home,
+  Info
+} from 'lucide-react';
+
+import { Card, Toggle } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import type { YouTubeSettings } from '~/types/storage';
+
+interface YouTubeTabProps {
+  youtube: YouTubeSettings | undefined;
+  onYouTubeChange: (youtube: YouTubeSettings) => void;
+}
+
+interface FeatureToggleProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}
+
+function FeatureToggle({
+  icon,
+  title,
+  description,
+  checked,
+  onChange,
+  disabled = false
+}: FeatureToggleProps) {
+  return (
+    <div
+      className={`flex items-start gap-4 p-4 rounded-lg transition-colors ${
+        disabled
+          ? 'bg-gray-50 opacity-60'
+          : checked
+            ? 'bg-blue-50'
+            : 'bg-gray-50 hover:bg-gray-100'
+      }`}
+    >
+      <div
+        className={`p-2 rounded-lg ${checked && !disabled ? 'bg-blue-100 text-blue-600' : 'bg-gray-200 text-gray-500'}`}
+      >
+        {icon}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <h3
+            className={`font-medium ${disabled ? 'text-gray-400' : 'text-gray-900'}`}
+          >
+            {title}
+          </h3>
+          <Toggle
+            checked={checked}
+            onChange={onChange}
+            disabled={disabled}
+            size="sm"
+          />
+        </div>
+        <p
+          className={`text-sm mt-1 ${disabled ? 'text-gray-400' : 'text-gray-500'}`}
+        >
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function YouTubeTab({ youtube, onYouTubeChange }: YouTubeTabProps) {
+  const isEnabled = youtube?.enabled ?? false;
+
+  const handleToggle = useCallback(
+    (key: keyof YouTubeSettings) => (checked: boolean) => {
+      if (!youtube) return;
+      onYouTubeChange({ ...youtube, [key]: checked });
+    },
+    [youtube, onYouTubeChange]
+  );
+
+  const features = [
+    {
+      key: 'hideShorts' as const,
+      icon: <PlaySquare className="w-5 h-5" />,
+      title: getMessage('youtubeHideShorts'),
+      description: getMessage('youtubeHideShortsDescription')
+    },
+    {
+      key: 'hideRecommendations' as const,
+      icon: <ThumbsUp className="w-5 h-5" />,
+      title: getMessage('youtubeHideRecommendations'),
+      description: getMessage('youtubeHideRecommendationsDescription')
+    },
+    {
+      key: 'hideComments' as const,
+      icon: <MessageSquare className="w-5 h-5" />,
+      title: getMessage('youtubeHideComments'),
+      description: getMessage('youtubeHideCommentsDescription')
+    },
+    {
+      key: 'hideSidebar' as const,
+      icon: <LayoutPanelLeft className="w-5 h-5" />,
+      title: getMessage('youtubeHideSidebar'),
+      description: getMessage('youtubeHideSidebarDescription')
+    },
+    {
+      key: 'hideHomeFeed' as const,
+      icon: <Home className="w-5 h-5" />,
+      title: getMessage('youtubeHideHomeFeed'),
+      description: getMessage('youtubeHideHomeFeedDescription')
+    }
+  ];
+
+  const activeFeatures = features.filter(
+    (f) => youtube?.[f.key as keyof YouTubeSettings]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header Card */}
+      <Card>
+        <div className="flex items-start gap-4">
+          <div className="p-3 bg-red-100 rounded-xl">
+            <Youtube className="w-8 h-8 text-red-600" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-xl font-semibold text-gray-900">
+              {getMessage('youtubeBlockingTitle')}
+            </h2>
+            <p className="text-gray-500 mt-1">
+              {getMessage('youtubeBlockingDescription')}
+            </p>
+          </div>
+        </div>
+
+        {/* Master Toggle */}
+        <div className="mt-6 p-4 bg-gray-50 rounded-lg">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="font-medium text-gray-900">
+                {getMessage('youtubeEnabled')}
+              </h3>
+              <p className="text-sm text-gray-500">
+                {getMessage('youtubeEnabledDescription')}
+              </p>
+            </div>
+            <Toggle
+              checked={isEnabled}
+              onChange={handleToggle('enabled')}
+              size="lg"
+            />
+          </div>
+        </div>
+      </Card>
+
+      {/* Feature Toggles */}
+      <Card>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          {getMessage('youtubePreviewTitle')}
+        </h2>
+
+        {!isEnabled && (
+          <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-2">
+            <Info className="w-4 h-4 text-amber-600 flex-shrink-0" />
+            <p className="text-sm text-amber-700">
+              {getMessage('youtubeDisabledNote')}
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          {features.map((feature) => (
+            <FeatureToggle
+              key={feature.key}
+              icon={feature.icon}
+              title={feature.title}
+              description={feature.description}
+              checked={youtube?.[feature.key] ?? false}
+              onChange={handleToggle(feature.key)}
+              disabled={!isEnabled}
+            />
+          ))}
+        </div>
+      </Card>
+
+      {/* Active Features Summary */}
+      {isEnabled && activeFeatures.length > 0 && (
+        <Card>
+          <h3 className="text-sm font-medium text-gray-700 mb-3">
+            {getMessage('active')}
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {activeFeatures.map((feature) => (
+              <span
+                key={feature.key}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-blue-100 text-blue-700 text-sm rounded-full"
+              >
+                {React.cloneElement(feature.icon as React.ReactElement, {
+                  className: 'w-4 h-4'
+                })}
+                {feature.title}
+              </span>
+            ))}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/options/index.ts
+++ b/src/components/options/index.ts
@@ -5,4 +5,5 @@ export * from './WeeklyCalendar';
 export * from './AnalyticsTab';
 export * from './PremiumTab';
 export * from './HelpTab';
+export * from './YouTubeTab';
 export * from './modals';

--- a/src/constants/tabs.ts
+++ b/src/constants/tabs.ts
@@ -3,6 +3,7 @@
  */
 export const TABS = {
   BLOCKLIST: 'blocklist',
+  YOUTUBE: 'youtube',
   STYLES: 'styles',
   SCHEDULES: 'schedules',
   ANALYTICS: 'analytics',
@@ -20,6 +21,7 @@ export type TabName = (typeof TABS)[keyof typeof TABS];
  */
 export const TAB_ORDER: TabName[] = [
   TABS.BLOCKLIST,
+  TABS.YOUTUBE,
   TABS.STYLES,
   TABS.SCHEDULES,
   TABS.ANALYTICS,

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -1,0 +1,251 @@
+import type { PlasmoCSConfig } from 'plasmo';
+
+import { Storage } from '@plasmohq/storage';
+
+import type { YouTubeSettings } from '~/types/storage';
+import { DEFAULT_YOUTUBE_SETTINGS } from '~/types/storage';
+
+// Run only on YouTube
+export const config: PlasmoCSConfig = {
+  matches: ['*://*.youtube.com/*'],
+  run_at: 'document_start'
+};
+
+// Storage instance
+const storage = new Storage({ area: 'local' });
+
+// CSS selectors for YouTube elements
+const SELECTORS = {
+  // Shorts
+  shortsShelf: 'ytd-rich-shelf-renderer[is-shorts]',
+  shortsTab: 'ytd-mini-guide-entry-renderer[aria-label="Shorts"]',
+  shortsSection: 'ytd-reel-shelf-renderer',
+  shortsSidebarTab:
+    'ytd-guide-entry-renderer a[title="Shorts"], ytd-guide-entry-renderer a[href="/shorts"]',
+
+  // Recommendations (Home page)
+  homeFeed: 'ytd-browse[page-subtype="home"] #contents',
+  homeChips: 'ytd-feed-filter-chip-bar-renderer',
+
+  // Recommendations (Watch page)
+  relatedVideos: '#related',
+  endScreen: '.ytp-endscreen-content',
+  autoplayToggle: '.ytp-autonav-toggle-button',
+
+  // Comments
+  comments: 'ytd-comments#comments',
+
+  // Sidebar (related videos on watch page)
+  sidebar: '#secondary #related',
+  secondaryInner: '#secondary-inner'
+} as const;
+
+// Current settings
+let currentSettings: YouTubeSettings = DEFAULT_YOUTUBE_SETTINGS;
+let styleElement: HTMLStyleElement | null = null;
+let observer: MutationObserver | null = null;
+
+// Generate CSS based on current settings
+function generateCSS(settings: YouTubeSettings): string {
+  if (!settings.enabled) {
+    return '';
+  }
+
+  const rules: string[] = [];
+
+  if (settings.hideShorts) {
+    rules.push(`
+      /* Hide Shorts shelf on home page */
+      ${SELECTORS.shortsShelf},
+      ${SELECTORS.shortsSection},
+      /* Hide Shorts tab in navigation */
+      ${SELECTORS.shortsTab},
+      ${SELECTORS.shortsSidebarTab},
+      /* Hide Shorts in search results */
+      ytd-video-renderer[is-shorts] {
+        display: none !important;
+      }
+    `);
+  }
+
+  if (settings.hideRecommendations) {
+    rules.push(`
+      /* Hide end screen recommendations */
+      ${SELECTORS.endScreen} {
+        display: none !important;
+      }
+    `);
+  }
+
+  if (settings.hideComments) {
+    rules.push(`
+      /* Hide comments section */
+      ${SELECTORS.comments} {
+        display: none !important;
+      }
+    `);
+  }
+
+  if (settings.hideSidebar) {
+    rules.push(`
+      /* Hide sidebar/related videos on watch page */
+      ytd-watch-flexy ${SELECTORS.relatedVideos},
+      ytd-watch-flexy ${SELECTORS.secondaryInner} #related {
+        display: none !important;
+      }
+      /* Expand video player when sidebar is hidden */
+      ytd-watch-flexy[flexy][is-two-columns_] #primary {
+        max-width: 100% !important;
+      }
+    `);
+  }
+
+  if (settings.hideHomeFeed) {
+    rules.push(`
+      /* Hide home feed - show only search bar */
+      ytd-browse[page-subtype="home"] ${SELECTORS.homeFeed},
+      ytd-browse[page-subtype="home"] ${SELECTORS.homeChips} {
+        display: none !important;
+      }
+      /* Show a message instead */
+      ytd-browse[page-subtype="home"]::after {
+        content: 'Home feed is hidden. Use search to find specific videos.';
+        display: block;
+        text-align: center;
+        padding: 100px 20px;
+        color: var(--yt-spec-text-secondary);
+        font-size: 16px;
+      }
+    `);
+  }
+
+  return rules.join('\n');
+}
+
+// Apply CSS to the page
+function applyStyles(settings: YouTubeSettings): void {
+  const css = generateCSS(settings);
+
+  if (!styleElement) {
+    styleElement = document.createElement('style');
+    styleElement.id = 'vision-focus-youtube-blocker';
+    const newStyleElement = styleElement;
+    // Insert at document_start, so we need to wait for head
+    const insertStyle = () => {
+      if (document.head) {
+        document.head.appendChild(newStyleElement);
+      } else {
+        requestAnimationFrame(insertStyle);
+      }
+    };
+    insertStyle();
+  }
+
+  styleElement.textContent = css;
+}
+
+// Handle dynamic content (YouTube is an SPA)
+function handleDynamicContent(): void {
+  if (!currentSettings.enabled) return;
+
+  // Additional DOM manipulation for dynamic elements
+  if (currentSettings.hideShorts) {
+    // Remove Shorts from navigation dynamically
+    document
+      .querySelectorAll(SELECTORS.shortsSidebarTab)
+      .forEach((el) => ((el as HTMLElement).style.display = 'none'));
+  }
+
+  if (currentSettings.hideRecommendations && currentSettings.hideHomeFeed) {
+    // Disable autoplay when recommendations are hidden
+    const autoplayToggle = document.querySelector(
+      SELECTORS.autoplayToggle
+    ) as HTMLElement;
+    if (autoplayToggle?.getAttribute('aria-checked') === 'true') {
+      autoplayToggle.click();
+    }
+  }
+}
+
+// Setup MutationObserver for SPA navigation
+function setupObserver(): void {
+  if (observer) {
+    observer.disconnect();
+  }
+
+  observer = new MutationObserver((mutations) => {
+    let shouldUpdate = false;
+
+    for (const mutation of mutations) {
+      if (mutation.type === 'childList' && mutation.addedNodes.length > 0) {
+        shouldUpdate = true;
+        break;
+      }
+    }
+
+    if (shouldUpdate) {
+      handleDynamicContent();
+    }
+  });
+
+  const newObserver = observer;
+  // Observe body for changes (YouTube SPA updates)
+  const startObserving = () => {
+    if (document.body && newObserver) {
+      newObserver.observe(document.body, {
+        childList: true,
+        subtree: true
+      });
+    } else {
+      requestAnimationFrame(startObserving);
+    }
+  };
+  startObserving();
+}
+
+// Load settings from storage
+async function loadSettings(): Promise<void> {
+  try {
+    const stored = await storage.get('settings');
+    if (stored && typeof stored === 'object' && 'youtube' in stored) {
+      currentSettings = (stored as { youtube: YouTubeSettings }).youtube;
+    }
+  } catch {
+    // Use default settings on error
+    currentSettings = DEFAULT_YOUTUBE_SETTINGS;
+  }
+
+  applyStyles(currentSettings);
+  handleDynamicContent();
+}
+
+// Watch for settings changes
+function watchSettings(): void {
+  storage.watch({
+    settings: (change) => {
+      if (change.newValue && typeof change.newValue === 'object') {
+        const newSettings = change.newValue as { youtube?: YouTubeSettings };
+        if (newSettings.youtube) {
+          currentSettings = newSettings.youtube;
+          applyStyles(currentSettings);
+          handleDynamicContent();
+        }
+      }
+    }
+  });
+}
+
+// Initialize
+async function init(): Promise<void> {
+  await loadSettings();
+  setupObserver();
+  watchSettings();
+
+  // Handle page navigation (YouTube SPA)
+  window.addEventListener('yt-navigate-finish', () => {
+    handleDynamicContent();
+  });
+}
+
+// Start
+init();

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -7,7 +7,8 @@ import {
   Crown,
   HelpCircle,
   Palette,
-  TrendingUp
+  TrendingUp,
+  Youtube
 } from 'lucide-react';
 
 import { Tabs } from '~/components/ui';
@@ -18,6 +19,7 @@ import {
   AnalyticsTab,
   PremiumTab,
   HelpTab,
+  YouTubeTab,
   NewPresetModal,
   ScheduleModal
 } from '~/components/options';
@@ -32,8 +34,16 @@ import {
 import { getMessage, setCurrentLanguage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
-import type { AppSettings, VisionSettings } from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_VISION } from '~/types/storage';
+import type {
+  AppSettings,
+  VisionSettings,
+  YouTubeSettings
+} from '~/types/storage';
+import {
+  DEFAULT_SETTINGS,
+  DEFAULT_VISION,
+  DEFAULT_YOUTUBE_SETTINGS
+} from '~/types/storage';
 
 import './styles/globals.css';
 
@@ -80,12 +90,25 @@ function OptionsApp() {
     }
   }, [settings?.language]);
 
+  // YouTube settings handler
+  const handleYouTubeChange = async (youtube: YouTubeSettings) => {
+    if (!settings) return;
+    const updated = { ...settings, youtube };
+    await storage.set('settings', updated);
+    setSettings(updated);
+  };
+
   // Tabs configuration (using TABS constant for type safety)
   const tabs: Array<{ id: TabName; label: string; icon: React.ReactNode }> = [
     {
       id: TABS.BLOCKLIST,
       label: getMessage('blockList'),
       icon: <Ban className="w-4 h-4" />
+    },
+    {
+      id: TABS.YOUTUBE,
+      label: getMessage('youtube'),
+      icon: <Youtube className="w-4 h-4" />
     },
     {
       id: TABS.STYLES,
@@ -181,6 +204,14 @@ function OptionsApp() {
             onUpdateNotifications={blocklist.handleUpdateNotifications}
             siteBlockCounts={analytics.analyticsData.siteBlockCounts}
             timeLimitUsage={analytics.analyticsData.timeLimitUsage}
+          />
+        )}
+
+        {/* YouTube Tab */}
+        {activeTab === TABS.YOUTUBE && (
+          <YouTubeTab
+            youtube={settings?.youtube ?? DEFAULT_YOUTUBE_SETTINGS}
+            onYouTubeChange={handleYouTubeChange}
           />
         )}
 

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -136,12 +136,23 @@ export interface NotificationSettings {
   timeLimitMinutes: NotificationMinutes; // Minutes before limit to notify (1, 3, 5, 10)
 }
 
+// YouTube in-app blocking settings
+export interface YouTubeSettings {
+  enabled: boolean; // Master switch for YouTube blocking features
+  hideShorts: boolean; // Hide Shorts shelf and tab
+  hideRecommendations: boolean; // Hide recommended videos on home and watch pages
+  hideComments: boolean; // Hide comment section
+  hideSidebar: boolean; // Hide related videos sidebar on watch page
+  hideHomeFeed: boolean; // Hide home feed (show only search)
+}
+
 export interface AppSettings {
   blockList: BlockItem[];
   schedules: Schedule[];
   paused: boolean; // Global pause for all blocking
   language: SupportedLanguage | null; // null = use browser language
   notifications: NotificationSettings; // Notification preferences
+  youtube: YouTubeSettings; // YouTube in-app blocking settings
 }
 
 // Analytics data
@@ -185,13 +196,24 @@ export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
   timeLimitMinutes: 5 // Notify 5 minutes before limit
 };
 
+// Default YouTube settings
+export const DEFAULT_YOUTUBE_SETTINGS: YouTubeSettings = {
+  enabled: false, // Disabled by default
+  hideShorts: false,
+  hideRecommendations: false,
+  hideComments: false,
+  hideSidebar: false,
+  hideHomeFeed: false
+};
+
 // Default values
 export const DEFAULT_SETTINGS: AppSettings = {
   blockList: [],
   schedules: [],
   paused: false,
   language: null, // Use browser language by default
-  notifications: DEFAULT_NOTIFICATION_SETTINGS
+  notifications: DEFAULT_NOTIFICATION_SETTINGS,
+  youtube: DEFAULT_YOUTUBE_SETTINGS
 };
 
 export const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {


### PR DESCRIPTION
## Summary
- YouTube専用のContent Scriptを追加（Shorts、おすすめ、コメント、サイドバー、ホームフィードの個別非表示）
- 設定画面に視覚的でわかりやすいYouTubeタブを追加
- MutationObserverによるSPA対応（YouTubeのページ遷移に追従）

## Features
### 非表示オプション
- **Shorts**: ショート動画シェルフ、タブ、検索結果を非表示
- **おすすめ動画**: 動画終了時のおすすめを非表示
- **コメント欄**: 動画下のコメントセクションを非表示
- **サイドバー**: 関連動画サイドバーを非表示（動画プレーヤーが拡大）
- **ホームフィード**: ホーム画面を非表示にして検索のみ許可

### UX設計
- マスタースイッチで機能全体のON/OFF
- 各オプションはアイコン付きのカード形式で視覚的にわかりやすく
- 有効な機能のサマリーバッジ表示
- 日本語/英語の国際化対応

## Technical Details
- Content Script: `src/contents/youtube.ts`（CSSインジェクション + MutationObserver）
- UIコンポーネント: `src/components/options/YouTubeTab.tsx`
- 設定永続化: `@plasmohq/storage` でリアルタイム同期

## Test plan
- [ ] YouTubeでShortsが非表示になることを確認
- [ ] YouTubeでサイドバーが非表示になることを確認
- [ ] ホームフィード非表示時にメッセージが表示されることを確認
- [ ] 設定変更が即座に反映されることを確認
- [ ] YouTubeのSPAナビゲーションでも機能することを確認

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)