### PR TITLE
feat: 分析データのXシェア・画像ダウンロード機能

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1602,5 +1602,25 @@
   "youtubePreviewTitle": {
     "message": "What gets hidden",
     "description": "Preview section title"
+  },
+  "shareToX": {
+    "message": "Share to X",
+    "description": "Share to X button"
+  },
+  "downloadImage": {
+    "message": "Download Image",
+    "description": "Download image button"
+  },
+  "shareSuccess": {
+    "message": "Image copied to clipboard! Paste it in the X post.",
+    "description": "Share success message"
+  },
+  "shareError": {
+    "message": "Failed to copy image. Please try again.",
+    "description": "Share error message"
+  },
+  "topBlockedSite": {
+    "message": "Most Blocked",
+    "description": "Top blocked site label"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1602,5 +1602,25 @@
   "youtubePreviewTitle": {
     "message": "非表示になる要素",
     "description": "プレビューセクションタイトル"
+  },
+  "shareToX": {
+    "message": "Xでシェア",
+    "description": "Xでシェアボタン"
+  },
+  "downloadImage": {
+    "message": "画像をダウンロード",
+    "description": "画像ダウンロードボタン"
+  },
+  "shareSuccess": {
+    "message": "画像をクリップボードにコピーしました！Xの投稿画面に貼り付けてください。",
+    "description": "シェア成功メッセージ"
+  },
+  "shareError": {
+    "message": "画像のコピーに失敗しました。もう一度お試しください。",
+    "description": "シェアエラーメッセージ"
+  },
+  "topBlockedSite": {
+    "message": "最もブロック",
+    "description": "最もブロックしたサイトラベル"
   }
 }

