### PR TITLE
feat: パスワード保護機能を実装 (#12)

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1602,5 +1602,149 @@
   "youtubePreviewTitle": {
     "message": "What gets hidden",
     "description": "Preview section title"
+  },
+  "passwordProtection": {
+    "message": "Password Protection",
+    "description": "Password protection section title"
+  },
+  "passwordProtectionDescription": {
+    "message": "Require a password to disable blocking or remove sites. Great for family accountability.",
+    "description": "Password protection description"
+  },
+  "passwordProtectionEnabled": {
+    "message": "Password protection is enabled",
+    "description": "Password protection enabled status"
+  },
+  "passwordProtectionDisabled": {
+    "message": "Password protection is not enabled",
+    "description": "Password protection disabled status"
+  },
+  "passwordProtectionActive": {
+    "message": "Password protection is active for these actions",
+    "description": "Password protection active indicator"
+  },
+  "setPassword": {
+    "message": "Set Password",
+    "description": "Set password button"
+  },
+  "changePassword": {
+    "message": "Change Password",
+    "description": "Change password button"
+  },
+  "removePassword": {
+    "message": "Remove Password",
+    "description": "Remove password button"
+  },
+  "newPassword": {
+    "message": "New Password",
+    "description": "New password label"
+  },
+  "currentPassword": {
+    "message": "Current Password",
+    "description": "Current password label"
+  },
+  "confirmPassword": {
+    "message": "Confirm Password",
+    "description": "Confirm password label"
+  },
+  "enterPassword": {
+    "message": "Enter Password",
+    "description": "Enter password label"
+  },
+  "passwordPlaceholder": {
+    "message": "Enter your password",
+    "description": "Password input placeholder"
+  },
+  "currentPasswordPlaceholder": {
+    "message": "Enter current password",
+    "description": "Current password placeholder"
+  },
+  "confirmPasswordPlaceholder": {
+    "message": "Confirm your password",
+    "description": "Confirm password placeholder"
+  },
+  "passwordRequired": {
+    "message": "Password Required",
+    "description": "Password required title"
+  },
+  "passwordRequiredDescription": {
+    "message": "Enter your password to continue with this action.",
+    "description": "Password required description"
+  },
+  "passwordRequiredForUnblock": {
+    "message": "Password Required",
+    "description": "Password required for unblock title"
+  },
+  "passwordRequiredForUnblockDescription": {
+    "message": "Enter your password to remove or disable this blocked site.",
+    "description": "Password required for unblock description"
+  },
+  "passwordRequiredForPause": {
+    "message": "Enter your password to pause blocking.",
+    "description": "Password required for pause description"
+  },
+  "passwordIncorrect": {
+    "message": "Incorrect password. Please try again.",
+    "description": "Incorrect password error"
+  },
+  "passwordVerificationFailed": {
+    "message": "Failed to verify password. Please try again.",
+    "description": "Password verification failed error"
+  },
+  "verifying": {
+    "message": "Verifying...",
+    "description": "Verifying text"
+  },
+  "passwordTooShort": {
+    "message": "Password must be at least 4 characters",
+    "description": "Password too short error"
+  },
+  "passwordTooLong": {
+    "message": "Password is too long",
+    "description": "Password too long error"
+  },
+  "passwordMismatch": {
+    "message": "Passwords do not match",
+    "description": "Password mismatch error"
+  },
+  "passwordNotSet": {
+    "message": "Password is not set",
+    "description": "Password not set error"
+  },
+  "currentPasswordIncorrect": {
+    "message": "Current password is incorrect",
+    "description": "Current password incorrect error"
+  },
+  "passwordSetSuccess": {
+    "message": "Password has been set successfully",
+    "description": "Password set success message"
+  },
+  "passwordChangedSuccess": {
+    "message": "Password has been changed successfully",
+    "description": "Password changed success message"
+  },
+  "passwordRemovedSuccess": {
+    "message": "Password protection has been disabled",
+    "description": "Password removed success message"
+  },
+  "passwordSetFailed": {
+    "message": "Failed to set password",
+    "description": "Password set failed error"
+  },
+  "passwordChangeFailed": {
+    "message": "Failed to change password",
+    "description": "Password change failed error"
+  },
+  "passwordRemoveFailed": {
+    "message": "Failed to remove password",
+    "description": "Password remove failed error"
+  },
+  "passwordSetInstructions": {
+    "message": "Set a password to protect your blocking settings. Share it with a family member or partner for accountability.",
+    "description": "Password set instructions"
+  },
+  "passwordRemoveWarning": {
+    "message": "Removing password protection will allow anyone to disable blocking without entering a password.",
+    "description": "Password remove warning"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1602,5 +1602,149 @@
   "youtubePreviewTitle": {
     "message": "非表示になる要素",
     "description": "プレビューセクションタイトル"
+  },
+  "passwordProtection": {
+    "message": "パスワード保護",
+    "description": "パスワード保護セクションタイトル"
+  },
+  "passwordProtectionDescription": {
+    "message": "ブロックの無効化やサイトの削除にパスワードを必要とします。家族やパートナーとの約束に最適です。",
+    "description": "パスワード保護の説明"
+  },
+  "passwordProtectionEnabled": {
+    "message": "パスワード保護が有効です",
+    "description": "パスワード保護有効状態"
+  },
+  "passwordProtectionDisabled": {
+    "message": "パスワード保護が無効です",
+    "description": "パスワード保護無効状態"
+  },
+  "passwordProtectionActive": {
+    "message": "これらの操作にはパスワードが必要です",
+    "description": "パスワード保護アクティブ表示"
+  },
+  "setPassword": {
+    "message": "パスワードを設定",
+    "description": "パスワード設定ボタン"
+  },
+  "changePassword": {
+    "message": "パスワードを変更",
+    "description": "パスワード変更ボタン"
+  },
+  "removePassword": {
+    "message": "パスワードを解除",
+    "description": "パスワード解除ボタン"
+  },
+  "newPassword": {
+    "message": "新しいパスワード",
+    "description": "新しいパスワードラベル"
+  },
+  "currentPassword": {
+    "message": "現在のパスワード",
+    "description": "現在のパスワードラベル"
+  },
+  "confirmPassword": {
+    "message": "パスワードの確認",
+    "description": "パスワード確認ラベル"
+  },
+  "enterPassword": {
+    "message": "パスワードを入力",
+    "description": "パスワード入力ラベル"
+  },
+  "passwordPlaceholder": {
+    "message": "パスワードを入力してください",
+    "description": "パスワード入力プレースホルダー"
+  },
+  "currentPasswordPlaceholder": {
+    "message": "現在のパスワードを入力",
+    "description": "現在のパスワードプレースホルダー"
+  },
+  "confirmPasswordPlaceholder": {
+    "message": "パスワードを再入力",
+    "description": "パスワード確認プレースホルダー"
+  },
+  "passwordRequired": {
+    "message": "パスワードが必要です",
+    "description": "パスワード必須タイトル"
+  },
+  "passwordRequiredDescription": {
+    "message": "この操作を続行するにはパスワードを入力してください。",
+    "description": "パスワード必須説明"
+  },
+  "passwordRequiredForUnblock": {
+    "message": "パスワードが必要です",
+    "description": "ブロック解除用パスワード必須タイトル"
+  },
+  "passwordRequiredForUnblockDescription": {
+    "message": "ブロックサイトを削除または無効にするにはパスワードを入力してください。",
+    "description": "ブロック解除用パスワード必須説明"
+  },
+  "passwordRequiredForPause": {
+    "message": "ブロックを一時停止するにはパスワードを入力してください。",
+    "description": "一時停止用パスワード必須説明"
+  },
+  "passwordIncorrect": {
+    "message": "パスワードが正しくありません。再度お試しください。",
+    "description": "パスワード不正エラー"
+  },
+  "passwordVerificationFailed": {
+    "message": "パスワードの確認に失敗しました。再度お試しください。",
+    "description": "パスワード確認失敗エラー"
+  },
+  "verifying": {
+    "message": "確認中...",
+    "description": "確認中テキスト"
+  },
+  "passwordTooShort": {
+    "message": "パスワードは4文字以上で入力してください",
+    "description": "パスワード短すぎエラー"
+  },
+  "passwordTooLong": {
+    "message": "パスワードが長すぎます",
+    "description": "パスワード長すぎエラー"
+  },
+  "passwordMismatch": {
+    "message": "パスワードが一致しません",
+    "description": "パスワード不一致エラー"
+  },
+  "passwordNotSet": {
+    "message": "パスワードが設定されていません",
+    "description": "パスワード未設定エラー"
+  },
+  "currentPasswordIncorrect": {
+    "message": "現在のパスワードが正しくありません",
+    "description": "現在のパスワード不正エラー"
+  },
+  "passwordSetSuccess": {
+    "message": "パスワードを設定しました",
+    "description": "パスワード設定成功メッセージ"
+  },
+  "passwordChangedSuccess": {
+    "message": "パスワードを変更しました",
+    "description": "パスワード変更成功メッセージ"
+  },
+  "passwordRemovedSuccess": {
+    "message": "パスワード保護を解除しました",
+    "description": "パスワード解除成功メッセージ"
+  },
+  "passwordSetFailed": {
+    "message": "パスワードの設定に失敗しました",
+    "description": "パスワード設定失敗エラー"
+  },
+  "passwordChangeFailed": {
+    "message": "パスワードの変更に失敗しました",
+    "description": "パスワード変更失敗エラー"
+  },
+  "passwordRemoveFailed": {
+    "message": "パスワードの解除に失敗しました",
+    "description": "パスワード解除失敗エラー"
+  },
+  "passwordSetInstructions": {
+    "message": "ブロック設定を保護するパスワードを設定します。家族やパートナーと共有して、お互いに責任を持ちましょう。",
+    "description": "パスワード設定の説明"
+  },
+  "passwordRemoveWarning": {
+    "message": "パスワード保護を解除すると、誰でもパスワードなしでブロックを無効にできるようになります。",
+    "description": "パスワード解除の警告"
   }
 }

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback } from 'react';
-import { Plus, Trash2, Shield, Clock, ChevronDown, ChevronUp, Bell } from 'lucide-react';
+import { Plus, Trash2, Shield, Clock, ChevronDown, ChevronUp, Bell, Lock } from 'lucide-react';
 
 import { Button, Card, Input, Toggle, Select } from '~/components/ui';
