### PR TITLE
refactor: AnalyticsTabを責務ごとにサブコンポーネントに分割

### DIFF
--- a/.claude/docs/SETUP_NEXTJS.md
+++ b/.claude/docs/SETUP_NEXTJS.md
@@ -58,13 +58,13 @@ npx storybook@latest init
 claude_desktop_config.json
 ```
 
-| 項目 | 用途 |
-| ---- | ---- |
+| 項目                          | 用途                                                    |
+| ----------------------------- | ------------------------------------------------------- |
 | `.claude/settings.local.json` | ローカル権限設定（チーム共有は `settings.json` を使用） |
-| `.claude/tmp/` | 一時ファイル（コミットメッセージ等） |
-| `.claude/logs/` | デバッグログ |
-| `.claude/mcp-cache/` | MCP サーバーキャッシュ |
-| `claude_desktop_config.json` | Claude Desktop 個人設定 |
+| `.claude/tmp/`                | 一時ファイル（コミットメッセージ等）                    |
+| `.claude/logs/`               | デバッグログ                                            |
+| `.claude/mcp-cache/`          | MCP サーバーキャッシュ                                  |
+| `claude_desktop_config.json`  | Claude Desktop 個人設定                                 |
 
 ### .prettierrc
 

--- a/docs/BLOCK_STATE_MACHINE.md
+++ b/docs/BLOCK_STATE_MACHINE.md
@@ -93,31 +93,33 @@ stateDiagram-v2
 
 ## ブロック理由（BlockReason）
 
-| 理由 | 説明 | 条件 |
-|------|------|------|
-| `always_blocked` | 常時ブロック | timeLimit が未設定 |
-| `time_limit_exceeded` | 時間制限超過 | 使用時間 >= 制限時間 |
-| `null` | ブロックされていない | 上記以外 |
+| 理由                  | 説明                 | 条件                 |
+| --------------------- | -------------------- | -------------------- |
+| `always_blocked`      | 常時ブロック         | timeLimit が未設定   |
+| `time_limit_exceeded` | 時間制限超過         | 使用時間 >= 制限時間 |
+| `null`                | ブロックされていない | 上記以外             |
 
 ## 状態を決定する要素
 
-| 要素 | 保存場所 | 型 | 説明 |
-|------|----------|-----|------|
-| グローバル一時停止 | `settings.paused` | `boolean` | 拡張機能全体の一時停止 |
-| ブロックリスト | `settings.blockList` | `BlockItem[]` | ブロック対象ドメインリスト |
-| サイト別有効/無効 | `blockItem.enabled` | `boolean` | 個別サイトのブロック ON/OFF |
-| サイト別時間制限 | `blockItem.timeLimit` | `TimeLimit \| null` | 「1日30分まで」などの設定 |
-| スケジュール | `settings.schedules` | `Schedule[]` | ブロック有効時間帯 |
-| 時間制限使用量 | `analytics.timeLimitUsage` | `Record<string, TimeLimitUsage>` | 実際の消費時間 |
+| 要素               | 保存場所                   | 型                               | 説明                        |
+| ------------------ | -------------------------- | -------------------------------- | --------------------------- |
+| グローバル一時停止 | `settings.paused`          | `boolean`                        | 拡張機能全体の一時停止      |
+| ブロックリスト     | `settings.blockList`       | `BlockItem[]`                    | ブロック対象ドメインリスト  |
+| サイト別有効/無効  | `blockItem.enabled`        | `boolean`                        | 個別サイトのブロック ON/OFF |
+| サイト別時間制限   | `blockItem.timeLimit`      | `TimeLimit \| null`              | 「1日30分まで」などの設定   |
+| スケジュール       | `settings.schedules`       | `Schedule[]`                     | ブロック有効時間帯          |
+| 時間制限使用量     | `analytics.timeLimitUsage` | `Record<string, TimeLimitUsage>` | 実際の消費時間              |
 
 ## リセットタイミング
 
 ### 日次リセット（Daily）
+
 - 条件: `lastDailyReset !== 今日の日付`
 - 処理: `dailyUsedSeconds = 0`, `lastDailyReset = 今日`
 - トリガー: `recordTimeLimitUsage()` または `resetExpiredUsage()`
 
 ### 時間リセット（Hourly）
+
 - 条件: `lastHourlyReset !== 現在の時間キー`
 - 処理: `hourlyUsedSeconds = 0`, `lastHourlyReset = 現在の時間キー`
 - トリガー: `recordTimeLimitUsage()` または `resetExpiredUsage()`
@@ -142,10 +144,10 @@ flowchart LR
 
 ## 関連ファイル
 
-| ファイル | 責務 |
-|---------|------|
-| `src/background/blocker.ts` | メインのブロック判定、ルール更新 |
-| `src/background/time-limit.ts` | 時間制限の判定と記録 |
-| `src/background/notifications.ts` | 通知判定と送信 |
-| `src/background/index.ts` | アラームによるリセット処理 |
-| `src/lib/blockService.ts` | ブロック状態の一元管理（新規） |
+| ファイル                          | 責務                             |
+| --------------------------------- | -------------------------------- |
+| `src/background/blocker.ts`       | メインのブロック判定、ルール更新 |
+| `src/background/time-limit.ts`    | 時間制限の判定と記録             |
+| `src/background/notifications.ts` | 通知判定と送信                   |
+| `src/background/index.ts`         | アラームによるリセット処理       |
+| `src/lib/blockService.ts`         | ブロック状態の一元管理（新規）   |

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -1,5 +1,9 @@
 import { getSettings } from '~/lib/storage';
-import { findEnabledBlockItemForDomain, getRemainingTime, getYouTubeRemainingTime } from '~/lib/blockService';
+import {
+  findEnabledBlockItemForDomain,
+  getRemainingTime,
+  getYouTubeRemainingTime
+} from '~/lib/blockService';
 import { getMessage } from '~/lib/i18n';
 
 // In-memory state to track which domains have been notified
@@ -110,7 +114,12 @@ export async function checkTimeLimitNotification(
   // Check if we should notify
   if (remainingMinutes <= notifyAtMinutes) {
     const totalMinutes = Math.round(limitSeconds / 60);
-    await showTimeLimitNotification(domain, remainingMinutes, totalMinutes, type);
+    await showTimeLimitNotification(
+      domain,
+      remainingMinutes,
+      totalMinutes,
+      type
+    );
     markAsNotified(domain, type);
   }
 }
@@ -145,7 +154,12 @@ export async function checkYouTubeTimeLimitNotification(): Promise<void> {
 
   if (remainingMinutes <= notifyAtMinutes) {
     const totalMinutes = Math.round(limitSeconds / 60);
-    await showTimeLimitNotification('youtube.com', remainingMinutes, totalMinutes, type);
+    await showTimeLimitNotification(
+      'youtube.com',
+      remainingMinutes,
+      totalMinutes,
+      type
+    );
     markAsNotified('youtube.com', type);
   }
 }

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -32,11 +32,7 @@ interface MonthlyReportCardProps {
 }
 
 // Trend icon component
-function TrendIcon({
-  trend
-}: {
-  trend: 'improving' | 'declining' | 'stable';
-}) {
+function TrendIcon({ trend }: { trend: 'improving' | 'declining' | 'stable' }) {
   if (trend === 'improving') {
     return (
       <div className="flex items-center gap-1 text-green-600">
@@ -77,7 +73,9 @@ function StatsGrid({
         <div className="flex items-center justify-center gap-1 text-red-600 mb-1">
           <Clock className="w-4 h-4" />
         </div>
-        <p className="text-lg font-bold text-red-700">{formatTime(wasteTime)}</p>
+        <p className="text-lg font-bold text-red-700">
+          {formatTime(wasteTime)}
+        </p>
         <p className="text-xs text-red-600">{getMessage('wasteTime')}</p>
       </div>
       <div className="text-center p-3 bg-green-50 rounded-lg">
@@ -220,9 +218,7 @@ export function WeeklyReportCard({
             <ChevronLeft className="w-4 h-4" />
           </Button>
           <span className="text-sm text-gray-600 min-w-[120px] text-center">
-            {report
-              ? formatWeekRange(report.weekStart, report.weekEnd)
-              : '---'}
+            {report ? formatWeekRange(report.weekStart, report.weekEnd) : '---'}
           </span>
           <Button
             variant="ghost"

--- a/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
+++ b/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
@@ -38,7 +38,8 @@ export function TimeLimitBadge({
   const textColor = isLow ? 'text-amber-700' : 'text-blue-700';
 
   const timeDisplay = formatTime(remainingSeconds);
-  const suffix = limitType === 'daily' ? getMessage('perDay') : getMessage('perHour');
+  const suffix =
+    limitType === 'daily' ? getMessage('perDay') : getMessage('perHour');
 
   if (compact) {
     return (

--- a/src/components/options/AnalyticsTab.tsx
+++ b/src/components/options/AnalyticsTab.tsx
@@ -1,52 +1,20 @@
-import React, { useMemo, useState, useRef, useCallback } from 'react';
-import {
-  AlertTriangle,
-  BarChart3,
-  Clock,
-  Lock,
-  RefreshCw,
-  Trash2,
-  EyeOff,
-  RotateCw,
-  Plus,
-  Shield,
-  Download,
-  ChevronDown,
-  Share2,
-  Image
-} from 'lucide-react';
+import React, { useState } from 'react';
+import { Plus } from 'lucide-react';
 
-import { Card, Button, Modal, Input } from '~/components/ui';
-import {
-  UpgradePrompt,
-  AnalyticsChart,
-  WeeklyReportCard,
-  MonthlyReportCard
-} from '~/components/features';
-import {
-  generateWeeklyReport,
-  generateMonthlyReport
-} from '~/lib/report';
-import { formatTime } from '~/lib/time';
+import { Card, Button, Input } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
-import {
-  exportBlockList,
-  exportBlockCounts,
-  exportDailyStats,
-  exportUnblockedSites
-} from '~/lib/export';
-import {
-  shareToX,
-  generateShareText,
-  captureElementAsCanvas,
-  copyImageToClipboard,
-  downloadImage
-} from '~/lib/share';
 import type {
   UnblockHistory,
   AnalyticsData,
   AppSettings
 } from '~/types/storage';
+
+import {
+  AnalyticsExportBar,
+  SiteRankingList,
+  AnalyticsSummary,
+  AnalyticsDateFilter
+} from './analytics';
 
 interface AnalyticsTabProps {
   unblockHistory: UnblockHistory;
@@ -60,28 +28,6 @@ interface AnalyticsTabProps {
   onAddSite: (domain: string) => void;
 }
 
-// Format relative time (e.g., "3 days ago")
-function formatRelativeTime(isoDate: string): string {
-  const date = new Date(isoDate);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-
-  if (diffDays === 0) {
-    return getMessage('today');
-  } else if (diffDays === 1) {
-    return getMessage('yesterday');
-  } else if (diffDays < 7) {
-    return getMessage('daysAgo', String(diffDays));
-  } else if (diffDays < 30) {
-    const weeks = Math.floor(diffDays / 7);
-    return getMessage('weeksAgo', String(weeks));
-  } else {
-    const months = Math.floor(diffDays / 30);
-    return getMessage('monthsAgo', String(months));
-  }
-}
-
 export function AnalyticsTab({
   unblockHistory,
   analyticsData,
@@ -93,17 +39,7 @@ export function AnalyticsTab({
   onRefresh,
   onAddSite
 }: AnalyticsTabProps) {
-  const [showResetModal, setShowResetModal] = useState(false);
   const [newSiteDomain, setNewSiteDomain] = useState('');
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const [showExportMenu, setShowExportMenu] = useState(false);
-  const [shareMessage, setShareMessage] = useState<{
-    type: 'success' | 'error';
-    text: string;
-  } | null>(null);
-  const chartRef = useRef<HTMLDivElement>(null);
-  const [weeklyOffset, setWeeklyOffset] = useState(0);
-  const [monthlyOffset, setMonthlyOffset] = useState(0);
 
   const handleAddSite = () => {
     if (newSiteDomain.trim()) {
@@ -112,310 +48,23 @@ export function AnalyticsTab({
     }
   };
 
-  const handleRefresh = async () => {
-    setIsRefreshing(true);
-    await onRefresh();
-    // Keep spinning for a moment so user can see it
-    setTimeout(() => setIsRefreshing(false), 500);
-  };
-
-  // Separate and sort tracked sites by status
-  const { blockedSites, unblockedSites } = useMemo(() => {
-    const allSites = Object.values(unblockHistory.sites);
-    const blocked = allSites
-      .filter((s) => s.status === 'blocked')
-      .sort(
-        (a, b) =>
-          new Date(b.blockedAt).getTime() - new Date(a.blockedAt).getTime()
-      );
-    const unblocked = allSites
-      .filter((s) => s.status === 'unblocked')
-      .sort((a, b) => b.timeAfterUnblock - a.timeAfterUnblock);
-    return { blockedSites: blocked, unblockedSites: unblocked };
-  }, [unblockHistory.sites]);
-
-  const hasTrackedSites = blockedSites.length > 0 || unblockedSites.length > 0;
-
-  // Calculate total time spent on unblocked sites
-  const totalTimeSpent = useMemo(() => {
-    return unblockedSites.reduce((sum, site) => sum + site.timeAfterUnblock, 0);
-  }, [unblockedSites]);
-
-  // Sort site block counts (descending by count)
-  const topBlockedSites = useMemo(() => {
-    const counts = Object.values(analyticsData.siteBlockCounts || {});
-    return counts.sort((a, b) => b.count - a.count).slice(0, 10);
-  }, [analyticsData.siteBlockCounts]);
-
-  // Generate reports
-  const weeklyReport = useMemo(() => {
-    return generateWeeklyReport(analyticsData, weeklyOffset);
-  }, [analyticsData, weeklyOffset]);
-
-  const monthlyReport = useMemo(() => {
-    return generateMonthlyReport(analyticsData, monthlyOffset);
-  }, [analyticsData, monthlyOffset]);
-
-  // Report navigation handlers
-  const handlePreviousWeek = useCallback(() => {
-    setWeeklyOffset((prev) => prev - 1);
-  }, []);
-
-  const handleNextWeek = useCallback(() => {
-    setWeeklyOffset((prev) => Math.min(prev + 1, 0));
-  }, []);
-
-  const handlePreviousMonth = useCallback(() => {
-    setMonthlyOffset((prev) => prev - 1);
-  }, []);
-
-  const handleNextMonth = useCallback(() => {
-    setMonthlyOffset((prev) => Math.min(prev + 1, 0));
-  }, []);
-
-  const handleReset = () => {
-    onReset();
-    setShowResetModal(false);
-  };
-
-  // Check if there's any data to export
-  const hasBlockList = (settings?.blockList?.length ?? 0) > 0;
-  const hasBlockCounts =
-    Object.keys(analyticsData.siteBlockCounts || {}).length > 0;
-  const hasDailyStats = Object.keys(analyticsData.dailyStats || {}).length > 0;
-  const hasUnblockedData = Object.keys(unblockHistory.sites || {}).length > 0;
-  const hasAnyData =
-    hasBlockList || hasBlockCounts || hasDailyStats || hasUnblockedData;
-
-  // Export handlers
-  const handleExportBlockList = () => {
-    if (settings?.blockList) {
-      exportBlockList(settings.blockList);
-    }
-    setShowExportMenu(false);
-  };
-
-  const handleExportBlockCounts = () => {
-    if (analyticsData.siteBlockCounts) {
-      exportBlockCounts(analyticsData.siteBlockCounts);
-    }
-    setShowExportMenu(false);
-  };
-
-  const handleExportDailyStats = () => {
-    if (analyticsData.dailyStats) {
-      exportDailyStats(analyticsData.dailyStats);
-    }
-    setShowExportMenu(false);
-  };
-
-  const handleExportUnblockedSites = () => {
-    if (isPremium) {
-      exportUnblockedSites(unblockHistory);
-    }
-    setShowExportMenu(false);
-  };
-
-  // Calculate total stats for sharing
-  const totalBlockCount = useMemo(() => {
-    return Object.values(analyticsData.siteBlockCounts || {}).reduce(
-      (sum, site) => sum + site.count,
-      0
-    );
-  }, [analyticsData.siteBlockCounts]);
-
-  const totalWasteTime = useMemo(() => {
-    return Object.values(analyticsData.dailyStats || {}).reduce(
-      (sum, stat) => sum + stat.wasteTime,
-      0
-    );
-  }, [analyticsData.dailyStats]);
-
-  const totalInvestTime = useMemo(() => {
-    return Object.values(analyticsData.dailyStats || {}).reduce(
-      (sum, stat) => sum + stat.investTime,
-      0
-    );
-  }, [analyticsData.dailyStats]);
-
-  const handleShareToX = async () => {
-    if (!chartRef.current) return;
-
-    try {
-      // Capture the chart as canvas
-      const canvas = await captureElementAsCanvas(chartRef.current);
-      if (!canvas) {
-        setShareMessage({ type: 'error', text: getMessage('shareError') });
-        return;
-      }
-
-      // Copy to clipboard
-      const success = await copyImageToClipboard(canvas);
-      if (!success) {
-        setShareMessage({ type: 'error', text: getMessage('shareError') });
-        return;
-      }
-
-      // Generate share text
-      const text = generateShareText({
-        totalBlockCount,
-        totalWasteTime,
-        totalInvestTime,
-        topBlockedSite: topBlockedSites[0]?.domain
-      });
-
-      // Show success message
-      setShareMessage({ type: 'success', text: getMessage('shareSuccess') });
-
-      // Open X intent
-      shareToX(text);
-
-      // Clear message after a delay
-      setTimeout(() => setShareMessage(null), 5000);
-    } catch {
-      setShareMessage({ type: 'error', text: getMessage('shareError') });
-    }
-  };
-
-  const handleDownloadImage = async () => {
-    if (!chartRef.current) return;
-
-    try {
-      const canvas = await captureElementAsCanvas(chartRef.current);
-      if (!canvas) {
-        setShareMessage({ type: 'error', text: getMessage('shareError') });
-        return;
-      }
-
-      const filename = `visionfocus-analytics-${new Date().toISOString().split('T')[0]}.png`;
-      downloadImage(canvas, filename);
-    } catch {
-      setShareMessage({ type: 'error', text: getMessage('shareError') });
-    }
-  };
+  const hasUnblockedSites = Object.values(unblockHistory.sites).some(
+    (s) => s.status === 'unblocked'
+  );
 
   return (
     <div className="space-y-6">
-      {/* Header Card with Export */}
-      <Card>
-        <div className="flex items-start justify-between">
-          <div className="flex items-start gap-3">
-            <div className="p-2 bg-blue-100 rounded-lg">
-              <Shield className="w-5 h-5 text-blue-600" />
-            </div>
-            <div>
-              <h2 className="text-lg font-semibold text-gray-900">
-                {getMessage('trackedSitesTitle')}
-              </h2>
-              <p className="text-sm text-gray-600 mt-1">
-                {getMessage('trackedSitesDescription')}
-              </p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            {/* Export Dropdown */}
-            <div className="relative">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setShowExportMenu(!showExportMenu)}
-                disabled={!hasAnyData}
-                className="flex items-center gap-1.5"
-              >
-                <Download className="w-4 h-4" />
-                {getMessage('exportData')}
-                <ChevronDown className="w-3 h-3" />
-              </Button>
-              {showExportMenu && (
-                <>
-                  <div
-                    className="fixed inset-0 z-10"
-                    onClick={() => setShowExportMenu(false)}
-                  />
-                  <div className="absolute right-0 mt-1 w-56 bg-white rounded-lg shadow-lg border border-gray-200 z-20 py-1">
-                    <button
-                      onClick={handleExportBlockList}
-                      disabled={!hasBlockList}
-                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {getMessage('exportBlockList')}
-                    </button>
-                    <button
-                      onClick={handleExportBlockCounts}
-                      disabled={!hasBlockCounts}
-                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {getMessage('exportBlockCounts')}
-                    </button>
-                    <button
-                      onClick={handleExportDailyStats}
-                      disabled={!hasDailyStats}
-                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {getMessage('exportDailyStats')}
-                    </button>
-                    {isPremium && (
-                      <button
-                        onClick={handleExportUnblockedSites}
-                        disabled={!hasUnblockedData}
-                        className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        {getMessage('exportUnblockedSites')}
-                      </button>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-            {/* Refresh Button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleRefresh}
-              disabled={isRefreshing}
-              className="text-gray-500 hover:text-gray-700"
-              title={getMessage('refresh')}
-            >
-              <RotateCw
-                className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`}
-              />
-            </Button>
-          </div>
-        </div>
-      </Card>
+      <AnalyticsExportBar
+        settings={settings}
+        analyticsData={analyticsData}
+        unblockHistory={unblockHistory}
+        isPremium={isPremium}
+        hasUnblockedSites={hasUnblockedSites}
+        onRefresh={onRefresh}
+        onReset={onReset}
+      />
 
