### PR TITLE
feat: スケジュールON時にブロックを自動有効化

### DIFF
--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -92,6 +92,8 @@ export function useSchedules({
       if (!settings) return;
       const updated = {
         ...settings,
+        // When enabling a schedule, also enable blocking (paused=false)
+        paused: enabled ? false : settings.paused,
         schedules: settings.schedules.map((s) =>
           s.id === id ? { ...s, enabled } : s
         )


### PR DESCRIPTION
## Summary
- スケジュールを有効にした際、ブロック機能（paused=false）も自動的に有効になるように変更
- これにより、スケジュールON時にpausedがtrueのままでブロックが有効にならない問題を解消

## Changes
- src/hooks/useSchedules.ts: handleToggleSchedule関数でスケジュールを有効にする際、pausedをfalseに設定する処理を追加

## Test plan
- [ ] スケジュールをONにした時、ブロック機能が自動的にONになることを確認
- [ ] スケジュールをOFFにした時、ブロック機能の状態が維持されることを確認
- [ ] 既存のスケジュール機能が正常に動作することを確認

Closes #5