+import { PasswordModal } from '~/components/options/modals';
 import { TimeLimitBadge } from '~/components/features';
 import { getMessage } from '~/lib/i18n';
 import { TIME_LIMIT_CONFIG } from '~/constants/limits';
@@ -294,6 +295,60 @@ export function BlocklistTab({
   siteBlockCounts = {},
   timeLimitUsage = {}
 }: BlocklistTabProps) {
+  // Password protection state
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
+  const [pendingToggleId, setPendingToggleId] = useState<string | null>(null);
+
+  const isPasswordProtected =
+    settings?.password?.enabled && settings?.password?.passwordHash;
+
+  // Handle remove with password check
+  const handleRemoveClick = useCallback(
+    (id: string) => {
+      if (isPasswordProtected) {
+        setPendingRemoveId(id);
+        setShowPasswordModal(true);
+      } else {
+        onRemoveDomain(id);
+      }
+    },
+    [isPasswordProtected, onRemoveDomain]
+  );
+
+  // Handle toggle with password check (only when disabling)
+  const handleToggleClick = useCallback(
+    (id: string, enabled: boolean) => {
+      // Only require password when disabling (turning off blocking)
+      if (!enabled && isPasswordProtected) {
+        setPendingToggleId(id);
+        setShowPasswordModal(true);
+      } else {
+        onToggleDomain(id, enabled);
+      }
+    },
+    [isPasswordProtected, onToggleDomain]
+  );
+
+  // Handle password confirmation success
+  const handlePasswordSuccess = useCallback(() => {
+    if (pendingRemoveId) {
+      onRemoveDomain(pendingRemoveId);
+      setPendingRemoveId(null);
+    }
+    if (pendingToggleId) {
+      onToggleDomain(pendingToggleId, false);
+      setPendingToggleId(null);
+    }
+  }, [pendingRemoveId, pendingToggleId, onRemoveDomain, onToggleDomain]);
+
+  // Handle modal close
+  const handlePasswordModalClose = useCallback(() => {
+    setShowPasswordModal(false);
+    setPendingRemoveId(null);
+    setPendingToggleId(null);
+  }, []);
+
   // Check if any sites have time limits configured
   const hasTimeLimitSites =
     settings?.blockList.some((item) => item.timeLimit !== null && item.timeLimit !== undefined) ??
@@ -356,7 +411,7 @@ export function BlocklistTab({
                     <div className="flex items-center gap-3">
                       <Toggle
                         checked={item.enabled}
-                        onChange={(checked) => onToggleDomain(item.id, checked)}
+                        onChange={(checked) => handleToggleClick(item.id, checked)}
                         size="sm"
                       />
                       <div>
@@ -388,7 +443,7 @@ export function BlocklistTab({
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => onRemoveDomain(item.id)}
+                      onClick={() => handleRemoveClick(item.id)}
                     >
                       <Trash2 className="w-4 h-4 text-red-500" />
                     </Button>
@@ -408,6 +463,26 @@ export function BlocklistTab({
           </div>
         )}
       </Card>
+
+      {/* Password Protection Indicator */}
+      {isPasswordProtected && (
+        <div className="flex items-center gap-2 text-sm text-amber-600">
+          <Lock className="w-4 h-4" />
+          <span>{getMessage('passwordProtectionActive')}</span>
+        </div>
+      )}
+
+      {/* Password Modal */}
+      {isPasswordProtected && settings?.password?.passwordHash && (
+        <PasswordModal
+          isOpen={showPasswordModal}
+          onClose={handlePasswordModalClose}
+          onSuccess={handlePasswordSuccess}
+          passwordHash={settings.password.passwordHash}
+          title={getMessage('passwordRequiredForUnblock')}
+          description={getMessage('passwordRequiredForUnblockDescription')}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 
 import { Button, Card } from '~/components/ui';
+import { PasswordSettingsSection } from '~/components/options/PasswordSettingsSection';
 import { getMessage } from '~/lib/i18n';
 import {
   exportSettings,
@@ -21,14 +22,18 @@ import {
   applyImportedSettings
 } from '~/lib/settingsExport';
 import { getSettings, getVision, setSettings, setVision } from '~/lib/storage';
+import type { PasswordSettings, AppSettings } from '~/types/storage';
+import { DEFAULT_PASSWORD_SETTINGS } from '~/types/storage';
 
 const VERSION = '1.0.0';
 
 interface HelpTabProps {
   onSettingsChange?: () => void;
+  settings?: AppSettings;
+  onPasswordUpdate?: (settings: PasswordSettings) => Promise<void>;
 }
 
-export function HelpTab({ onSettingsChange }: HelpTabProps) {
+export function HelpTab({ onSettingsChange, settings, onPasswordUpdate }: HelpTabProps) {
   const [exportStatus, setExportStatus] = useState<
     'idle' | 'loading' | 'success' | 'error'
   >('idle');
@@ -226,6 +231,14 @@ export function HelpTab({ onSettingsChange }: HelpTabProps) {
           </details>
         </div>
       </Card>
+
+      {/* Password Protection */}
+      {onPasswordUpdate && (
+        <PasswordSettingsSection
+          passwordSettings={settings?.password ?? DEFAULT_PASSWORD_SETTINGS}
+          onUpdate={onPasswordUpdate}
+        />
+      )}
 
       {/* Settings Backup */}
       <Card>

--- a/src/components/options/PasswordSettingsSection.tsx
+++ b/src/components/options/PasswordSettingsSection.tsx
@@ -1,0 +1,503 @@
+import React, { useState, useCallback } from 'react';
+import { Lock, Shield, Eye, EyeOff, Check, AlertTriangle } from 'lucide-react';
+
+import { Button, Card, Input, Toggle } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import {
+  hashPassword,
+  verifyPassword,
+  validatePasswordStrength
+} from '~/lib/password';
+import type { PasswordSettings } from '~/types/storage';
+
+interface PasswordSettingsSectionProps {
+  passwordSettings: PasswordSettings;
+  onUpdate: (settings: PasswordSettings) => Promise<void>;
+}
+
+type SettingMode = 'view' | 'set' | 'change' | 'remove';
+
+export function PasswordSettingsSection({
+  passwordSettings,
+  onUpdate
+}: PasswordSettingsSectionProps) {
+  const [mode, setMode] = useState<SettingMode>('view');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const isEnabled = passwordSettings.enabled && passwordSettings.passwordHash;
+
+  const resetForm = useCallback(() => {
+    setCurrentPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setShowCurrentPassword(false);
+    setShowNewPassword(false);
+    setShowConfirmPassword(false);
+    setError(null);
+    setSuccess(null);
+    setMode('view');
+  }, []);
+
+  const handleSetPassword = useCallback(async () => {
+    setError(null);
+
+    // Validate new password
+    const validation = validatePasswordStrength(newPassword);
+    if (!validation.isValid && validation.errorKey) {
+      setError(getMessage(validation.errorKey));
+      return;
+    }
+
+    // Check confirmation matches
+    if (newPassword !== confirmPassword) {
+      setError(getMessage('passwordMismatch'));
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      const hash = await hashPassword(newPassword);
+      await onUpdate({
+        enabled: true,
+        passwordHash: hash
+      });
+      setSuccess(getMessage('passwordSetSuccess'));
+      setTimeout(() => {
+        resetForm();
+      }, 2000);
+    } catch {
+      setError(getMessage('passwordSetFailed'));
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [newPassword, confirmPassword, onUpdate, resetForm]);
+
+  const handleChangePassword = useCallback(async () => {
+    setError(null);
+
+    // Verify current password
+    if (!passwordSettings.passwordHash) {
+      setError(getMessage('passwordNotSet'));
+      return;
+    }
+
+    const isCurrentValid = await verifyPassword(
+      currentPassword,
+      passwordSettings.passwordHash
+    );
+    if (!isCurrentValid) {
+      setError(getMessage('currentPasswordIncorrect'));
+      return;
+    }
+
+    // Validate new password
+    const validation = validatePasswordStrength(newPassword);
+    if (!validation.isValid && validation.errorKey) {
+      setError(getMessage(validation.errorKey));
+      return;
+    }
+
+    // Check confirmation matches
+    if (newPassword !== confirmPassword) {
+      setError(getMessage('passwordMismatch'));
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      const hash = await hashPassword(newPassword);
+      await onUpdate({
+        enabled: true,
+        passwordHash: hash
+      });
+      setSuccess(getMessage('passwordChangedSuccess'));
+      setTimeout(() => {
+        resetForm();
+      }, 2000);
+    } catch {
+      setError(getMessage('passwordChangeFailed'));
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [currentPassword, newPassword, confirmPassword, passwordSettings, onUpdate, resetForm]);
+
+  const handleRemovePassword = useCallback(async () => {
+    setError(null);
+
+    // Verify current password
+    if (!passwordSettings.passwordHash) {
+      setError(getMessage('passwordNotSet'));
+      return;
+    }
+
+    const isCurrentValid = await verifyPassword(
+      currentPassword,
+      passwordSettings.passwordHash
+    );
+    if (!isCurrentValid) {
+      setError(getMessage('currentPasswordIncorrect'));
+      return;
+    }
+
+    setIsProcessing(true);
+    try {
+      await onUpdate({
+        enabled: false,
+        passwordHash: null
+      });
+      setSuccess(getMessage('passwordRemovedSuccess'));
+      setTimeout(() => {
+        resetForm();
+      }, 2000);
+    } catch {
+      setError(getMessage('passwordRemoveFailed'));
+    } finally {
+      setIsProcessing(false);
+    }
+  }, [currentPassword, passwordSettings, onUpdate, resetForm]);
+
+  const handleToggle = useCallback(
+    (enabled: boolean) => {
+      if (enabled && !isEnabled) {
+        // Start setting password
+        setMode('set');
+      } else if (!enabled && isEnabled) {
+        // Start removing password
+        setMode('remove');
+      }
+    },
+    [isEnabled]
+  );
+
+  return (
+    <Card>
+      <div className="flex items-center gap-3 mb-4">
+        <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
+          <Lock className="w-5 h-5 text-amber-600" />
+        </div>
+        <div className="flex-1">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {getMessage('passwordProtection')}
+          </h2>
+          <p className="text-sm text-gray-500">
+            {getMessage('passwordProtectionDescription')}
+          </p>
+        </div>
+        {mode === 'view' && (
+          <Toggle checked={isEnabled} onChange={handleToggle} />
+        )}
+      </div>
+
+      {/* Status indicator */}
+      {mode === 'view' && (
+        <div
+          className={`flex items-center gap-2 p-3 rounded-lg ${
+            isEnabled ? 'bg-green-50' : 'bg-gray-50'
+          }`}
+        >
+          <Shield
+            className={`w-4 h-4 ${isEnabled ? 'text-green-600' : 'text-gray-400'}`}
+          />
+          <span
+            className={`text-sm ${isEnabled ? 'text-green-700' : 'text-gray-500'}`}
+          >
+            {isEnabled
+              ? getMessage('passwordProtectionEnabled')
+              : getMessage('passwordProtectionDisabled')}
+          </span>
+          {isEnabled && (
+            <button
+              onClick={() => setMode('change')}
+              className="ml-auto text-sm text-blue-600 hover:text-blue-800"
+            >
+              {getMessage('changePassword')}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Set Password Form */}
+      {mode === 'set' && (
+        <div className="space-y-4">
+          <div className="p-3 bg-blue-50 rounded-lg">
+            <p className="text-sm text-blue-700">
+              {getMessage('passwordSetInstructions')}
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('newPassword')}
+              </label>
+              <div className="relative">
+                <Input
+                  type={showNewPassword ? 'text' : 'password'}
+                  value={newPassword}
+                  onChange={setNewPassword}
+                  placeholder={getMessage('passwordPlaceholder')}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowNewPassword(!showNewPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                >
+                  {showNewPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('confirmPassword')}
+              </label>
+              <div className="relative">
+                <Input
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={setConfirmPassword}
+                  placeholder={getMessage('confirmPasswordPlaceholder')}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                >
+                  {showConfirmPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-600">
+              <AlertTriangle className="w-4 h-4" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && (
+            <div className="flex items-center gap-2 text-sm text-green-600">
+              <Check className="w-4 h-4" />
+              <span>{success}</span>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <Button variant="secondary" onClick={resetForm} className="flex-1">
+              {getMessage('cancel')}
+            </Button>
+            <Button
+              onClick={handleSetPassword}
+              disabled={isProcessing || !newPassword || !confirmPassword}
+              className="flex-1"
+            >
+              {isProcessing ? getMessage('processing') : getMessage('setPassword')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Change Password Form */}
+      {mode === 'change' && (
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('currentPassword')}
+              </label>
+              <div className="relative">
+                <Input
+                  type={showCurrentPassword ? 'text' : 'password'}
+                  value={currentPassword}
+                  onChange={setCurrentPassword}
+                  placeholder={getMessage('currentPasswordPlaceholder')}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                >
+                  {showCurrentPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('newPassword')}
+              </label>
+              <div className="relative">
+                <Input
+                  type={showNewPassword ? 'text' : 'password'}
+                  value={newPassword}
+                  onChange={setNewPassword}
+                  placeholder={getMessage('passwordPlaceholder')}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowNewPassword(!showNewPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                >
+                  {showNewPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('confirmPassword')}
+              </label>
+              <div className="relative">
+                <Input
+                  type={showConfirmPassword ? 'text' : 'password'}
+                  value={confirmPassword}
+                  onChange={setConfirmPassword}
+                  placeholder={getMessage('confirmPasswordPlaceholder')}
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                >
+                  {showConfirmPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-600">
+              <AlertTriangle className="w-4 h-4" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && (
+            <div className="flex items-center gap-2 text-sm text-green-600">
+              <Check className="w-4 h-4" />
+              <span>{success}</span>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <Button variant="secondary" onClick={resetForm} className="flex-1">
+              {getMessage('cancel')}
+            </Button>
+            <Button
+              onClick={handleChangePassword}
+              disabled={
+                isProcessing || !currentPassword || !newPassword || !confirmPassword
+              }
+              className="flex-1"
+            >
+              {isProcessing
+                ? getMessage('processing')
+                : getMessage('changePassword')}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Remove Password Form */}
+      {mode === 'remove' && (
+        <div className="space-y-4">
+          <div className="p-3 bg-amber-50 rounded-lg">
+            <p className="text-sm text-amber-700">
+              {getMessage('passwordRemoveWarning')}
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {getMessage('currentPassword')}
+            </label>
+            <div className="relative">
+              <Input
+                type={showCurrentPassword ? 'text' : 'password'}
+                value={currentPassword}
+                onChange={setCurrentPassword}
+                placeholder={getMessage('currentPasswordPlaceholder')}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+              >
+                {showCurrentPassword ? (
+                  <EyeOff className="w-4 h-4" />
+                ) : (
+                  <Eye className="w-4 h-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {error && (
+            <div className="flex items-center gap-2 text-sm text-red-600">
+              <AlertTriangle className="w-4 h-4" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          {success && (
+            <div className="flex items-center gap-2 text-sm text-green-600">
+              <Check className="w-4 h-4" />
+              <span>{success}</span>
+            </div>
+          )}
+
+          <div className="flex gap-3">
+            <Button variant="secondary" onClick={resetForm} className="flex-1">
+              {getMessage('cancel')}
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleRemovePassword}
+              disabled={isProcessing || !currentPassword}
+              className="flex-1"
+            >
+              {isProcessing
+                ? getMessage('processing')
+                : getMessage('removePassword')}
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/options/index.ts
+++ b/src/components/options/index.ts
@@ -6,4 +6,5 @@ export * from './AnalyticsTab';
 export * from './PremiumTab';
 export * from './HelpTab';
 export * from './YouTubeTab';
+export * from './PasswordSettingsSection';
 export * from './modals';

--- a/src/components/options/modals/PasswordModal.tsx
+++ b/src/components/options/modals/PasswordModal.tsx
@@ -1,0 +1,132 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Lock, Eye, EyeOff } from 'lucide-react';
+
+import { Modal, Button, Input } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import { verifyPassword } from '~/lib/password';
+
+interface PasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  passwordHash: string;
+  title?: string;
+  description?: string;
+}
+
+export function PasswordModal({
+  isOpen,
+  onClose,
+  onSuccess,
+  passwordHash,
+  title,
+  description
+}: PasswordModalProps) {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setPassword('');
+      setError(null);
+      setShowPassword(false);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!password) {
+      setError(getMessage('passwordRequired'));
+      return;
+    }
+
+    setIsVerifying(true);
+    setError(null);
+
+    try {
+      const isValid = await verifyPassword(password, passwordHash);
+
+      if (isValid) {
+        onSuccess();
+        onClose();
+      } else {
+        setError(getMessage('passwordIncorrect'));
+      }
+    } catch {
+      setError(getMessage('passwordVerificationFailed'));
+    } finally {
+      setIsVerifying(false);
+    }
+  }, [password, passwordHash, onSuccess, onClose]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !isVerifying) {
+        handleSubmit();
+      }
+    },
+    [handleSubmit, isVerifying]
+  );
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title || getMessage('passwordRequired')}
+      size="sm"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 p-4 bg-amber-50 rounded-lg">
+          <Lock className="w-5 h-5 text-amber-600 flex-shrink-0" />
+          <p className="text-sm text-amber-800">
+            {description || getMessage('passwordRequiredDescription')}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">
+            {getMessage('enterPassword')}
+          </label>
+          <div className="relative">
+            <Input
+              type={showPassword ? 'text' : 'password'}
+              value={password}
+              onChange={setPassword}
+              onKeyDown={handleKeyDown}
+              placeholder={getMessage('passwordPlaceholder')}
+              className="pr-10"
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+            >
+              {showPassword ? (
+                <EyeOff className="w-4 h-4" />
+              ) : (
+                <Eye className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <Button variant="secondary" onClick={onClose} className="flex-1">
+            {getMessage('cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isVerifying || !password}
+            className="flex-1"
+          >
+            {isVerifying ? getMessage('verifying') : getMessage('confirm')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/options/modals/index.ts
+++ b/src/components/options/modals/index.ts
@@ -1,2 +1,3 @@
 export * from './NewPresetModal';
 export * from './ScheduleModal';
+export * from './PasswordModal';

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -1,0 +1,54 @@
+/**
+ * Password utility functions using Web Crypto API
+ * Used for password protection on unblock operations
+ */
+
+/**
+ * Hash a password using SHA-256
+ * @param password - Plain text password to hash
+ * @returns Promise<string> - Hex-encoded hash
+ */
+export async function hashPassword(password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  return hashHex;
+}
+
+/**
+ * Verify a password against a stored hash
+ * @param password - Plain text password to verify
+ * @param storedHash - Previously stored hash to compare against
+ * @returns Promise<boolean> - True if password matches
+ */
+export async function verifyPassword(
+  password: string,
+  storedHash: string
+): Promise<boolean> {
+  const inputHash = await hashPassword(password);
+  return inputHash === storedHash;
+}
+
+/**
+ * Validate password strength
+ * @param password - Password to validate
+ * @returns Object with isValid and optional error message
+ */
+export function validatePasswordStrength(password: string): {
+  isValid: boolean;
+  errorKey: string | null;
+} {
+  // Minimum length requirement
+  if (password.length < 4) {
+    return { isValid: false, errorKey: 'passwordTooShort' };
+  }
+
+  // Maximum length to prevent abuse
+  if (password.length > 100) {
+    return { isValid: false, errorKey: 'passwordTooLong' };
+  }
+
+  return { isValid: true, errorKey: null };
+}

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -37,7 +37,8 @@ import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
 import type {
   AppSettings,
   VisionSettings,
-  YouTubeSettings
+  YouTubeSettings,
+  PasswordSettings
 } from '~/types/storage';
 import {
   DEFAULT_SETTINGS,
@@ -94,6 +95,14 @@ function OptionsApp() {
   const handleYouTubeChange = async (youtube: YouTubeSettings) => {
     if (!settings) return;
     const updated = { ...settings, youtube };
+    await storage.set('settings', updated);
+    setSettings(updated);
+  };
+
+  // Password settings handler
+  const handlePasswordUpdate = async (password: PasswordSettings) => {
+    if (!settings) return;
+    const updated = { ...settings, password };
     await storage.set('settings', updated);
     setSettings(updated);
   };
@@ -254,6 +263,7 @@ function OptionsApp() {
         {/* Help Tab */}
         {activeTab === TABS.HELP && (
           <HelpTab
+            settings={settings}
             onSettingsChange={async () => {
               // Reload settings and vision after import
               const [newSettings, newVision] = await Promise.all([
@@ -264,6 +274,7 @@ function OptionsApp() {
               if (newVision) setVision(newVision);
               await analytics.reloadAnalyticsData();
             }}
+            onPasswordUpdate={handlePasswordUpdate}
           />
         )}
       </main>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,12 +2,13 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { sendToBackground } from '@plasmohq/messaging';
 import { useStorage } from '@plasmohq/storage/hook';
-import { Ban, Shield, TrendingUp, Clock } from 'lucide-react';
+import { Ban, Shield, TrendingUp, Clock, Lock, Eye, EyeOff, X } from 'lucide-react';
 
 import { GoalCard, Header, QuickBlockButton, TimeLimitBadge } from '~/components/features';
 import { useBackgroundStats, usePremiumStatus } from '~/hooks';
 import { extractDomain } from '~/lib/domain';
 import { getMessage, setCurrentLanguage } from '~/lib/i18n';
+import { verifyPassword } from '~/lib/password';
 import { storage } from '~/lib/storage';
 import type {
   AppSettings,
@@ -46,6 +47,13 @@ function PopupApp() {
     limitType: 'daily' | 'hourly' | null;
     limitSeconds: number | null;
   } | null>(null);
+
+  // Password modal state for pause toggle
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
+  const [passwordInput, setPasswordInput] = useState('');
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
 
   // Sync language setting with i18n module
   useEffect(() => {
@@ -105,15 +113,70 @@ function PopupApp() {
     });
   }, []);
 
-  const handlePausedChange = useCallback(async (paused: boolean) => {
-    try {
-      await sendToBackground({
-        name: 'toggle-pause',
-        body: { paused }
-      });
-    } catch {
-      // Silently handle error
+  const isPasswordProtected =
+    settings?.password?.enabled && settings?.password?.passwordHash;
+
+  const handlePausedChange = useCallback(
+    async (paused: boolean) => {
+      // Only require password when pausing (disabling blocking)
+      if (paused && isPasswordProtected) {
+        setShowPasswordModal(true);
+        setPasswordInput('');
+        setPasswordError(null);
+        setShowPassword(false);
+        return;
+      }
+
+      try {
+        await sendToBackground({
+          name: 'toggle-pause',
+          body: { paused }
+        });
+      } catch {
+        // Silently handle error
+      }
+    },
+    [isPasswordProtected]
+  );
+
+  const handlePasswordSubmit = useCallback(async () => {
+    if (!passwordInput || !settings?.password?.passwordHash) {
+      setPasswordError(getMessage('passwordRequired'));
+      return;
     }
+
+    setIsVerifying(true);
+    setPasswordError(null);
+
+    try {
+      const isValid = await verifyPassword(
+        passwordInput,
+        settings.password.passwordHash
+      );
+
+      if (isValid) {
+        setShowPasswordModal(false);
+        setPasswordInput('');
+        // Now actually toggle pause
+        await sendToBackground({
+          name: 'toggle-pause',
+          body: { paused: true }
+        });
+      } else {
+        setPasswordError(getMessage('passwordIncorrect'));
+      }
+    } catch {
+      setPasswordError(getMessage('passwordVerificationFailed'));
+    } finally {
+      setIsVerifying(false);
+    }
+  }, [passwordInput, settings?.password?.passwordHash]);
+
+  const handlePasswordModalClose = useCallback(() => {
+    setShowPasswordModal(false);
+    setPasswordInput('');
+    setPasswordError(null);
+    setShowPassword(false);
   }, []);
 
   const handleLanguageChange = useCallback(
@@ -258,6 +321,88 @@ function PopupApp() {
           )}
         </div>
       </div>
+
+      {/* Password Modal for Pause */}
+      {showPasswordModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
+          <div
+            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={handlePasswordModalClose}
+          />
+          <div className="relative w-full mx-4 max-w-sm bg-white rounded-xl shadow-xl">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-800">
+                {getMessage('passwordRequired')}
+              </h2>
+              <button
+                onClick={handlePasswordModalClose}
+                className="p-1 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="p-4 space-y-4">
+              <div className="flex items-center gap-3 p-3 bg-amber-50 rounded-lg">
+                <Lock className="w-5 h-5 text-amber-600 flex-shrink-0" />
+                <p className="text-sm text-amber-800">
+                  {getMessage('passwordRequiredForPause')}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-gray-700">
+                  {getMessage('enterPassword')}
+                </label>
+                <div className="relative">
+                  <input
+                    type={showPassword ? 'text' : 'password'}
+                    value={passwordInput}
+                    onChange={(e) => setPasswordInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !isVerifying) {
+                        handlePasswordSubmit();
+                      }
+                    }}
+                    placeholder={getMessage('passwordPlaceholder')}
+                    className="w-full px-3 py-2 pr-10 text-gray-800 placeholder-gray-400 bg-white border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    autoFocus
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-4 h-4" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+                {passwordError && (
+                  <p className="text-sm text-red-600">{passwordError}</p>
+                )}
+              </div>
+
+              <div className="flex gap-3">
+                <button
+                  onClick={handlePasswordModalClose}
+                  className="flex-1 px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+                >
+                  {getMessage('cancel')}
+                </button>
+                <button
+                  onClick={handlePasswordSubmit}
+                  disabled={isVerifying || !passwordInput}
+                  className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-lg hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {isVerifying ? getMessage('verifying') : getMessage('confirm')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -146,6 +146,12 @@ export interface YouTubeSettings {
   hideHomeFeed: boolean; // Hide home feed (show only search)
 }
 
+// Password protection settings for unblock operations
+export interface PasswordSettings {
+  enabled: boolean; // Whether password protection is enabled
+  passwordHash: string | null; // SHA-256 hash of the password (null if not set)
+}
+
 export interface AppSettings {
   blockList: BlockItem[];
   schedules: Schedule[];
@@ -153,6 +159,7 @@ export interface AppSettings {
   language: SupportedLanguage | null; // null = use browser language
   notifications: NotificationSettings; // Notification preferences
   youtube: YouTubeSettings; // YouTube in-app blocking settings
+  password: PasswordSettings; // Password protection for unblock operations
 }
 
 // Analytics data
@@ -206,6 +213,12 @@ export const DEFAULT_YOUTUBE_SETTINGS: YouTubeSettings = {
   hideHomeFeed: false
 };
 
+// Default password settings
+export const DEFAULT_PASSWORD_SETTINGS: PasswordSettings = {
+  enabled: false,
+  passwordHash: null
+};
+
 // Default values
 export const DEFAULT_SETTINGS: AppSettings = {
   blockList: [],
@@ -213,7 +226,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   paused: false,
   language: null, // Use browser language by default
   notifications: DEFAULT_NOTIFICATION_SETTINGS,
-  youtube: DEFAULT_YOUTUBE_SETTINGS
+  youtube: DEFAULT_YOUTUBE_SETTINGS,
+  password: DEFAULT_PASSWORD_SETTINGS
 };
 
 export const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {


### PR DESCRIPTION
## Summary
- ブロック解除時にパスワード入力を必須にする機能を追加
- パートナーや家族がいるユーザー向けに、自分だけでは解除できないようにする機能
- 設定画面でパスワードの設定/変更/解除が可能

## Changes
- `src/types/storage.ts`: PasswordSettings型をAppSettingsに追加
- `src/lib/password.ts`: Web Crypto APIを使用したパスワードハッシュ化ユーティリティ
- `src/components/options/PasswordSettingsSection.tsx`: パスワード設定UI
- `src/components/options/modals/PasswordModal.tsx`: パスワード確認モーダル
- `src/components/options/BlocklistTab.tsx`: サイト削除・無効化時のパスワード確認
- `src/popup.tsx`: 一時停止トグルのパスワード確認
- `assets/_locales/*/messages.json`: 日英対応メッセージ追加

## Test plan
- [ ] ヘルプタブでパスワードを設定できること
- [ ] パスワード設定後、ブロックリストからサイトを削除時にパスワードが要求されること
- [ ] パスワード設定後、サイトの無効化時にパスワードが要求されること
- [ ] パスワード設定後、ポップアップの一時停止時にパスワードが要求されること
- [ ] 正しいパスワードを入力すると操作が実行されること
- [ ] 間違ったパスワードを入力するとエラーが表示されること
- [ ] パスワードの変更・解除ができること

Closes #12

:robot: Generated with [Claude Code](https://claude.com/claude-code)
