### PR TITLE
feat: 週次・月次レポート機能を追加（Premium専用）

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -631,6 +631,22 @@
     "message": "Top Invest Sites",
     "description": "Top invest sites heading"
   },
+  "dailyBreakdown": {
+    "message": "Daily Breakdown",
+    "description": "Daily breakdown chart title"
+  },
+  "weeklyBreakdown": {
+    "message": "Weekly Breakdown",
+    "description": "Weekly breakdown chart title"
+  },
+  "reportsSection": {
+    "message": "Reports",
+    "description": "Reports section title"
+  },
+  "reportsPremiumDescription": {
+    "message": "View detailed weekly and monthly reports to track your productivity trends",
+    "description": "Reports premium feature description"
+  },
   "close": {
     "message": "Close",
     "description": "Close button"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -631,6 +631,22 @@
     "message": "投資サイトトップ",
     "description": "投資サイトトップ見出し"
   },
+  "dailyBreakdown": {
+    "message": "日別内訳",
+    "description": "日別内訳チャートタイトル"
+  },
+  "weeklyBreakdown": {
+    "message": "週別内訳",
+    "description": "週別内訳チャートタイトル"
+  },
+  "reportsSection": {
+    "message": "レポート",
+    "description": "レポートセクションタイトル"
+  },
+  "reportsPremiumDescription": {
+    "message": "週次・月次レポートで生産性の推移を確認",
+    "description": "レポートプレミアム機能の説明"
+  },
   "close": {
     "message": "閉じる",
     "description": "閉じるボタン"

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -1,0 +1,367 @@
+import React from 'react';
+import {
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Shield,
+  Clock,
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  BarChart3
+} from 'lucide-react';
+
+import { Card, Button } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import { formatTime } from '~/lib/time';
+import { formatWeekRange, formatMonth } from '~/lib/report';
+import type { WeeklyReport, MonthlyReport } from '~/types/report';
+
+interface WeeklyReportCardProps {
+  report: WeeklyReport | null;
+  onPrevious: () => void;
+  onNext: () => void;
+  canGoNext: boolean;
+}
+
+interface MonthlyReportCardProps {
+  report: MonthlyReport | null;
+  onPrevious: () => void;
+  onNext: () => void;
+  canGoNext: boolean;
+}
+
+// Trend icon component
+function TrendIcon({
+  trend
+}: {
+  trend: 'improving' | 'declining' | 'stable';
+}) {
+  if (trend === 'improving') {
+    return (
+      <div className="flex items-center gap-1 text-green-600">
+        <TrendingUp className="w-4 h-4" />
+        <span className="text-sm font-medium">{getMessage('improving')}</span>
+      </div>
+    );
+  }
+  if (trend === 'declining') {
+    return (
+      <div className="flex items-center gap-1 text-red-600">
+        <TrendingDown className="w-4 h-4" />
+        <span className="text-sm font-medium">{getMessage('declining')}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-1 text-gray-500">
+      <Minus className="w-4 h-4" />
+      <span className="text-sm font-medium">{getMessage('stable')}</span>
+    </div>
+  );
+}
+
+// Stats grid component
+function StatsGrid({
+  wasteTime,
+  investTime,
+  blockCount
+}: {
+  wasteTime: number;
+  investTime: number;
+  blockCount: number;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div className="text-center p-3 bg-red-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-red-600 mb-1">
+          <Clock className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-red-700">{formatTime(wasteTime)}</p>
+        <p className="text-xs text-red-600">{getMessage('wasteTime')}</p>
+      </div>
+      <div className="text-center p-3 bg-green-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-green-600 mb-1">
+          <Clock className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-green-700">
+          {formatTime(investTime)}
+        </p>
+        <p className="text-xs text-green-600">{getMessage('investTime')}</p>
+      </div>
+      <div className="text-center p-3 bg-blue-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-blue-600 mb-1">
+          <Shield className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-blue-700">{blockCount}</p>
+        <p className="text-xs text-blue-600">{getMessage('blockedCount')}</p>
+      </div>
+    </div>
+  );
+}
+
+// Top sites list component
+function TopSitesList({
+  sites,
+  type
+}: {
+  sites: { domain: string; time: number }[];
+  type: 'waste' | 'invest';
+}) {
+  if (sites.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 text-center py-2">
+        {getMessage('noData')}
+      </p>
+    );
+  }
+
+  const bgColor = type === 'waste' ? 'bg-red-50' : 'bg-green-50';
+  const textColor = type === 'waste' ? 'text-red-600' : 'text-green-600';
+
+  return (
+    <div className="space-y-2">
+      {sites.slice(0, 3).map((site, index) => (
+        <div
+          key={site.domain}
+          className={`flex items-center justify-between p-2 ${bgColor} rounded-lg`}
+        >
+          <div className="flex items-center gap-2">
+            <span className="w-5 h-5 flex items-center justify-center text-xs font-medium text-gray-500 bg-white rounded-full">
+              {index + 1}
+            </span>
+            <span className="text-sm font-medium text-gray-800 truncate max-w-[120px]">
+              {site.domain}
+            </span>
+          </div>
+          <span className={`text-sm font-medium ${textColor}`}>
+            {formatTime(site.time)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Mini bar chart for daily/weekly breakdown
+function MiniBarChart({
+  data,
+  type
+}: {
+  data: { wasteTime: number; investTime: number }[];
+  type: 'daily' | 'weekly';
+}) {
+  const maxValue = Math.max(
+    ...data.map((d) => Math.max(d.wasteTime, d.investTime)),
+    1
+  );
+
+  const dayLabels = ['日', '月', '火', '水', '木', '金', '土'];
+
+  return (
+    <div className="flex items-end justify-between gap-1 h-20">
+      {data.map((item, index) => {
+        const wasteHeight = (item.wasteTime / maxValue) * 100;
+        const investHeight = (item.investTime / maxValue) * 100;
+
+        return (
+          <div key={index} className="flex flex-col items-center flex-1">
+            <div className="flex gap-0.5 items-end h-16 w-full justify-center">
+              <div
+                className="w-2 bg-red-400 rounded-t"
+                style={{ height: `${Math.max(wasteHeight, 2)}%` }}
+                title={`${getMessage('waste')}: ${formatTime(item.wasteTime)}`}
+              />
+              <div
+                className="w-2 bg-green-400 rounded-t"
+                style={{ height: `${Math.max(investHeight, 2)}%` }}
+                title={`${getMessage('invest')}: ${formatTime(item.investTime)}`}
+              />
+            </div>
+            <span className="text-[10px] text-gray-500 mt-1">
+              {type === 'daily' ? dayLabels[index] : `W${index + 1}`}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Empty state component
+function EmptyReport({ message }: { message: string }) {
+  return (
+    <div className="text-center py-8">
+      <BarChart3 className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+      <p className="text-sm text-gray-500">{message}</p>
+    </div>
+  );
+}
+
+// Weekly Report Card
+export function WeeklyReportCard({
+  report,
+  onPrevious,
+  onNext,
+  canGoNext
+}: WeeklyReportCardProps) {
+  return (
+    <Card>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Calendar className="w-5 h-5 text-primary-500" />
+          <h3 className="text-lg font-semibold text-gray-900">
+            {getMessage('weeklyReport')}
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={onPrevious}>
+            <ChevronLeft className="w-4 h-4" />
+          </Button>
+          <span className="text-sm text-gray-600 min-w-[120px] text-center">
+            {report
+              ? formatWeekRange(report.weekStart, report.weekEnd)
+              : '---'}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onNext}
+            disabled={!canGoNext}
+          >
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+
+      {!report ? (
+        <EmptyReport message={getMessage('noReportData')} />
+      ) : (
+        <div className="space-y-4">
+          {/* Trend */}
+          <div className="flex justify-end">
+            <TrendIcon trend={report.trend} />
+          </div>
+
+          {/* Stats */}
+          <StatsGrid
+            wasteTime={report.totalWasteTime}
+            investTime={report.totalInvestTime}
+            blockCount={report.totalBlockCount}
+          />
+
+          {/* Daily Breakdown Chart */}
+          <div className="pt-4 border-t border-gray-100">
+            <h4 className="text-sm font-medium text-gray-700 mb-3">
+              {getMessage('dailyBreakdown')}
+            </h4>
+            <MiniBarChart
+              data={report.dailyBreakdown.map((d) => ({
+                wasteTime: d.wasteTime,
+                investTime: d.investTime
+              }))}
+              type="daily"
+            />
+          </div>
+
+          {/* Top Sites */}
+          <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-100">
+            <div>
+              <h4 className="text-sm font-medium text-red-700 mb-2">
+                {getMessage('topWasteSites')}
+              </h4>
+              <TopSitesList sites={report.topWasteSites} type="waste" />
+            </div>
+            <div>
+              <h4 className="text-sm font-medium text-green-700 mb-2">
+                {getMessage('topInvestSites')}
+              </h4>
+              <TopSitesList sites={report.topInvestSites} type="invest" />
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+// Monthly Report Card
+export function MonthlyReportCard({
+  report,
+  onPrevious,
+  onNext,
+  canGoNext
+}: MonthlyReportCardProps) {
+  return (
+    <Card>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Calendar className="w-5 h-5 text-primary-500" />
+          <h3 className="text-lg font-semibold text-gray-900">
+            {getMessage('monthlyReport')}
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={onPrevious}>
+            <ChevronLeft className="w-4 h-4" />
+          </Button>
+          <span className="text-sm text-gray-600 min-w-[120px] text-center">
+            {report ? formatMonth(report.month) : '---'}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onNext}
+            disabled={!canGoNext}
+          >
+            <ChevronRight className="w-4 h-4" />
+          </Button>
+        </div>
+      </div>
+
+      {!report ? (
+        <EmptyReport message={getMessage('noReportData')} />
+      ) : (
+        <div className="space-y-4">
+          {/* Trend */}
+          <div className="flex justify-end">
+            <TrendIcon trend={report.trend} />
+          </div>
+
+          {/* Stats */}
+          <StatsGrid
+            wasteTime={report.totalWasteTime}
+            investTime={report.totalInvestTime}
+            blockCount={report.totalBlockCount}
+          />
+
+          {/* Weekly Breakdown Chart */}
+          <div className="pt-4 border-t border-gray-100">
+            <h4 className="text-sm font-medium text-gray-700 mb-3">
+              {getMessage('weeklyBreakdown')}
+            </h4>
+            <MiniBarChart data={report.weeklyBreakdown} type="weekly" />
+          </div>
+
+          {/* Top Sites */}
+          <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-100">
+            <div>
+              <h4 className="text-sm font-medium text-red-700 mb-2">
+                {getMessage('topWasteSites')}
+              </h4>
+              <TopSitesList sites={report.topWasteSites} type="waste" />
+            </div>
+            <div>
+              <h4 className="text-sm font-medium text-green-700 mb-2">
+                {getMessage('topInvestSites')}
+              </h4>
+              <TopSitesList sites={report.topInvestSites} type="invest" />
+            </div>
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/components/features/ReportCard/index.ts
+++ b/src/components/features/ReportCard/index.ts
@@ -1,0 +1,1 @@
+export { WeeklyReportCard, MonthlyReportCard } from './ReportCard';

--- a/src/components/features/index.ts
+++ b/src/components/features/index.ts
@@ -5,6 +5,7 @@ export * from './GoalCard';
 export * from './Header';
 export * from './ImageUploader';
 export * from './QuickBlockButton';
+export * from './ReportCard';
 export * from './StatsCard';
 export * from './TimeLimitBadge';
 export * from './UpgradePrompt';

--- a/src/components/options/AnalyticsTab.tsx
+++ b/src/components/options/AnalyticsTab.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useState, useRef } from 'react';
+import React, { useMemo, useState, useRef, useCallback } from 'react';
 import {
   AlertTriangle,
+  BarChart3,
   Clock,
   Lock,
   RefreshCw,
@@ -16,7 +17,16 @@ import {
 } from 'lucide-react';
 
 import { Card, Button, Modal, Input } from '~/components/ui';
-import { UpgradePrompt, AnalyticsChart } from '~/components/features';
+import {
+  UpgradePrompt,
+  AnalyticsChart,
+  WeeklyReportCard,
+  MonthlyReportCard
+} from '~/components/features';
+import {
+  generateWeeklyReport,
+  generateMonthlyReport
+} from '~/lib/report';
 import { formatTime } from '~/lib/time';
 import { getMessage } from '~/lib/i18n';
 import {
@@ -92,6 +102,8 @@ export function AnalyticsTab({
     text: string;
   } | null>(null);
   const chartRef = useRef<HTMLDivElement>(null);
+  const [weeklyOffset, setWeeklyOffset] = useState(0);
+  const [monthlyOffset, setMonthlyOffset] = useState(0);
 
   const handleAddSite = () => {
     if (newSiteDomain.trim()) {
@@ -134,6 +146,32 @@ export function AnalyticsTab({
     const counts = Object.values(analyticsData.siteBlockCounts || {});
     return counts.sort((a, b) => b.count - a.count).slice(0, 10);
   }, [analyticsData.siteBlockCounts]);
+
+  // Generate reports
+  const weeklyReport = useMemo(() => {
+    return generateWeeklyReport(analyticsData, weeklyOffset);
+  }, [analyticsData, weeklyOffset]);
+
+  const monthlyReport = useMemo(() => {
+    return generateMonthlyReport(analyticsData, monthlyOffset);
+  }, [analyticsData, monthlyOffset]);
+
+  // Report navigation handlers
+  const handlePreviousWeek = useCallback(() => {
+    setWeeklyOffset((prev) => prev - 1);
+  }, []);
+
+  const handleNextWeek = useCallback(() => {
+    setWeeklyOffset((prev) => Math.min(prev + 1, 0));
+  }, []);
+
+  const handlePreviousMonth = useCallback(() => {
+    setMonthlyOffset((prev) => prev - 1);
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setMonthlyOffset((prev) => Math.min(prev + 1, 0));
+  }, []);
 
   const handleReset = () => {
     onReset();
@@ -628,6 +666,58 @@ export function AnalyticsTab({
               analytics={analyticsData}
               unblockHistory={unblockHistory}
             />
+          </div>
+        </Card>
+      )}
+
+      {/* Reports Section (Premium only) */}
+      {isPremium && (
+        <Card>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            {getMessage('reportsSection')}
+          </h3>
+          <div className="grid md:grid-cols-2 gap-6">
+            <WeeklyReportCard
+              report={weeklyReport}
+              onPrevious={handlePreviousWeek}
+              onNext={handleNextWeek}
+              canGoNext={weeklyOffset < 0}
+            />
+            <MonthlyReportCard
+              report={monthlyReport}
+              onPrevious={handlePreviousMonth}
+              onNext={handleNextMonth}
+              canGoNext={monthlyOffset < 0}
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Reports Upgrade Prompt for Free Users */}
+      {!isPremium && (
+        <Card>
+          <div className="flex items-start gap-3">
+            <div className="p-2 bg-purple-100 rounded-lg">
+              <BarChart3 className="w-5 h-5 text-purple-600" />
+            </div>
+            <div className="flex-1">
+              <h3 className="text-lg font-semibold text-gray-900">
+                {getMessage('reportsSection')}
+              </h3>
+              <p className="text-sm text-gray-600 mt-1">
+                {getMessage('reportsPremiumDescription')}
+              </p>
+              <div className="mt-4">
+                <UpgradePrompt
+                  variant="inline"
+                  features={[
+                    getMessage('weeklyReport'),
+                    getMessage('monthlyReport'),
+                    getMessage('productivityImproving').replace('!', '')
+                  ]}
+                />
+              </div>
+            </div>
           </div>
         </Card>
       )}

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -1,0 +1,276 @@
+// Report generation logic for weekly and monthly reports
+
+import type { AnalyticsData, DailyStat, SiteTime } from '~/types/storage';
+import type { WeeklyReport, MonthlyReport } from '~/types/report';
+
+// Get the start of the week (Monday) for a given date
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1); // Adjust for Sunday
+  d.setDate(diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+// Get the end of the week (Sunday) for a given date
+function getWeekEnd(date: Date): Date {
+  const start = getWeekStart(date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+// Format date to YYYY-MM-DD
+function formatDateKey(date: Date): string {
+  return date.toISOString().split('T')[0];
+}
+
+// Format date to YYYY-MM
+function formatMonthKey(date: Date): string {
+  return date.toISOString().slice(0, 7);
+}
+
+// Get all dates in a range
+function getDatesInRange(start: Date, end: Date): string[] {
+  const dates: string[] = [];
+  const current = new Date(start);
+  while (current <= end) {
+    dates.push(formatDateKey(current));
+    current.setDate(current.getDate() + 1);
+  }
+  return dates;
+}
+
+// Get top sites by time from SiteTime data
+function getTopSites(
+  siteTime: Record<string, SiteTime>,
+  category: 'waste' | 'invest',
+  limit: number = 5
+): { domain: string; time: number }[] {
+  return Object.values(siteTime)
+    .filter((site) => site.category === category)
+    .sort((a, b) => b.time - a.time)
+    .slice(0, limit)
+    .map((site) => ({ domain: site.domain, time: site.time }));
+}
+
+// Calculate trend based on comparing first half vs second half of data
+function calculateTrend(
+  data: { wasteTime: number; investTime: number }[]
+): 'improving' | 'declining' | 'stable' {
+  if (data.length < 2) {
+    return 'stable';
+  }
+
+  const midpoint = Math.floor(data.length / 2);
+  const firstHalf = data.slice(0, midpoint);
+  const secondHalf = data.slice(midpoint);
+
+  // Calculate productivity ratio (invest / (waste + invest))
+  const calcRatio = (items: { wasteTime: number; investTime: number }[]) => {
+    const totalWaste = items.reduce((sum, item) => sum + item.wasteTime, 0);
+    const totalInvest = items.reduce((sum, item) => sum + item.investTime, 0);
+    const total = totalWaste + totalInvest;
+    return total > 0 ? totalInvest / total : 0;
+  };
+
+  const firstRatio = calcRatio(firstHalf);
+  const secondRatio = calcRatio(secondHalf);
+  const change = secondRatio - firstRatio;
+
+  // Threshold for determining trend (5% change)
+  const threshold = 0.05;
+
+  if (change > threshold) {
+    return 'improving';
+  } else if (change < -threshold) {
+    return 'declining';
+  }
+  return 'stable';
+}
+
+// Generate weekly report
+export function generateWeeklyReport(
+  analytics: AnalyticsData,
+  weekOffset: number = 0 // 0 = current week, -1 = last week, etc.
+): WeeklyReport | null {
+  const today = new Date();
+  const targetDate = new Date(today);
+  targetDate.setDate(today.getDate() + weekOffset * 7);
+
+  const weekStart = getWeekStart(targetDate);
+  const weekEnd = getWeekEnd(targetDate);
+  const dates = getDatesInRange(weekStart, weekEnd);
+
+  // Collect daily stats for this week
+  const dailyBreakdown: DailyStat[] = dates.map((date) => {
+    const stat = analytics.dailyStats[date];
+    return (
+      stat || {
+        date,
+        wasteTime: 0,
+        investTime: 0,
+        blockCount: 0
+      }
+    );
+  });
+
+  // Calculate totals
+  const totalWasteTime = dailyBreakdown.reduce(
+    (sum, day) => sum + day.wasteTime,
+    0
+  );
+  const totalInvestTime = dailyBreakdown.reduce(
+    (sum, day) => sum + day.investTime,
+    0
+  );
+  const totalBlockCount = dailyBreakdown.reduce(
+    (sum, day) => sum + day.blockCount,
+    0
+  );
+
+  // Only return null if there's absolutely no data
+  const hasData = totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
+  if (!hasData && weekOffset < 0) {
+    // For past weeks, return null if no data
+    return null;
+  }
+
+  // Get top sites
+  const topWasteSites = getTopSites(analytics.siteTime, 'waste');
+  const topInvestSites = getTopSites(analytics.siteTime, 'invest');
+
+  // Calculate trend
+  const trend = calculateTrend(
+    dailyBreakdown.map((d) => ({
+      wasteTime: d.wasteTime,
+      investTime: d.investTime
+    }))
+  );
+
+  return {
+    weekStart: formatDateKey(weekStart),
+    weekEnd: formatDateKey(weekEnd),
+    totalWasteTime,
+    totalInvestTime,
+    totalBlockCount,
+    dailyBreakdown,
+    topWasteSites,
+    topInvestSites,
+    trend
+  };
+}
+
+// Generate monthly report
+export function generateMonthlyReport(
+  analytics: AnalyticsData,
+  monthOffset: number = 0 // 0 = current month, -1 = last month, etc.
+): MonthlyReport | null {
+  const today = new Date();
+  const targetDate = new Date(today.getFullYear(), today.getMonth() + monthOffset, 1);
+
+  const monthStart = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
+  const monthEnd = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0);
+  const dates = getDatesInRange(monthStart, monthEnd);
+
+  // Calculate totals
+  let totalWasteTime = 0;
+  let totalInvestTime = 0;
+  let totalBlockCount = 0;
+
+  dates.forEach((date) => {
+    const stat = analytics.dailyStats[date];
+    if (stat) {
+      totalWasteTime += stat.wasteTime;
+      totalInvestTime += stat.investTime;
+      totalBlockCount += stat.blockCount;
+    }
+  });
+
+  // Only return null if there's absolutely no data
+  const hasData = totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
+  if (!hasData && monthOffset < 0) {
+    // For past months, return null if no data
+    return null;
+  }
+
+  // Generate weekly breakdown
+  const weeklyBreakdown: {
+    weekStart: string;
+    wasteTime: number;
+    investTime: number;
+  }[] = [];
+
+  const initialWeekStart = getWeekStart(monthStart);
+  for (
+    let weekStartMs = initialWeekStart.getTime();
+    weekStartMs <= monthEnd.getTime();
+    weekStartMs += 7 * 24 * 60 * 60 * 1000
+  ) {
+    const currentWeekStart = new Date(weekStartMs);
+    const weekEndDate = new Date(currentWeekStart);
+    weekEndDate.setDate(currentWeekStart.getDate() + 6);
+
+    const weekDates = getDatesInRange(
+      currentWeekStart < monthStart ? monthStart : currentWeekStart,
+      weekEndDate > monthEnd ? monthEnd : weekEndDate
+    );
+
+    let weekWaste = 0;
+    let weekInvest = 0;
+
+    weekDates.forEach((date) => {
+      const stat = analytics.dailyStats[date];
+      if (stat) {
+        weekWaste += stat.wasteTime;
+        weekInvest += stat.investTime;
+      }
+    });
+
+    weeklyBreakdown.push({
+      weekStart: formatDateKey(currentWeekStart),
+      wasteTime: weekWaste,
+      investTime: weekInvest
+    });
+  }
+
+  // Get top sites
+  const topWasteSites = getTopSites(analytics.siteTime, 'waste');
+  const topInvestSites = getTopSites(analytics.siteTime, 'invest');
+
+  // Calculate trend
+  const trend = calculateTrend(weeklyBreakdown);
+
+  return {
+    month: formatMonthKey(targetDate),
+    totalWasteTime,
+    totalInvestTime,
+    totalBlockCount,
+    weeklyBreakdown,
+    topWasteSites,
+    topInvestSites,
+    trend
+  };
+}
+
+// Get formatted week range string
+export function formatWeekRange(weekStart: string, weekEnd: string): string {
+  const start = new Date(weekStart);
+  const end = new Date(weekEnd);
+  const startMonth = start.toLocaleDateString(undefined, { month: 'short' });
+  const endMonth = end.toLocaleDateString(undefined, { month: 'short' });
+
+  if (startMonth === endMonth) {
+    return `${startMonth} ${start.getDate()} - ${end.getDate()}`;
+  }
+  return `${startMonth} ${start.getDate()} - ${endMonth} ${end.getDate()}`;
+}
+
+// Get formatted month string
+export function formatMonth(monthKey: string): string {
+  const [year, month] = monthKey.split('-');
+  const date = new Date(parseInt(year), parseInt(month) - 1);
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+}


### PR DESCRIPTION
## Summary
- 週次・月次レポート機能を Premium ユーザー向けに追加
- 分析タブにレポートセクションを統合し、過去のデータを週単位・月単位で確認可能

## Changes
- `src/lib/report.ts`: レポート生成ロジック
  - `generateWeeklyReport()`: 週次レポート（日別内訳、トップサイト、トレンド分析）
  - `generateMonthlyReport()`: 月次レポート（週別内訳、トップサイト、トレンド分析）
- `src/components/features/ReportCard/`: レポート表示コンポーネント
  - `WeeklyReportCard`: 週次レポートカード（ナビゲーション付き）
  - `MonthlyReportCard`: 月次レポートカード（ナビゲーション付き）
- `AnalyticsTab`: レポートセクション統合
  - Premium: 週次・月次レポートをグリッド表示
  - Free: アップグレードプロンプト表示
- i18n: 日英両方のメッセージファイルに新しいキーを追加

## Test Plan
- [ ] Premium ユーザーとして週次レポートが表示される
- [ ] Premium ユーザーとして月次レポートが表示される
- [ ] レポートのナビゲーション（前週/次週、前月/次月）が正常に動作する
- [ ] Free ユーザーにはアップグレードプロンプトが表示される
- [ ] 日本語/英語の切り替えで正しいメッセージが表示される

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)