--- a/src/components/options/AnalyticsTab.tsx
+++ b/src/components/options/AnalyticsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import {
   AlertTriangle,
   Clock,
@@ -10,7 +10,9 @@ import {
   Plus,
   Shield,
   Download,
-  ChevronDown
+  ChevronDown,
+  Share2,
+  Image
 } from 'lucide-react';
 
 import { Card, Button, Modal, Input } from '~/components/ui';
@@ -23,6 +25,13 @@ import {
   exportDailyStats,
   exportUnblockedSites
 } from '~/lib/export';
+import {
+  shareToX,
+  generateShareText,
+  captureElementAsCanvas,
+  copyImageToClipboard,
+  downloadImage
+} from '~/lib/share';
 import type {
   UnblockHistory,
   AnalyticsData,
@@ -78,6 +87,11 @@ export function AnalyticsTab({
   const [newSiteDomain, setNewSiteDomain] = useState('');
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [showExportMenu, setShowExportMenu] = useState(false);
+  const [shareMessage, setShareMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
 
   const handleAddSite = () => {
     if (newSiteDomain.trim()) {
@@ -162,6 +176,84 @@ export function AnalyticsTab({
       exportUnblockedSites(unblockHistory);
     }
     setShowExportMenu(false);
+  };
+
+  // Calculate total stats for sharing
+  const totalBlockCount = useMemo(() => {
+    return Object.values(analyticsData.siteBlockCounts || {}).reduce(
+      (sum, site) => sum + site.count,
+      0
+    );
+  }, [analyticsData.siteBlockCounts]);
+
+  const totalWasteTime = useMemo(() => {
+    return Object.values(analyticsData.dailyStats || {}).reduce(
+      (sum, stat) => sum + stat.wasteTime,
+      0
+    );
+  }, [analyticsData.dailyStats]);
+
+  const totalInvestTime = useMemo(() => {
+    return Object.values(analyticsData.dailyStats || {}).reduce(
+      (sum, stat) => sum + stat.investTime,
+      0
+    );
+  }, [analyticsData.dailyStats]);
+
+  const handleShareToX = async () => {
+    if (!chartRef.current) return;
+
+    try {
+      // Capture the chart as canvas
+      const canvas = await captureElementAsCanvas(chartRef.current);
+      if (!canvas) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      // Copy to clipboard
+      const success = await copyImageToClipboard(canvas);
+      if (!success) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      // Generate share text
+      const text = generateShareText({
+        totalBlockCount,
+        totalWasteTime,
+        totalInvestTime,
+        topBlockedSite: topBlockedSites[0]?.domain
+      });
+
+      // Show success message
+      setShareMessage({ type: 'success', text: getMessage('shareSuccess') });
+
+      // Open X intent
+      shareToX(text);
+
+      // Clear message after a delay
+      setTimeout(() => setShareMessage(null), 5000);
+    } catch {
+      setShareMessage({ type: 'error', text: getMessage('shareError') });
+    }
+  };
+
+  const handleDownloadImage = async () => {
+    if (!chartRef.current) return;
+
+    try {
+      const canvas = await captureElementAsCanvas(chartRef.current);
+      if (!canvas) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      const filename = `visionfocus-analytics-${new Date().toISOString().split('T')[0]}.png`;
+      downloadImage(canvas, filename);
+    } catch {
+      setShareMessage({ type: 'error', text: getMessage('shareError') });
+    }
   };
 
   return (
@@ -487,20 +579,56 @@ export function AnalyticsTab({
             <h3 className="text-lg font-semibold text-gray-900">
               {getMessage('usageChart')}
             </h3>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => setShowResetModal(true)}
-              className="flex items-center gap-1.5 text-gray-500 hover:text-red-500"
-            >
-              <Trash2 className="w-4 h-4" />
-              {getMessage('reset')}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleShareToX}
+                className="flex items-center gap-1.5"
+                title={getMessage('shareToX')}
+              >
+                <Share2 className="w-4 h-4" />
+                {getMessage('shareToX')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleDownloadImage}
+                className="flex items-center gap-1.5"
+                title={getMessage('downloadImage')}
+              >
+                <Image className="w-4 h-4" />
+                {getMessage('downloadImage')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowResetModal(true)}
+                className="flex items-center gap-1.5 text-gray-500 hover:text-red-500"
+              >
+                <Trash2 className="w-4 h-4" />
+                {getMessage('reset')}
+              </Button>
+            </div>
           </div>
-          <AnalyticsChart
-            analytics={analyticsData}
-            unblockHistory={unblockHistory}
-          />
+          {/* Share message */}
+          {shareMessage && (
+            <div
+              className={`mb-4 p-3 rounded-lg text-sm ${
+                shareMessage.type === 'success'
+                  ? 'bg-green-50 text-green-700'
+                  : 'bg-red-50 text-red-700'
+              }`}
+            >
+              {shareMessage.text}
+            </div>
+          )}
+          <div ref={chartRef}>
+            <AnalyticsChart
+              analytics={analyticsData}
+              unblockHistory={unblockHistory}
+            />
+          </div>
         </Card>
       )}
 

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,0 +1,111 @@
+// Share utilities for X (Twitter) sharing
+
+import { formatTime } from './time';
+
+/**
+ * Generate share text for analytics data
+ */
+export function generateShareText(data: {
+  totalBlockCount: number;
+  totalWasteTime: number;
+  totalInvestTime: number;
+  topBlockedSite?: string;
+}): string {
+  const { totalBlockCount, totalWasteTime, totalInvestTime, topBlockedSite } =
+    data;
+
+  const lines: string[] = [];
+
+  // Header
+  lines.push('📊 VisionFocus Report');
+  lines.push('');
+
+  // Stats
+  if (totalBlockCount > 0) {
+    lines.push(`🚫 Blocked: ${totalBlockCount} times`);
+  }
+
+  if (totalInvestTime > 0) {
+    lines.push(`🎯 Invest Time: ${formatTime(totalInvestTime)}`);
+  }
+
+  if (totalWasteTime > 0) {
+    lines.push(`⏰ Waste Time: ${formatTime(totalWasteTime)}`);
+  }
+
+  if (topBlockedSite) {
+    lines.push(`🔒 Top Blocked: ${topBlockedSite}`);
+  }
+
+  lines.push('');
+  lines.push('#VisionFocus #productivity');
+
+  return lines.join('\n');
+}
+
+/**
+ * Open X (Twitter) intent with pre-filled text
+ */
+export function shareToX(text: string): void {
+  const encodedText = encodeURIComponent(text);
+  const url = `https://twitter.com/intent/tweet?text=${encodedText}`;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+/**
+ * Copy image to clipboard from canvas element
+ */
+export async function copyImageToClipboard(
+  canvas: HTMLCanvasElement
+): Promise<boolean> {
+  try {
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob((b) => resolve(b), 'image/png')
+    );
+
+    if (!blob) {
+      return false;
+    }
+
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Download image from canvas element
+ */
+export function downloadImage(
+  canvas: HTMLCanvasElement,
+  filename: string
+): void {
+  const link = document.createElement('a');
+  link.download = filename;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}
+
+/**
+ * Capture DOM element as canvas using html2canvas-like approach
+ * Note: This is a simplified version that creates a canvas from element data
+ */
+export async function captureElementAsCanvas(
+  element: HTMLElement
+): Promise<HTMLCanvasElement | null> {
+  try {
+    // Dynamically import html2canvas
+    const html2canvas = (await import('html2canvas')).default;
+    const canvas = await html2canvas(element, {
+      backgroundColor: '#ffffff',
+      scale: 2, // Higher resolution
+      logging: false,
+      useCORS: true
+    });
+    return canvas;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
分析タブにXシェア機能と画像ダウンロード機能を追加しました。

### 実装内容
- **シェアボタン**: 画像をクリップボードにコピー → X投稿画面を開く（Web Intent方式）
- **画像DLボタン**: 表示中のグラフを画像としてダウンロード
- **Free/Premium両方で利用可能**（既存の分析機能の出し分けに準拠）

### 技術詳細
- `src/lib/share.ts`: シェア用ユーティリティ関数
- `html2canvas`でDOM要素をキャプチャ
- `navigator.clipboard.write`で画像をクリップボードにコピー
- Web Intentで事前入力済みのX投稿画面を開く

## 関連Issue
Closes #47

## Test plan
- [ ] 分析タブで「Xでシェア」ボタンをクリック
- [ ] 画像がクリップボードにコピーされることを確認
- [ ] X投稿画面が開き、テキストが入力済みであることを確認
- [ ] 投稿画面で Ctrl+V（⌘+V）で画像が貼り付けられることを確認
- [ ] 「画像をダウンロード」ボタンでPNG画像がダウンロードされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)