-      {/* Top Blocked Sites */}
-      {topBlockedSites.length > 0 && (
-        <Card>
-          <div className="flex items-center gap-2 mb-4">
-            <Shield className="w-5 h-5 text-red-500" />
-            <h3 className="text-lg font-semibold text-gray-900">
-              {getMessage('topBlockedSites')}
-            </h3>
-          </div>
-          <div className="space-y-2">
-            {topBlockedSites.map((site, index) => (
-              <div
-                key={site.domain}
-                className="flex items-center justify-between py-2 px-3 bg-gray-50 rounded-lg"
-              >
-                <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 flex items-center justify-center text-sm font-medium text-gray-500 bg-gray-200 rounded-full">
-                    {index + 1}
-                  </span>
-                  <span className="font-medium text-gray-900">
-                    {site.domain}
-                  </span>
-                </div>
-                <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-red-100 text-red-700 text-sm font-medium rounded-full">
-                  <Shield className="w-3.5 h-3.5" />
-                  {getMessage('blockedTimesShort', site.count.toString())}
-                </span>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
+      <SiteRankingList analyticsData={analyticsData} />
 
       {/* Add Site */}
       <Card>
@@ -442,309 +91,17 @@ export function AnalyticsTab({
         </div>
       </Card>
 
-      {/* Empty State */}
-      {!hasTrackedSites && (
-        <Card>
-          <div className="text-center py-12">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-3xl">&#10003;</span>
-            </div>
-            <h3 className="text-lg font-medium text-gray-900 mb-2">
-              {getMessage('noUnblockedSites')}
-            </h3>
-            <p className="text-sm text-gray-500">
-              {getMessage('noUnblockedSitesDescription')}
-            </p>
-          </div>
-        </Card>
-      )}
+      <AnalyticsSummary
+        unblockHistory={unblockHistory}
+        isPremium={isPremium}
+        onReblock={onReblock}
+        onStopTracking={onStopTracking}
+      />
 
-      {/* Blocked Sites List */}
-      {blockedSites.length > 0 && (
-        <Card>
-          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <Lock className="w-4 h-4 text-green-600" />
-            {getMessage('statusBlocked')} ({blockedSites.length})
-          </h3>
-          <div className="space-y-3">
-            {blockedSites.map((site) => (
-              <div
-                key={site.domain}
-                className="p-3 bg-green-50 rounded-lg border border-green-100"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 bg-green-500 rounded-full" />
-                      <span className="font-medium text-gray-900 truncate">
-                        {site.domain}
-                      </span>
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
-                        {getMessage('statusBlocked')}
-                      </span>
-                    </div>
-                    <p className="text-sm text-gray-500 mt-1">
-                      {getMessage('blockedSince')}:{' '}
-                      {formatRelativeTime(site.blockedAt)}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <span className="text-lg font-bold text-green-600">
-                      0{getMessage('time') === 'Time' ? 'm' : '分'}
-                    </span>
-                    <p className="text-xs text-gray-500">
-                      {getMessage('timeSaved')}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {/* Unblocked Sites List */}
-      {unblockedSites.length > 0 && (
-        <Card>
-          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-orange-500" />
-            {getMessage('statusUnblocked')} ({unblockedSites.length})
-          </h3>
-          <div className="space-y-3">
-            {unblockedSites.map((site) => (
-              <div
-                key={site.domain}
-                className="p-4 bg-orange-50 rounded-lg border border-orange-100"
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <div className="w-2 h-2 bg-orange-500 rounded-full" />
-                      <span className="font-medium text-gray-900 truncate">
-                        {site.domain}
-                      </span>
-                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-700">
-                        {getMessage('statusUnblocked')}
-                      </span>
-                    </div>
-
-                    <p className="text-sm text-gray-500 mt-1">
-                      {getMessage('unblockedOn')}:{' '}
-                      {site.unblockedAt
-                        ? formatRelativeTime(site.unblockedAt)
-                        : '-'}
-                    </p>
-
-                    <div className="flex items-center gap-2 mt-2">
-                      <Clock className="w-4 h-4 text-gray-400" />
-                      {isPremium ? (
-                        <span className="text-sm font-medium text-orange-600">
-                          {getMessage('timeSpentSinceUnblock')}:{' '}
-                          {formatTime(site.timeAfterUnblock)}
-                        </span>
-                      ) : (
-                        <span className="text-sm text-gray-400 flex items-center gap-1">
-                          {getMessage('timeSpentSinceUnblock')}:{' '}
-                          <span className="tracking-widest">******</span>
-                          <Lock className="w-3 h-3" />
-                        </span>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Action buttons */}
-                  <div className="flex items-center gap-2">
-                    {isPremium && (
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        onClick={() => onReblock(site.domain)}
-                        className="flex items-center gap-1.5"
-                      >
-                        <RefreshCw className="w-4 h-4" />
-                        {getMessage('reblock')}
-                      </Button>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onStopTracking(site.domain)}
-                      className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700"
-                    >
-                      <EyeOff className="w-4 h-4" />
-                      {getMessage('stopTracking')}
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ))}
-
-            {/* Total time (Premium only) */}
-            {isPremium && unblockedSites.length > 1 && (
-              <div className="pt-4 border-t border-orange-200">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm font-medium text-gray-700">
-                    {getMessage('totalTimeOnUnblockedSites')}
-                  </span>
-                  <span className="text-lg font-bold text-orange-600">
-                    {formatTime(totalTimeSpent)}
-                  </span>
-                </div>
-              </div>
-            )}
-          </div>
-        </Card>
-      )}
-
-      {/* Upgrade Prompt for Free Users */}
-      {unblockedSites.length > 0 && !isPremium && (
-        <Card>
-          <UpgradePrompt
-            variant="inline"
-            features={[
-              getMessage('upgradeFeatureViewTime'),
-              getMessage('upgradeFeatureReblock'),
-              getMessage('upgradeFeatureChart')
-            ]}
-          />
-        </Card>
-      )}
-
-      {/* Analytics Chart (Premium only) */}
-      {unblockedSites.length > 0 && isPremium && (
-        <Card>
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-lg font-semibold text-gray-900">
-              {getMessage('usageChart')}
-            </h3>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleShareToX}
-                className="flex items-center gap-1.5"
-                title={getMessage('shareToX')}
-              >
-                <Share2 className="w-4 h-4" />
-                {getMessage('shareToX')}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={handleDownloadImage}
-                className="flex items-center gap-1.5"
-                title={getMessage('downloadImage')}
-              >
-                <Image className="w-4 h-4" />
-                {getMessage('downloadImage')}
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => setShowResetModal(true)}
-                className="flex items-center gap-1.5 text-gray-500 hover:text-red-500"
-              >
-                <Trash2 className="w-4 h-4" />
-                {getMessage('reset')}
-              </Button>
-            </div>
-          </div>
-          {/* Share message */}
-          {shareMessage && (
-            <div
-              className={`mb-4 p-3 rounded-lg text-sm ${
-                shareMessage.type === 'success'
-                  ? 'bg-green-50 text-green-700'
-                  : 'bg-red-50 text-red-700'
-              }`}
-            >
-              {shareMessage.text}
-            </div>
-          )}
-          <div ref={chartRef}>
-            <AnalyticsChart
-              analytics={analyticsData}
-              unblockHistory={unblockHistory}
-            />
-          </div>
-        </Card>
-      )}
-
-      {/* Reports Section (Premium only) */}
-      {isPremium && (
-        <Card>
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">
-            {getMessage('reportsSection')}
-          </h3>
-          <div className="grid md:grid-cols-2 gap-6">
-            <WeeklyReportCard
-              report={weeklyReport}
-              onPrevious={handlePreviousWeek}
-              onNext={handleNextWeek}
-              canGoNext={weeklyOffset < 0}
-            />
-            <MonthlyReportCard
-              report={monthlyReport}
-              onPrevious={handlePreviousMonth}
-              onNext={handleNextMonth}
-              canGoNext={monthlyOffset < 0}
-            />
-          </div>
-        </Card>
-      )}
-
-      {/* Reports Upgrade Prompt for Free Users */}
-      {!isPremium && (
-        <Card>
-          <div className="flex items-start gap-3">
-            <div className="p-2 bg-purple-100 rounded-lg">
-              <BarChart3 className="w-5 h-5 text-purple-600" />
-            </div>
-            <div className="flex-1">
-              <h3 className="text-lg font-semibold text-gray-900">
-                {getMessage('reportsSection')}
-              </h3>
-              <p className="text-sm text-gray-600 mt-1">
-                {getMessage('reportsPremiumDescription')}
-              </p>
-              <div className="mt-4">
-                <UpgradePrompt
-                  variant="inline"
-                  features={[
-                    getMessage('weeklyReport'),
-                    getMessage('monthlyReport'),
-                    getMessage('productivityImproving').replace('!', '')
-                  ]}
-                />
-              </div>
-            </div>
-          </div>
-        </Card>
-      )}
-
-      {/* Reset Confirmation Modal */}
-      <Modal
-        isOpen={showResetModal}
-        onClose={() => setShowResetModal(false)}
-        title={getMessage('resetAnalyticsTitle')}
-      >
-        <div className="space-y-4">
-          <p className="text-sm text-gray-600">
-            {getMessage('resetAnalyticsDescription')}
-          </p>
-          <div className="flex justify-end gap-3">
-            <Button
-              variant="secondary"
-              onClick={() => setShowResetModal(false)}
-            >
-              {getMessage('cancel')}
-            </Button>
-            <Button variant="danger" onClick={handleReset}>
-              {getMessage('reset')}
-            </Button>
-          </div>
-        </div>
-      </Modal>
+      <AnalyticsDateFilter
+        analyticsData={analyticsData}
+        isPremium={isPremium}
+      />
     </div>
   );
 }

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -70,7 +70,8 @@ function TimeLimitEditor({ item, onUpdate, usage }: TimeLimitEditorProps) {
       ? TIME_LIMIT_CONFIG.DEFAULT_DAILY_LIMIT / 60
       : TIME_LIMIT_CONFIG.DEFAULT_HOURLY_LIMIT / 60;
 
-  const [selectedType, setSelectedType] = useState<LimitTypeOption>(currentType);
+  const [selectedType, setSelectedType] =
+    useState<LimitTypeOption>(currentType);
   const [minutes, setMinutes] = useState(currentMinutes);
 
   const handleTypeChange = useCallback(
@@ -277,10 +278,7 @@ function NotificationSettingsSection({
               {getMessage('notificationTimeLimitEnabledDescription')}
             </p>
           </div>
-          <Toggle
-            checked={timeLimitEnabled}
-            onChange={handleToggle}
-          />
+          <Toggle checked={timeLimitEnabled} onChange={handleToggle} />
         </div>
 
         {timeLimitEnabled && (
@@ -540,8 +538,9 @@ export function BlocklistTab({
 
   // Check if any sites have time limits configured
   const hasTimeLimitSites =
-    settings?.blockList.some((item) => item.timeLimit !== null && item.timeLimit !== undefined) ??
-    false;
+    settings?.blockList.some(
+      (item) => item.timeLimit !== null && item.timeLimit !== undefined
+    ) ?? false;
 
   return (
     <div className="space-y-6">
@@ -600,7 +599,9 @@ export function BlocklistTab({
                     <div className="flex items-center gap-3">
                       <Toggle
                         checked={item.enabled}
-                        onChange={(checked) => handleToggleClick(item.id, checked)}
+                        onChange={(checked) =>
+                          handleToggleClick(item.id, checked)
+                        }
                         size="sm"
                       />
                       <div>
@@ -625,7 +626,10 @@ export function BlocklistTab({
                       {blockCount > 0 && (
                         <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">
                           <Shield className="w-3 h-3" />
-                          {getMessage('blockedTimesShort', blockCount.toString())}
+                          {getMessage(
+                            'blockedTimesShort',
+                            blockCount.toString()
+                          )}
                         </span>
                       )}
                     </div>
@@ -642,7 +646,9 @@ export function BlocklistTab({
                   <div className="ml-11">
                     <TimeLimitEditor
                       item={item}
-                      onUpdate={(timeLimit) => onUpdateTimeLimit(item.id, timeLimit)}
+                      onUpdate={(timeLimit) =>
+                        onUpdateTimeLimit(item.id, timeLimit)
+                      }
                       usage={usage}
                     />
                   </div>

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -33,7 +33,11 @@ interface HelpTabProps {
   onPasswordUpdate?: (settings: PasswordSettings) => Promise<void>;
 }
 
-export function HelpTab({ onSettingsChange, settings, onPasswordUpdate }: HelpTabProps) {
+export function HelpTab({
+  onSettingsChange,
+  settings,
+  onPasswordUpdate
+}: HelpTabProps) {
   const [exportStatus, setExportStatus] = useState<
     'idle' | 'loading' | 'success' | 'error'
   >('idle');

--- a/src/components/options/PasswordSettingsSection.tsx
+++ b/src/components/options/PasswordSettingsSection.tsx
@@ -127,7 +127,14 @@ export function PasswordSettingsSection({
     } finally {
       setIsProcessing(false);
     }
-  }, [currentPassword, newPassword, confirmPassword, passwordSettings, onUpdate, resetForm]);
+  }, [
+    currentPassword,
+    newPassword,
+    confirmPassword,
+    passwordSettings,
+    onUpdate,
+    resetForm
+  ]);
 
   const handleRemovePassword = useCallback(async () => {
     setError(null);
@@ -310,7 +317,9 @@ export function PasswordSettingsSection({
               disabled={isProcessing || !newPassword || !confirmPassword}
               className="flex-1"
             >
-              {isProcessing ? getMessage('processing') : getMessage('setPassword')}
+              {isProcessing
+                ? getMessage('processing')
+                : getMessage('setPassword')}
             </Button>
           </div>
         </div>
@@ -420,7 +429,10 @@ export function PasswordSettingsSection({
             <Button
               onClick={handleChangePassword}
               disabled={
-                isProcessing || !currentPassword || !newPassword || !confirmPassword
+                isProcessing ||
+                !currentPassword ||
+                !newPassword ||
+                !confirmPassword
               }
               className="flex-1"
             >

--- a/src/components/options/analytics/AnalyticsDateFilter.tsx
+++ b/src/components/options/analytics/AnalyticsDateFilter.tsx
@@ -1,0 +1,101 @@
+import React, { useMemo, useState, useCallback } from 'react';
+import { BarChart3 } from 'lucide-react';
+
+import { Card } from '~/components/ui';
+import {
+  UpgradePrompt,
+  WeeklyReportCard,
+  MonthlyReportCard
+} from '~/components/features';
+import { generateWeeklyReport, generateMonthlyReport } from '~/lib/report';
+import { getMessage } from '~/lib/i18n';
+import type { AnalyticsData } from '~/types/storage';
+
+interface AnalyticsDateFilterProps {
+  analyticsData: AnalyticsData;
+  isPremium: boolean;
+}
+
+export function AnalyticsDateFilter({
+  analyticsData,
+  isPremium
+}: AnalyticsDateFilterProps) {
+  const [weeklyOffset, setWeeklyOffset] = useState(0);
+  const [monthlyOffset, setMonthlyOffset] = useState(0);
+
+  const weeklyReport = useMemo(() => {
+    return generateWeeklyReport(analyticsData, weeklyOffset);
+  }, [analyticsData, weeklyOffset]);
+
+  const monthlyReport = useMemo(() => {
+    return generateMonthlyReport(analyticsData, monthlyOffset);
+  }, [analyticsData, monthlyOffset]);
+
+  const handlePreviousWeek = useCallback(() => {
+    setWeeklyOffset((prev) => prev - 1);
+  }, []);
+
+  const handleNextWeek = useCallback(() => {
+    setWeeklyOffset((prev) => Math.min(prev + 1, 0));
+  }, []);
+
+  const handlePreviousMonth = useCallback(() => {
+    setMonthlyOffset((prev) => prev - 1);
+  }, []);
+
+  const handleNextMonth = useCallback(() => {
+    setMonthlyOffset((prev) => Math.min(prev + 1, 0));
+  }, []);
+
+  if (isPremium) {
+    return (
+      <Card>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          {getMessage('reportsSection')}
+        </h3>
+        <div className="grid md:grid-cols-2 gap-6">
+          <WeeklyReportCard
+            report={weeklyReport}
+            onPrevious={handlePreviousWeek}
+            onNext={handleNextWeek}
+            canGoNext={weeklyOffset < 0}
+          />
+          <MonthlyReportCard
+            report={monthlyReport}
+            onPrevious={handlePreviousMonth}
+            onNext={handleNextMonth}
+            canGoNext={monthlyOffset < 0}
+          />
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <div className="flex items-start gap-3">
+        <div className="p-2 bg-purple-100 rounded-lg">
+          <BarChart3 className="w-5 h-5 text-purple-600" />
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold text-gray-900">
+            {getMessage('reportsSection')}
+          </h3>
+          <p className="text-sm text-gray-600 mt-1">
+            {getMessage('reportsPremiumDescription')}
+          </p>
+          <div className="mt-4">
+            <UpgradePrompt
+              variant="inline"
+              features={[
+                getMessage('weeklyReport'),
+                getMessage('monthlyReport'),
+                getMessage('productivityImproving').replace('!', '')
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/options/analytics/AnalyticsExportBar.tsx
+++ b/src/components/options/analytics/AnalyticsExportBar.tsx
@@ -1,0 +1,360 @@
+import React, { useState, useRef, useMemo, useCallback } from 'react';
+import {
+  Shield,
+  Download,
+  ChevronDown,
+  RotateCw,
+  Share2,
+  Image,
+  Trash2
+} from 'lucide-react';
+
+import { Card, Button, Modal } from '~/components/ui';
+import { AnalyticsChart } from '~/components/features';
+import { getMessage } from '~/lib/i18n';
+import {
+  exportBlockList,
+  exportBlockCounts,
+  exportDailyStats,
+  exportUnblockedSites
+} from '~/lib/export';
+import {
+  shareToX,
+  generateShareText,
+  captureElementAsCanvas,
+  copyImageToClipboard,
+  downloadImage
+} from '~/lib/share';
+import type {
+  UnblockHistory,
+  AnalyticsData,
+  AppSettings
+} from '~/types/storage';
+
+interface AnalyticsExportBarProps {
+  settings: AppSettings | null;
+  analyticsData: AnalyticsData;
+  unblockHistory: UnblockHistory;
+  isPremium: boolean;
+  hasUnblockedSites: boolean;
+  onRefresh: () => Promise<void>;
+  onReset: () => void;
+}
+
+export function AnalyticsExportBar({
+  settings,
+  analyticsData,
+  unblockHistory,
+  isPremium,
+  hasUnblockedSites,
+  onRefresh,
+  onReset
+}: AnalyticsExportBarProps) {
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [showResetModal, setShowResetModal] = useState(false);
+  const [shareMessage, setShareMessage] = useState<{
+    type: 'success' | 'error';
+    text: string;
+  } | null>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    await onRefresh();
+    setTimeout(() => setIsRefreshing(false), 500);
+  };
+
+  const hasBlockList = (settings?.blockList?.length ?? 0) > 0;
+  const hasBlockCounts =
+    Object.keys(analyticsData.siteBlockCounts || {}).length > 0;
+  const hasDailyStats = Object.keys(analyticsData.dailyStats || {}).length > 0;
+  const hasUnblockedData = Object.keys(unblockHistory.sites || {}).length > 0;
+  const hasAnyData =
+    hasBlockList || hasBlockCounts || hasDailyStats || hasUnblockedData;
+
+  const handleExportBlockList = () => {
+    if (settings?.blockList) {
+      exportBlockList(settings.blockList);
+    }
+    setShowExportMenu(false);
+  };
+
+  const handleExportBlockCounts = () => {
+    if (analyticsData.siteBlockCounts) {
+      exportBlockCounts(analyticsData.siteBlockCounts);
+    }
+    setShowExportMenu(false);
+  };
+
+  const handleExportDailyStats = () => {
+    if (analyticsData.dailyStats) {
+      exportDailyStats(analyticsData.dailyStats);
+    }
+    setShowExportMenu(false);
+  };
+
+  const handleExportUnblockedSites = () => {
+    if (isPremium) {
+      exportUnblockedSites(unblockHistory);
+    }
+    setShowExportMenu(false);
+  };
+
+  const totalBlockCount = useMemo(() => {
+    return Object.values(analyticsData.siteBlockCounts || {}).reduce(
+      (sum, site) => sum + site.count,
+      0
+    );
+  }, [analyticsData.siteBlockCounts]);
+
+  const totalWasteTime = useMemo(() => {
+    return Object.values(analyticsData.dailyStats || {}).reduce(
+      (sum, stat) => sum + stat.wasteTime,
+      0
+    );
+  }, [analyticsData.dailyStats]);
+
+  const totalInvestTime = useMemo(() => {
+    return Object.values(analyticsData.dailyStats || {}).reduce(
+      (sum, stat) => sum + stat.investTime,
+      0
+    );
+  }, [analyticsData.dailyStats]);
+
+  const topBlockedSites = useMemo(() => {
+    const counts = Object.values(analyticsData.siteBlockCounts || {});
+    return counts.sort((a, b) => b.count - a.count).slice(0, 10);
+  }, [analyticsData.siteBlockCounts]);
+
+  const handleShareToX = useCallback(async () => {
+    if (!chartRef.current) return;
+
+    try {
+      const canvas = await captureElementAsCanvas(chartRef.current);
+      if (!canvas) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      const success = await copyImageToClipboard(canvas);
+      if (!success) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      const text = generateShareText({
+        totalBlockCount,
+        totalWasteTime,
+        totalInvestTime,
+        topBlockedSite: topBlockedSites[0]?.domain
+      });
+
+      setShareMessage({ type: 'success', text: getMessage('shareSuccess') });
+
+      shareToX(text);
+
+      setTimeout(() => setShareMessage(null), 5000);
+    } catch {
+      setShareMessage({ type: 'error', text: getMessage('shareError') });
+    }
+  }, [totalBlockCount, totalWasteTime, totalInvestTime, topBlockedSites]);
+
+  const handleDownloadImage = useCallback(async () => {
+    if (!chartRef.current) return;
+
+    try {
+      const canvas = await captureElementAsCanvas(chartRef.current);
+      if (!canvas) {
+        setShareMessage({ type: 'error', text: getMessage('shareError') });
+        return;
+      }
+
+      const filename = `visionfocus-analytics-${new Date().toISOString().split('T')[0]}.png`;
+      downloadImage(canvas, filename);
+    } catch {
+      setShareMessage({ type: 'error', text: getMessage('shareError') });
+    }
+  }, []);
+
+  const handleReset = () => {
+    onReset();
+    setShowResetModal(false);
+  };
+
+  return (
+    <>
+      {/* Header Card with Export */}
+      <Card>
+        <div className="flex items-start justify-between">
+          <div className="flex items-start gap-3">
+            <div className="p-2 bg-blue-100 rounded-lg">
+              <Shield className="w-5 h-5 text-blue-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">
+                {getMessage('trackedSitesTitle')}
+              </h2>
+              <p className="text-sm text-gray-600 mt-1">
+                {getMessage('trackedSitesDescription')}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {/* Export Dropdown */}
+            <div className="relative">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowExportMenu(!showExportMenu)}
+                disabled={!hasAnyData}
+                className="flex items-center gap-1.5"
+              >
+                <Download className="w-4 h-4" />
+                {getMessage('exportData')}
+                <ChevronDown className="w-3 h-3" />
+              </Button>
+              {showExportMenu && (
+                <>
+                  <div
+                    className="fixed inset-0 z-10"
+                    onClick={() => setShowExportMenu(false)}
+                  />
+                  <div className="absolute right-0 mt-1 w-56 bg-white rounded-lg shadow-lg border border-gray-200 z-20 py-1">
+                    <button
+                      onClick={handleExportBlockList}
+                      disabled={!hasBlockList}
+                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {getMessage('exportBlockList')}
+                    </button>
+                    <button
+                      onClick={handleExportBlockCounts}
+                      disabled={!hasBlockCounts}
+                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {getMessage('exportBlockCounts')}
+                    </button>
+                    <button
+                      onClick={handleExportDailyStats}
+                      disabled={!hasDailyStats}
+                      className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {getMessage('exportDailyStats')}
+                    </button>
+                    {isPremium && (
+                      <button
+                        onClick={handleExportUnblockedSites}
+                        disabled={!hasUnblockedData}
+                        className="w-full px-4 py-2 text-left text-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {getMessage('exportUnblockedSites')}
+                      </button>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+            {/* Refresh Button */}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="text-gray-500 hover:text-gray-700"
+              title={getMessage('refresh')}
+            >
+              <RotateCw
+                className={`w-4 h-4 ${isRefreshing ? 'animate-spin' : ''}`}
+              />
+            </Button>
+          </div>
+        </div>
+      </Card>
+
+      {/* Analytics Chart (Premium only) */}
+      {hasUnblockedSites && isPremium && (
+        <Card>
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-lg font-semibold text-gray-900">
+              {getMessage('usageChart')}
+            </h3>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleShareToX}
+                className="flex items-center gap-1.5"
+                title={getMessage('shareToX')}
+              >
+                <Share2 className="w-4 h-4" />
+                {getMessage('shareToX')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={handleDownloadImage}
+                className="flex items-center gap-1.5"
+                title={getMessage('downloadImage')}
+              >
+                <Image className="w-4 h-4" />
+                {getMessage('downloadImage')}
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => setShowResetModal(true)}
+                className="flex items-center gap-1.5 text-gray-500 hover:text-red-500"
+              >
+                <Trash2 className="w-4 h-4" />
+                {getMessage('reset')}
+              </Button>
+            </div>
+          </div>
+          {/* Share message */}
+          {shareMessage && (
+            <div
+              className={`mb-4 p-3 rounded-lg text-sm ${
+                shareMessage.type === 'success'
+                  ? 'bg-green-50 text-green-700'
+                  : 'bg-red-50 text-red-700'
+              }`}
+            >
+              {shareMessage.text}
+            </div>
+          )}
+          <div ref={chartRef}>
+            <AnalyticsChart
+              analytics={analyticsData}
+              unblockHistory={unblockHistory}
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Reset Confirmation Modal */}
+      <Modal
+        isOpen={showResetModal}
+        onClose={() => setShowResetModal(false)}
+        title={getMessage('resetAnalyticsTitle')}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600">
+            {getMessage('resetAnalyticsDescription')}
+          </p>
+          <div className="flex justify-end gap-3">
+            <Button
+              variant="secondary"
+              onClick={() => setShowResetModal(false)}
+            >
+              {getMessage('cancel')}
+            </Button>
+            <Button variant="danger" onClick={handleReset}>
+              {getMessage('reset')}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -1,0 +1,254 @@
+import React, { useMemo } from 'react';
+import { AlertTriangle, Clock, Lock, RefreshCw, EyeOff } from 'lucide-react';
+
+import { Card, Button } from '~/components/ui';
+import { UpgradePrompt } from '~/components/features';
+import { formatTime } from '~/lib/time';
+import { getMessage } from '~/lib/i18n';
+import type { UnblockHistory, TrackedSite } from '~/types/storage';
+
+function formatRelativeTime(isoDate: string): string {
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) {
+    return getMessage('today');
+  } else if (diffDays === 1) {
+    return getMessage('yesterday');
+  } else if (diffDays < 7) {
+    return getMessage('daysAgo', String(diffDays));
+  } else if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return getMessage('weeksAgo', String(weeks));
+  } else {
+    const months = Math.floor(diffDays / 30);
+    return getMessage('monthsAgo', String(months));
+  }
+}
+
+interface AnalyticsSummaryProps {
+  unblockHistory: UnblockHistory;
+  isPremium: boolean;
+  onReblock: (domain: string) => void;
+  onStopTracking: (domain: string) => void;
+}
+
+export function AnalyticsSummary({
+  unblockHistory,
+  isPremium,
+  onReblock,
+  onStopTracking
+}: AnalyticsSummaryProps) {
+  const { blockedSites, unblockedSites } = useMemo(() => {
+    const allSites = Object.values(unblockHistory.sites);
+    const blocked = allSites
+      .filter((s) => s.status === 'blocked')
+      .sort(
+        (a, b) =>
+          new Date(b.blockedAt).getTime() - new Date(a.blockedAt).getTime()
+      );
+    const unblocked = allSites
+      .filter((s) => s.status === 'unblocked')
+      .sort((a, b) => b.timeAfterUnblock - a.timeAfterUnblock);
+    return { blockedSites: blocked, unblockedSites: unblocked };
+  }, [unblockHistory.sites]);
+
+  const hasTrackedSites = blockedSites.length > 0 || unblockedSites.length > 0;
+
+  const totalTimeSpent = useMemo(() => {
+    return unblockedSites.reduce((sum, site) => sum + site.timeAfterUnblock, 0);
+  }, [unblockedSites]);
+
+  return (
+    <>
+      {/* Empty State */}
+      {!hasTrackedSites && (
+        <Card>
+          <div className="text-center py-12">
+            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <span className="text-3xl">&#10003;</span>
+            </div>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              {getMessage('noUnblockedSites')}
+            </h3>
+            <p className="text-sm text-gray-500">
+              {getMessage('noUnblockedSitesDescription')}
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {/* Blocked Sites List */}
+      {blockedSites.length > 0 && (
+        <Card>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+            <Lock className="w-4 h-4 text-green-600" />
+            {getMessage('statusBlocked')} ({blockedSites.length})
+          </h3>
+          <div className="space-y-3">
+            {blockedSites.map((site) => (
+              <BlockedSiteItem key={site.domain} site={site} />
+            ))}
+          </div>
+        </Card>
+      )}
+
+      {/* Unblocked Sites List */}
+      {unblockedSites.length > 0 && (
+        <Card>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+            <AlertTriangle className="w-4 h-4 text-orange-500" />
+            {getMessage('statusUnblocked')} ({unblockedSites.length})
+          </h3>
+          <div className="space-y-3">
+            {unblockedSites.map((site) => (
+              <UnblockedSiteItem
+                key={site.domain}
+                site={site}
+                isPremium={isPremium}
+                onReblock={onReblock}
+                onStopTracking={onStopTracking}
+              />
+            ))}
+
+            {/* Total time (Premium only) */}
+            {isPremium && unblockedSites.length > 1 && (
+              <div className="pt-4 border-t border-orange-200">
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-gray-700">
+                    {getMessage('totalTimeOnUnblockedSites')}
+                  </span>
+                  <span className="text-lg font-bold text-orange-600">
+                    {formatTime(totalTimeSpent)}
+                  </span>
+                </div>
+              </div>
+            )}
+          </div>
+        </Card>
+      )}
+
+      {/* Upgrade Prompt for Free Users */}
+      {unblockedSites.length > 0 && !isPremium && (
+        <Card>
+          <UpgradePrompt
+            variant="inline"
+            features={[
+              getMessage('upgradeFeatureViewTime'),
+              getMessage('upgradeFeatureReblock'),
+              getMessage('upgradeFeatureChart')
+            ]}
+          />
+        </Card>
+      )}
+    </>
+  );
+}
+
+function BlockedSiteItem({ site }: { site: TrackedSite }) {
+  return (
+    <div className="p-3 bg-green-50 rounded-lg border border-green-100">
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 bg-green-500 rounded-full" />
+            <span className="font-medium text-gray-900 truncate">
+              {site.domain}
+            </span>
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+              {getMessage('statusBlocked')}
+            </span>
+          </div>
+          <p className="text-sm text-gray-500 mt-1">
+            {getMessage('blockedSince')}: {formatRelativeTime(site.blockedAt)}
+          </p>
+        </div>
+        <div className="text-right">
+          <span className="text-lg font-bold text-green-600">
+            0{getMessage('time') === 'Time' ? 'm' : '\u5206'}
+          </span>
+          <p className="text-xs text-gray-500">{getMessage('timeSaved')}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface UnblockedSiteItemProps {
+  site: TrackedSite;
+  isPremium: boolean;
+  onReblock: (domain: string) => void;
+  onStopTracking: (domain: string) => void;
+}
+
+function UnblockedSiteItem({
+  site,
+  isPremium,
+  onReblock,
+  onStopTracking
+}: UnblockedSiteItemProps) {
+  return (
+    <div className="p-4 bg-orange-50 rounded-lg border border-orange-100">
+      <div className="flex items-start justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 bg-orange-500 rounded-full" />
+            <span className="font-medium text-gray-900 truncate">
+              {site.domain}
+            </span>
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-700">
+              {getMessage('statusUnblocked')}
+            </span>
+          </div>
+
+          <p className="text-sm text-gray-500 mt-1">
+            {getMessage('unblockedOn')}:{' '}
+            {site.unblockedAt ? formatRelativeTime(site.unblockedAt) : '-'}
+          </p>
+
+          <div className="flex items-center gap-2 mt-2">
+            <Clock className="w-4 h-4 text-gray-400" />
+            {isPremium ? (
+              <span className="text-sm font-medium text-orange-600">
+                {getMessage('timeSpentSinceUnblock')}:{' '}
+                {formatTime(site.timeAfterUnblock)}
+              </span>
+            ) : (
+              <span className="text-sm text-gray-400 flex items-center gap-1">
+                {getMessage('timeSpentSinceUnblock')}:{' '}
+                <span className="tracking-widest">******</span>
+                <Lock className="w-3 h-3" />
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2">
+          {isPremium && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onReblock(site.domain)}
+              className="flex items-center gap-1.5"
+            >
+              <RefreshCw className="w-4 h-4" />
+              {getMessage('reblock')}
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onStopTracking(site.domain)}
+            className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700"
+          >
+            <EyeOff className="w-4 h-4" />
+            {getMessage('stopTracking')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/options/analytics/SiteRankingList.tsx
+++ b/src/components/options/analytics/SiteRankingList.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import { Shield } from 'lucide-react';
+
+import { Card } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import type { AnalyticsData } from '~/types/storage';
+
+interface SiteRankingListProps {
+  analyticsData: AnalyticsData;
+}
+
+export function SiteRankingList({ analyticsData }: SiteRankingListProps) {
+  const topBlockedSites = useMemo(() => {
+    const counts = Object.values(analyticsData.siteBlockCounts || {});
+    return counts.sort((a, b) => b.count - a.count).slice(0, 10);
+  }, [analyticsData.siteBlockCounts]);
+
+  if (topBlockedSites.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <div className="flex items-center gap-2 mb-4">
+        <Shield className="w-5 h-5 text-red-500" />
+        <h3 className="text-lg font-semibold text-gray-900">
+          {getMessage('topBlockedSites')}
+        </h3>
+      </div>
+      <div className="space-y-2">
+        {topBlockedSites.map((site, index) => (
+          <div
+            key={site.domain}
+            className="flex items-center justify-between py-2 px-3 bg-gray-50 rounded-lg"
+          >
+            <div className="flex items-center gap-3">
+              <span className="w-6 h-6 flex items-center justify-center text-sm font-medium text-gray-500 bg-gray-200 rounded-full">
+                {index + 1}
+              </span>
+              <span className="font-medium text-gray-900">{site.domain}</span>
+            </div>
+            <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-red-100 text-red-700 text-sm font-medium rounded-full">
+              <Shield className="w-3.5 h-3.5" />
+              {getMessage('blockedTimesShort', site.count.toString())}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/options/analytics/index.ts
+++ b/src/components/options/analytics/index.ts
@@ -1,0 +1,4 @@
+export { AnalyticsSummary } from './AnalyticsSummary';
+export { SiteRankingList } from './SiteRankingList';
+export { AnalyticsExportBar } from './AnalyticsExportBar';
+export { AnalyticsDateFilter } from './AnalyticsDateFilter';

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -2,7 +2,11 @@ import type { PlasmoCSConfig } from 'plasmo';
 
 import { Storage } from '@plasmohq/storage';
 
-import type { YouTubeSettings, TimeLimitUsage, AnalyticsData } from '~/types/storage';
+import type {
+  YouTubeSettings,
+  TimeLimitUsage,
+  AnalyticsData
+} from '~/types/storage';
 import { DEFAULT_YOUTUBE_SETTINGS } from '~/types/storage';
 
 // Run only on YouTube
@@ -47,7 +51,10 @@ let styleElement: HTMLStyleElement | null = null;
 let observer: MutationObserver | null = null;
 
 // Check if the YouTube time limit has been exceeded based on usage data
-function checkTimeLimitExceeded(settings: YouTubeSettings, usage: TimeLimitUsage | undefined): boolean {
+function checkTimeLimitExceeded(
+  settings: YouTubeSettings,
+  usage: TimeLimitUsage | undefined
+): boolean {
   if (!settings.enabled || !settings.timeLimit || !usage) {
     return false;
   }
@@ -61,9 +68,11 @@ function checkTimeLimitExceeded(settings: YouTubeSettings, usage: TimeLimitUsage
 
   let usedSeconds: number;
   if (type === 'daily') {
-    usedSeconds = usage.lastDailyReset === todayKey ? usage.dailyUsedSeconds : 0;
+    usedSeconds =
+      usage.lastDailyReset === todayKey ? usage.dailyUsedSeconds : 0;
   } else {
-    usedSeconds = usage.lastHourlyReset === hourKey ? usage.hourlyUsedSeconds : 0;
+    usedSeconds =
+      usage.lastHourlyReset === hourKey ? usage.hourlyUsedSeconds : 0;
   }
 
   return usedSeconds >= limitSeconds;
@@ -253,7 +262,9 @@ function setupObserver(): void {
 // Load analytics to check time limit
 async function loadTimeLimitState(): Promise<void> {
   try {
-    const analytics = await storage.get('analytics') as AnalyticsData | undefined;
+    const analytics = (await storage.get('analytics')) as
+      | AnalyticsData
+      | undefined;
     const usage = analytics?.timeLimitUsage?.['youtube.com'];
     timeLimitExceeded = checkTimeLimitExceeded(currentSettings, usage);
   } catch {
@@ -264,7 +275,10 @@ async function loadTimeLimitState(): Promise<void> {
 // Load settings from storage
 async function loadSettings(): Promise<void> {
   try {
-    const stored = await storage.get('settings') as Record<string, unknown> | null;
+    const stored = (await storage.get('settings')) as Record<
+      string,
+      unknown
+    > | null;
     if (stored && 'youtube' in stored) {
       currentSettings = stored.youtube as YouTubeSettings;
     }

--- a/src/hooks/useBlocklist.ts
+++ b/src/hooks/useBlocklist.ts
@@ -4,7 +4,11 @@ import { sendToBackground } from '@plasmohq/messaging';
 import { parseDomainInput } from '~/lib/domain';
 import { storage } from '~/lib/storage';
 import { canAddToBlocklist } from '~/lib/license';
-import type { AppSettings, TimeLimit, NotificationSettings } from '~/types/storage';
+import type {
+  AppSettings,
+  TimeLimit,
+  NotificationSettings
+} from '~/types/storage';
 
 interface UseBlocklistOptions {
   settings: AppSettings | undefined;
@@ -18,8 +22,13 @@ interface UseBlocklistReturn {
   handleAddDomain: () => Promise<void>;
   handleRemoveDomain: (id: string) => Promise<void>;
   handleToggleDomain: (id: string, enabled: boolean) => Promise<void>;
-  handleUpdateTimeLimit: (id: string, timeLimit: TimeLimit | null) => Promise<void>;
-  handleUpdateNotifications: (notifications: NotificationSettings) => Promise<void>;
+  handleUpdateTimeLimit: (
+    id: string,
+    timeLimit: TimeLimit | null
+  ) => Promise<void>;
+  handleUpdateNotifications: (
+    notifications: NotificationSettings
+  ) => Promise<void>;
 }
 
 export function useBlocklist({

--- a/src/lib/blockService.ts
+++ b/src/lib/blockService.ts
@@ -9,8 +9,21 @@
 
 import { getSettings, getAnalytics, setAnalytics } from '~/lib/storage';
 import { extractDomain, matchesDomain } from '~/lib/domain';
-import { isWithinSchedule, getTodayKey, getCurrentHourKey, needsDailyReset, needsHourlyReset } from '~/lib/time';
-import type { AppSettings, BlockItem, Schedule, TimeLimitUsage, AnalyticsData, YouTubeSettings } from '~/types/storage';
+import {
+  isWithinSchedule,
+  getTodayKey,
+  getCurrentHourKey,
+  needsDailyReset,
+  needsHourlyReset
+} from '~/lib/time';
+import type {
+  AppSettings,
+  BlockItem,
+  Schedule,
+  TimeLimitUsage,
+  AnalyticsData,
+  YouTubeSettings
+} from '~/types/storage';
 
 // Block reason type - matches the state machine documentation
 export type BlockReason = 'always_blocked' | 'time_limit_exceeded' | null;
@@ -40,10 +53,8 @@ export async function findBlockItemForDomain(
   domain: string,
   settings?: AppSettings
 ): Promise<BlockItem | null> {
-  const s = settings ?? await getSettings();
-  return (
-    s.blockList.find((item) => matchesDomain(domain, item)) || null
-  );
+  const s = settings ?? (await getSettings());
+  return s.blockList.find((item) => matchesDomain(domain, item)) || null;
 }
 
 /**
@@ -125,7 +136,7 @@ export async function hasExceededTimeLimit(
   domain: string,
   blockItem?: BlockItem | null
 ): Promise<boolean> {
-  const item = blockItem ?? await findEnabledBlockItemForDomain(domain);
+  const item = blockItem ?? (await findEnabledBlockItemForDomain(domain));
 
   if (!item) {
     return false;
@@ -155,7 +166,7 @@ export async function getRemainingTime(
   domain: string,
   blockItem?: BlockItem | null
 ): Promise<number | null> {
-  const item = blockItem ?? await findEnabledBlockItemForDomain(domain);
+  const item = blockItem ?? (await findEnabledBlockItemForDomain(domain));
 
   if (!item || !item.timeLimit) {
     return null;
@@ -237,7 +248,9 @@ export async function shouldBlockUrl(url: string): Promise<boolean> {
  * Check if a domain should be tracked for block count
  * This validates all conditions: enabled, schedule, etc.
  */
-export async function shouldTrackBlockForDomain(domain: string): Promise<boolean> {
+export async function shouldTrackBlockForDomain(
+  domain: string
+): Promise<boolean> {
   const settings = await getSettings();
 
   // Check global pause
@@ -345,7 +358,9 @@ export async function resetExpiredUsage(): Promise<void> {
 /**
  * Get time limit info for a URL (used by popup/newtab)
  */
-export async function getTimeLimitInfo(url: string): Promise<TimeLimitInfo | null> {
+export async function getTimeLimitInfo(
+  url: string
+): Promise<TimeLimitInfo | null> {
   const domain = extractDomain(url);
   if (!domain) return null;
 
@@ -366,7 +381,9 @@ export async function getTimeLimitInfo(url: string): Promise<TimeLimitInfo | nul
   const remaining = await getRemainingTime(domain, blockItem);
   const analytics = await getAnalytics();
   const usage = analytics.timeLimitUsage[domain];
-  const effective = usage ? getEffectiveUsage(usage) : { dailyUsedSeconds: 0, hourlyUsedSeconds: 0 };
+  const effective = usage
+    ? getEffectiveUsage(usage)
+    : { dailyUsedSeconds: 0, hourlyUsedSeconds: 0 };
 
   const usedSeconds =
     blockItem.timeLimit.type === 'daily'

--- a/src/lib/password.ts
+++ b/src/lib/password.ts
@@ -13,7 +13,9 @@ export async function hashPassword(password: string): Promise<string> {
   const data = encoder.encode(password);
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  const hashHex = hashArray
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
   return hashHex;
 }
 

--- a/src/lib/report.ts
+++ b/src/lib/report.ts
@@ -132,7 +132,8 @@ export function generateWeeklyReport(
   );
 
   // Only return null if there's absolutely no data
-  const hasData = totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
+  const hasData =
+    totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
   if (!hasData && weekOffset < 0) {
     // For past weeks, return null if no data
     return null;
@@ -169,10 +170,22 @@ export function generateMonthlyReport(
   monthOffset: number = 0 // 0 = current month, -1 = last month, etc.
 ): MonthlyReport | null {
   const today = new Date();
-  const targetDate = new Date(today.getFullYear(), today.getMonth() + monthOffset, 1);
+  const targetDate = new Date(
+    today.getFullYear(),
+    today.getMonth() + monthOffset,
+    1
+  );
 
-  const monthStart = new Date(targetDate.getFullYear(), targetDate.getMonth(), 1);
-  const monthEnd = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0);
+  const monthStart = new Date(
+    targetDate.getFullYear(),
+    targetDate.getMonth(),
+    1
+  );
+  const monthEnd = new Date(
+    targetDate.getFullYear(),
+    targetDate.getMonth() + 1,
+    0
+  );
   const dates = getDatesInRange(monthStart, monthEnd);
 
   // Calculate totals
@@ -190,7 +203,8 @@ export function generateMonthlyReport(
   });
 
   // Only return null if there's absolutely no data
-  const hasData = totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
+  const hasData =
+    totalWasteTime > 0 || totalInvestTime > 0 || totalBlockCount > 0;
   if (!hasData && monthOffset < 0) {
     // For past months, return null if no data
     return null;

--- a/src/lib/settingsExport.ts
+++ b/src/lib/settingsExport.ts
@@ -19,7 +19,11 @@ import type {
   DashboardPreset,
   NotificationSettings
 } from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_VISION, DEFAULT_NOTIFICATION_SETTINGS } from '~/types/storage';
+import {
+  DEFAULT_SETTINGS,
+  DEFAULT_VISION,
+  DEFAULT_NOTIFICATION_SETTINGS
+} from '~/types/storage';
 
 // Export data version for future compatibility
 const EXPORT_VERSION = 1;
@@ -109,7 +113,12 @@ const presetSchema = displaySettingsSchema.extend({
 
 const notificationSettingsSchema = z.object({
   timeLimitEnabled: z.boolean(),
-  timeLimitMinutes: z.union([z.literal(1), z.literal(3), z.literal(5), z.literal(10)])
+  timeLimitMinutes: z.union([
+    z.literal(1),
+    z.literal(3),
+    z.literal(5),
+    z.literal(10)
+  ])
 });
 
 const exportDataSchema = z.object({
@@ -310,7 +319,10 @@ export function applyImportedSettings(
     blockList: mergedBlockList,
     schedules: mergedSchedules,
     language: data.language ?? currentSettings.language,
-    notifications: data.notifications ?? currentSettings.notifications ?? DEFAULT_NOTIFICATION_SETTINGS
+    notifications:
+      data.notifications ??
+      currentSettings.notifications ??
+      DEFAULT_NOTIFICATION_SETTINGS
   };
 
   const newVision: VisionSettings = {

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -106,7 +106,9 @@ function OptionsApp() {
     if (!prevEnabled && newEnabled) {
       // YouTube blocking enabled - create TrackedSite entry
       await incrementYouTubeBlockCount();
-      const history = (await storage.get('unblockHistory') as UnblockHistory) ?? DEFAULT_UNBLOCK_HISTORY;
+      const history =
+        ((await storage.get('unblockHistory')) as UnblockHistory) ??
+        DEFAULT_UNBLOCK_HISTORY;
       history.sites['youtube.com'] = {
         domain: 'youtube.com',
         status: 'blocked',
@@ -118,7 +120,9 @@ function OptionsApp() {
       await storage.set('unblockHistory', history);
     } else if (prevEnabled && !newEnabled) {
       // YouTube blocking disabled - mark as unblocked in history
-      const history = (await storage.get('unblockHistory') as UnblockHistory) ?? DEFAULT_UNBLOCK_HISTORY;
+      const history =
+        ((await storage.get('unblockHistory')) as UnblockHistory) ??
+        DEFAULT_UNBLOCK_HISTORY;
       const existing = history.sites['youtube.com'];
       if (existing) {
         existing.status = 'unblocked';

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -2,9 +2,23 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { sendToBackground } from '@plasmohq/messaging';
 import { useStorage } from '@plasmohq/storage/hook';
-import { Ban, Shield, TrendingUp, Clock, Lock, Eye, EyeOff, X } from 'lucide-react';
+import {
+  Ban,
+  Shield,
+  TrendingUp,
+  Clock,
+  Lock,
+  Eye,
+  EyeOff,
+  X
+} from 'lucide-react';
 
-import { GoalCard, Header, QuickBlockButton, TimeLimitBadge } from '~/components/features';
+import {
+  GoalCard,
+  Header,
+  QuickBlockButton,
+  TimeLimitBadge
+} from '~/components/features';
 import { useBackgroundStats, usePremiumStatus } from '~/hooks';
 import { extractDomain } from '~/lib/domain';
 import { getMessage, setCurrentLanguage } from '~/lib/i18n';
@@ -396,7 +410,9 @@ function PopupApp() {
                   disabled={isVerifying || !passwordInput}
                   className="flex-1 px-4 py-2 text-white bg-primary-500 rounded-lg hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
-                  {isVerifying ? getMessage('verifying') : getMessage('confirm')}
+                  {isVerifying
+                    ? getMessage('verifying')
+                    : getMessage('confirm')}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- AnalyticsTab.tsx (751行) を責務ごとに4つのサブコンポーネントに分割し、コンテナコンポーネント化 (約100行)
- AnalyticsSummary: トラッキングサイト一覧（ブロック中・解除済み）、空状態、合計時間表示
- SiteRankingList: ブロック回数ランキングTop10の表示
- AnalyticsExportBar: ヘッダーカード、CSVエクスポート、SNSシェア、画像DL、チャート表示、リセットモーダル
- AnalyticsDateFilter: 週次・月次レポートのナビゲーション（Premium/Free分岐）
- バレルエクスポート (analytics/index.ts) を作成
- 既存のpropsインターフェースに変更なし

Closes #90