### PR TITLE
fix: Toggleコンポーネントにlgサイズを追加

### DIFF
--- a/src/components/ui/Toggle/Toggle.tsx
+++ b/src/components/ui/Toggle/Toggle.tsx
@@ -5,7 +5,7 @@ export interface ToggleProps {
   onChange: (checked: boolean) => void;
   label?: string;
   disabled?: boolean;
-  size?: 'sm' | 'md';
+  size?: 'sm' | 'md' | 'lg';
 }
 
 const sizeClasses = {
@@ -18,6 +18,11 @@ const sizeClasses = {
     button: 'h-6 w-11',
     thumb: 'h-5 w-5',
     translate: 'translate-x-5'
+  },
+  lg: {
+    button: 'h-7 w-14',
+    thumb: 'h-6 w-6',
+    translate: 'translate-x-7'
   }
 };
 


### PR DESCRIPTION
## Summary
- YouTubeタブでToggleコンポーネントがエラーになる問題を修正
- Toggle コンポーネントに `lg` サイズを追加

## 原因
`YouTubeTab.tsx:157` で `size="lg"` を使用していたが、Toggle コンポーネントは `'sm' | 'md'` のみサポートしていた。`sizeClasses['lg']` が `undefined` となり、`undefined.button` でエラーが発生。

## 修正内容
- `Toggle.tsx`: `lg` サイズ（h-7 w-14）を追加
- TypeScript 型定義も `'sm' | 'md' | 'lg'` に更新

## Test Plan
- [ ] YouTubeタブが正常に表示される
- [ ] Toggle の lg サイズが正しく表示される

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)