### PR TITLE
refactor: StylesTabのprop drilling解消とサブコンポーネント化

### DIFF
--- a/src/components/options/StylesTab.tsx
+++ b/src/components/options/StylesTab.tsx
@@ -1,85 +1,34 @@
 import React from 'react';
-import { Check, Lock, Plus, Save, Target, Trash2 } from 'lucide-react';
 
-import { Button, Card, Input } from '~/components/ui';
-import {
-  UpgradePrompt,
-  ImageUploader,
-  FontPicker
-} from '~/components/features';
+import { useStorage } from '@plasmohq/storage/hook';
+
+import { Card } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
-import { BACKGROUND_OPTIONS, getBackgroundUrl } from '~/constants/backgrounds';
+import { getBackgroundUrl } from '~/constants/backgrounds';
 import { FONT_SIZE_PX, FONT_WEIGHT_VALUE } from '~/constants/fonts';
-import type {
-  VisionSettings,
-  DashboardPreset,
-  DashboardDisplaySettings
-} from '~/types/storage';
-import type { FontSettings } from '~/types/font';
+import { getFontDefinition } from '~/types/font';
+import { usePresets } from '~/hooks';
+import { storage } from '~/lib/storage';
+import { NewPresetModal } from '~/components/options/modals';
+import { PresetSelector, DisplaySettingsForm } from './styles';
+import type { VisionSettings } from '~/types/storage';
 import type { FeatureLimits } from '~/types/premium';
-import { DEFAULT_FONT_SETTINGS, getFontDefinition } from '~/types/font';
+import { DEFAULT_VISION } from '~/types/storage';
 
 interface StylesTabProps {
-  // Vision data
-  vision: VisionSettings | undefined;
-  draftPresets: DashboardPreset[];
-  selectedPresetId: string | null;
-  draftDisplaySettings: DashboardDisplaySettings;
-  editingPresetName: string;
-  isDirty: boolean;
-  visionSaved: boolean;
-
-  // Premium state
   isPremium: boolean;
   featureLimits: FeatureLimits;
-
-  // Preset handlers
-  onSelectPreset: (presetId: string) => void;
-  onCreatePresetClick: () => void;
-  onDeletePreset: (id: string) => void;
-  onApplyPreset: () => void;
-  onSavePreset: () => void;
-  onPresetNameChange: (name: string) => void;
-
-  // Display settings handlers
-  onGoalTextChange: (text: string) => void;
-  onGoalSubTextChange: (text: string) => void;
-  onTextColorChange: (color: string) => void;
-  onBackgroundTypeChange: (type: 'image' | 'color') => void;
-  onBackgroundChange: (bgId: string) => void;
-  onBackgroundColorChange: (color: string) => void;
-  onCustomBackgroundChange: (dataUrl: string | null) => void;
-  onFontSettingsChange: (fontSettings: FontSettings) => void;
 }
 
-export function StylesTab({
-  vision,
-  draftPresets,
-  selectedPresetId,
-  draftDisplaySettings,
-  editingPresetName,
-  isDirty,
-  visionSaved,
-  isPremium,
-  featureLimits,
-  onSelectPreset,
-  onCreatePresetClick,
-  onDeletePreset,
-  onApplyPreset,
-  onSavePreset,
-  onPresetNameChange,
-  onGoalTextChange,
-  onGoalSubTextChange,
-  onTextColorChange,
-  onBackgroundTypeChange,
-  onBackgroundChange,
-  onBackgroundColorChange,
-  onCustomBackgroundChange,
-  onFontSettingsChange
-}: StylesTabProps) {
-  const selectedPreset = draftPresets.find((p) => p.id === selectedPresetId);
+export function StylesTab({ isPremium, featureLimits }: StylesTabProps) {
+  const [vision, setVision] = useStorage<VisionSettings>(
+    { key: 'vision', instance: storage },
+    DEFAULT_VISION
+  );
 
-  // Determine if we're in editing mode
+  const presets = usePresets({ vision, setVision });
+
+  const { draftDisplaySettings, selectedPresetId } = presets;
   const isEditing = !!selectedPresetId;
 
   return (
@@ -88,369 +37,14 @@ export function StylesTab({
     >
       {/* Left Column - Settings */}
       <div className={`${isEditing ? 'lg:col-span-3' : ''} space-y-6`}>
-        {/* Preset Selector */}
-        <Card>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">
-              {getMessage('dashboardPresets')}
-            </h2>
-            {!isPremium && (
-              <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
-                {getMessage('premium')}
-              </span>
-            )}
-          </div>
+        <PresetSelector
+          presets={presets}
+          vision={vision}
+          isPremium={isPremium}
+          featureLimits={featureLimits}
+        />
 
-          {/* Empty state or Preset tabs */}
-          {draftPresets.length === 0 ? (
-            <div className="text-center py-6">
-              <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-3">
-                <Target className="w-6 h-6 text-gray-400" />
-              </div>
-              <p className="text-sm font-medium text-gray-900 mb-1">
-                {getMessage('noPresetsTitle')}
-              </p>
-              <p className="text-xs text-gray-500 mb-4">
-                {getMessage('noPresetsDescription')}
-              </p>
-              <Button onClick={onCreatePresetClick} size="sm">
-                <Plus className="w-4 h-4" />
-                {getMessage('createFirstPreset')}
-              </Button>
-            </div>
-          ) : (
-            <>
-              <div className="flex flex-wrap gap-2">
-                {/* Preset buttons */}
-                {draftPresets.map((preset, index) => {
-                  const isActive = vision?.activePresetId === preset.id;
-                  const isSelected = selectedPresetId === preset.id;
-                  const isLocked =
-                    !isPremium && index >= featureLimits.maxPresets;
-                  return (
-                    <button
-                      key={preset.id}
-                      onClick={() => !isLocked && onSelectPreset(preset.id)}
-                      disabled={isLocked}
-                      title={
-                        isLocked ? getMessage('upgradeToUsePreset') : undefined
-                      }
-                      className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 ${
-                        isLocked
-                          ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
-                          : isSelected
-                            ? 'bg-blue-500 text-white'
-                            : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                      }`}
-                    >
-                      {isLocked && (
-                        <Lock className="w-3.5 h-3.5 text-gray-400" />
-                      )}
-                      {!isLocked && isActive && (
-                        <Check
-                          className={`w-3.5 h-3.5 ${
-                            isSelected ? 'text-white' : 'text-green-600'
-                          }`}
-                        />
-                      )}
-                      {preset.name}
-                    </button>
-                  );
-                })}
-
-                {/* New preset button */}
-                {draftPresets.length < featureLimits.maxPresets && (
-                  <button
-                    onClick={onCreatePresetClick}
-                    className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors flex items-center gap-1"
-                  >
-                    <Plus className="w-4 h-4" />
-                    {getMessage('newPreset')}
-                  </button>
-                )}
-              </div>
-
-              {!isPremium &&
-                draftPresets.length >= featureLimits.maxPresets && (
-                  <p className="text-xs text-amber-600 mt-2">
-                    {getMessage(
-                      'maxPresetsReached',
-                      String(featureLimits.maxPresets)
-                    )}
-                  </p>
-                )}
-
-              {/* Warning if active preset is locked */}
-              {!isPremium &&
-                vision?.activePresetId &&
-                draftPresets.findIndex((p) => p.id === vision.activePresetId) >=
-                  featureLimits.maxPresets && (
-                  <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg mt-2">
-                    <Lock className="w-3.5 h-3.5 flex-shrink-0" />
-                    <span>{getMessage('lockedPresetWarning')}</span>
-                  </div>
-                )}
-            </>
-          )}
-        </Card>
-
-        {/* Editing indicator and action buttons */}
-        {selectedPreset && (
-          <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
-            <div className="flex items-center gap-2">
-              <Target className="w-5 h-5 text-blue-600" />
-              <span className="text-sm font-medium text-blue-900">
-                {getMessage('editingPreset', selectedPreset.name)}
-              </span>
-              {isDirty && (
-                <span className="text-xs text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full">
-                  {getMessage('unsavedChanges')}
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onDeletePreset(selectedPreset.id)}
-              >
-                <Trash2 className="w-4 h-4 text-red-500" />
-              </Button>
-              {vision?.activePresetId === selectedPresetId ? (
-                <span className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-green-700 bg-green-100 rounded-lg">
-                  <Check className="w-4 h-4" />
-                  {getMessage('activePreset')}
-                </span>
-              ) : (
-                <Button variant="secondary" onClick={onApplyPreset} size="sm">
-                  <Check className="w-4 h-4" />
-                  {getMessage('applyPreset')}
-                </Button>
-              )}
-              <Button
-                onClick={onSavePreset}
-                disabled={
-                  !draftDisplaySettings.goalText.trim() ||
-                  !editingPresetName.trim() ||
-                  !isDirty
-                }
-                size="sm"
-              >
-                <Save className="w-4 h-4" />
-                {visionSaved ? getMessage('saved') : getMessage('save')}
-              </Button>
-            </div>
-          </div>
-        )}
-
-        {/* Goal Settings - Only shown when editing a preset */}
-        {selectedPresetId && (
-          <>
-            <Card>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                <div className="flex items-center gap-2">
-                  <Target className="w-5 h-5 text-primary-600" />
-                  {getMessage('goalSettings')}
-                </div>
-              </h2>
-              <div className="space-y-4">
-                {/* Preset Name (only when editing a preset) */}
-                {selectedPreset && (
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 mb-1">
-                      {getMessage('presetName')}
-                    </label>
-                    <Input
-                      value={editingPresetName}
-                      onChange={onPresetNameChange}
-                      placeholder={getMessage('presetNamePlaceholder')}
-                    />
-                  </div>
-                )}
-
-                {/* Main Goal */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    {getMessage('yourGoal')}
-                  </label>
-                  <Input
-                    value={draftDisplaySettings.goalText}
-                    onChange={onGoalTextChange}
-                    placeholder={getMessage('goalPlaceholder')}
-                  />
-                </div>
-
-                {/* Sub-message */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    {getMessage('goalSubText')}
-                  </label>
-                  <textarea
-                    value={draftDisplaySettings.goalSubText}
-                    onChange={(e) => onGoalSubTextChange(e.target.value)}
-                    placeholder={getMessage('goalSubTextPlaceholder')}
-                    maxLength={100}
-                    rows={3}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-sm"
-                  />
-                  <p className="text-xs text-gray-400 mt-1 text-right">
-                    {draftDisplaySettings.goalSubText.length} / 100
-                  </p>
-                </div>
-
-                {/* Text Color */}
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    {getMessage('textColor')}
-                  </label>
-                  <div className="flex items-center gap-4">
-                    <input
-                      type="color"
-                      value={draftDisplaySettings.textColor}
-                      onChange={(e) => onTextColorChange(e.target.value)}
-                      className="w-10 h-10 rounded-lg cursor-pointer border border-gray-300"
-                    />
-                    <input
-                      type="text"
-                      value={draftDisplaySettings.textColor}
-                      onChange={(e) => onTextColorChange(e.target.value)}
-                      className="px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono w-28"
-                      placeholder="#ffffff"
-                    />
-                  </div>
-                </div>
-              </div>
-            </Card>
-
-            {/* Background Settings */}
-            <Card>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                {getMessage('dashboardBackground')}
-              </h2>
-
-              {/* Background Type Toggle */}
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  {getMessage('backgroundType')}
-                </label>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => onBackgroundTypeChange('image')}
-                    className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      (draftDisplaySettings.backgroundType || 'image') ===
-                      'image'
-                        ? 'bg-blue-500 text-white'
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                    }`}
-                  >
-                    {getMessage('backgroundTypeImage')}
-                  </button>
-                  <button
-                    onClick={() => onBackgroundTypeChange('color')}
-                    className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                      draftDisplaySettings.backgroundType === 'color'
-                        ? 'bg-blue-500 text-white'
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                    }`}
-                  >
-                    {getMessage('backgroundTypeColor')}
-                  </button>
-                </div>
-              </div>
-
-              {/* Image Selection */}
-              {(draftDisplaySettings.backgroundType || 'image') === 'image' && (
-                <div className="grid grid-cols-3 gap-4">
-                  {BACKGROUND_OPTIONS.map((bg) => (
-                    <button
-                      key={bg.id}
-                      onClick={() => onBackgroundChange(bg.id)}
-                      className={`relative aspect-video rounded-lg overflow-hidden border-2 transition-colors ${
-                        draftDisplaySettings.backgroundImage === bg.id
-                          ? 'border-blue-500'
-                          : 'border-gray-200 hover:border-gray-300'
-                      }`}
-                    >
-                      <img
-                        src={getBackgroundUrl(bg.id)}
-                        alt={bg.name}
-                        className="w-full h-full object-cover"
-                      />
-                      <span className="absolute bottom-1 left-1 text-xs bg-black/50 text-white px-2 py-0.5 rounded">
-                        {bg.name}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              )}
-
-              {/* Color Selection */}
-              {draftDisplaySettings.backgroundType === 'color' && (
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    {getMessage('selectColor')}
-                  </label>
-                  <div className="flex items-center gap-4">
-                    <input
-                      type="color"
-                      value={draftDisplaySettings.backgroundColor}
-                      onChange={(e) => onBackgroundColorChange(e.target.value)}
-                      className="w-12 h-12 rounded-lg cursor-pointer border border-gray-300"
-                    />
-                    <input
-                      type="text"
-                      value={draftDisplaySettings.backgroundColor}
-                      onChange={(e) => onBackgroundColorChange(e.target.value)}
-                      className="px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono w-28"
-                      placeholder="#1a1a2e"
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* Custom Background Upload (Premium) */}
-              <div className="mt-6 pt-4 border-t border-gray-200">
-                <div className="flex items-center justify-between mb-3">
-                  <h3 className="text-sm font-medium text-gray-900">
-                    {getMessage('customBackground')}
-                  </h3>
-                  {!isPremium && (
-                    <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
-                      {getMessage('premium')}
-                    </span>
-                  )}
-                </div>
-                {isPremium ? (
-                  <ImageUploader
-                    value={draftDisplaySettings.customBackgroundData || null}
-                    onChange={onCustomBackgroundChange}
-                  />
-                ) : (
-                  <UpgradePrompt
-                    variant="inline"
-                    limitType="customBackground"
-                  />
-                )}
-              </div>
-            </Card>
-
-            {/* Font Customization */}
-            <Card>
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                {getMessage('fontCustomization')}
-              </h2>
-              <FontPicker
-                value={
-                  draftDisplaySettings.fontSettings || DEFAULT_FONT_SETTINGS
-                }
-                onChange={onFontSettingsChange}
-                previewText={
-                  draftDisplaySettings.goalText || getMessage('goalPlaceholder')
-                }
-              />
-            </Card>
-          </>
-        )}
+        <DisplaySettingsForm presets={presets} isPremium={isPremium} />
       </div>
 
       {/* Right Column - Preview (sticky) - Only shown when editing */}
@@ -465,7 +59,9 @@ export function StylesTab({
                 className="relative aspect-video rounded-lg overflow-hidden"
                 style={
                   draftDisplaySettings.backgroundType === 'color'
-                    ? { backgroundColor: draftDisplaySettings.backgroundColor }
+                    ? {
+                        backgroundColor: draftDisplaySettings.backgroundColor
+                      }
                     : draftDisplaySettings.customBackgroundData
                       ? {
                           backgroundImage: `url(${draftDisplaySettings.customBackgroundData})`,
@@ -536,6 +132,15 @@ export function StylesTab({
           </div>
         </div>
       )}
+
+      {/* New Preset Modal */}
+      <NewPresetModal
+        isOpen={presets.showSavePresetModal}
+        onClose={() => presets.setShowSavePresetModal(false)}
+        presetName={presets.presetName}
+        onPresetNameChange={presets.setPresetName}
+        onCreate={presets.handleCreatePreset}
+      />
     </div>
   );
 }

--- a/src/components/options/styles/DisplaySettingsForm.tsx
+++ b/src/components/options/styles/DisplaySettingsForm.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { Target } from 'lucide-react';
+
+import { Card, Input } from '~/components/ui';
+import {
+  UpgradePrompt,
+  ImageUploader,
+  FontPicker
+} from '~/components/features';
+import { getMessage } from '~/lib/i18n';
+import { BACKGROUND_OPTIONS, getBackgroundUrl } from '~/constants/backgrounds';
+import type { DashboardPreset } from '~/types/storage';
+import { DEFAULT_FONT_SETTINGS } from '~/types/font';
+import type { UsePresetsReturn } from '~/hooks/usePresets';
+
+interface DisplaySettingsFormProps {
+  presets: UsePresetsReturn;
+  isPremium: boolean;
+}
+
+export function DisplaySettingsForm({
+  presets,
+  isPremium
+}: DisplaySettingsFormProps) {
+  const {
+    draftDisplaySettings,
+    selectedPresetId,
+    draftPresets,
+    editingPresetName,
+    handlePresetNameChange,
+    handleGoalTextChange,
+    handleGoalSubTextChange,
+    handleTextColorChange,
+    handleBackgroundTypeChange,
+    handleBackgroundChange,
+    handleBackgroundColorChange,
+    handleCustomBackgroundChange,
+    handleFontSettingsChange
+  } = presets;
+
+  const selectedPreset: DashboardPreset | undefined = draftPresets.find(
+    (p) => p.id === selectedPresetId
+  );
+
+  if (!selectedPresetId) {
+    return null;
+  }
+
+  return (
+    <>
+      {/* Goal Settings */}
+      <Card>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="flex items-center gap-2">
+            <Target className="w-5 h-5 text-primary-600" />
+            {getMessage('goalSettings')}
+          </div>
+        </h2>
+        <div className="space-y-4">
+          {/* Preset Name (only when editing a preset) */}
+          {selectedPreset && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                {getMessage('presetName')}
+              </label>
+              <Input
+                value={editingPresetName}
+                onChange={handlePresetNameChange}
+                placeholder={getMessage('presetNamePlaceholder')}
+              />
+            </div>
+          )}
+
+          {/* Main Goal */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {getMessage('yourGoal')}
+            </label>
+            <Input
+              value={draftDisplaySettings.goalText}
+              onChange={handleGoalTextChange}
+              placeholder={getMessage('goalPlaceholder')}
+            />
+          </div>
+
+          {/* Sub-message */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              {getMessage('goalSubText')}
+            </label>
+            <textarea
+              value={draftDisplaySettings.goalSubText}
+              onChange={(e) => handleGoalSubTextChange(e.target.value)}
+              placeholder={getMessage('goalSubTextPlaceholder')}
+              maxLength={100}
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-sm"
+            />
+            <p className="text-xs text-gray-400 mt-1 text-right">
+              {draftDisplaySettings.goalSubText.length} / 100
+            </p>
+          </div>
+
+          {/* Text Color */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {getMessage('textColor')}
+            </label>
+            <div className="flex items-center gap-4">
+              <input
+                type="color"
+                value={draftDisplaySettings.textColor}
+                onChange={(e) => handleTextColorChange(e.target.value)}
+                className="w-10 h-10 rounded-lg cursor-pointer border border-gray-300"
+              />
+              <input
+                type="text"
+                value={draftDisplaySettings.textColor}
+                onChange={(e) => handleTextColorChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono w-28"
+                placeholder="#ffffff"
+              />
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      {/* Background Settings */}
+      <Card>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          {getMessage('dashboardBackground')}
+        </h2>
+
+        {/* Background Type Toggle */}
+        <div className="mb-4">
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            {getMessage('backgroundType')}
+          </label>
+          <div className="flex gap-2">
+            <button
+              onClick={() => handleBackgroundTypeChange('image')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                (draftDisplaySettings.backgroundType || 'image') === 'image'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {getMessage('backgroundTypeImage')}
+            </button>
+            <button
+              onClick={() => handleBackgroundTypeChange('color')}
+              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                draftDisplaySettings.backgroundType === 'color'
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {getMessage('backgroundTypeColor')}
+            </button>
+          </div>
+        </div>
+
+        {/* Image Selection */}
+        {(draftDisplaySettings.backgroundType || 'image') === 'image' && (
+          <div className="grid grid-cols-3 gap-4">
+            {BACKGROUND_OPTIONS.map((bg) => (
+              <button
+                key={bg.id}
+                onClick={() => handleBackgroundChange(bg.id)}
+                className={`relative aspect-video rounded-lg overflow-hidden border-2 transition-colors ${
+                  draftDisplaySettings.backgroundImage === bg.id
+                    ? 'border-blue-500'
+                    : 'border-gray-200 hover:border-gray-300'
+                }`}
+              >
+                <img
+                  src={getBackgroundUrl(bg.id)}
+                  alt={bg.name}
+                  className="w-full h-full object-cover"
+                />
+                <span className="absolute bottom-1 left-1 text-xs bg-black/50 text-white px-2 py-0.5 rounded">
+                  {bg.name}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Color Selection */}
+        {draftDisplaySettings.backgroundType === 'color' && (
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {getMessage('selectColor')}
+            </label>
+            <div className="flex items-center gap-4">
+              <input
+                type="color"
+                value={draftDisplaySettings.backgroundColor}
+                onChange={(e) => handleBackgroundColorChange(e.target.value)}
+                className="w-12 h-12 rounded-lg cursor-pointer border border-gray-300"
+              />
+              <input
+                type="text"
+                value={draftDisplaySettings.backgroundColor}
+                onChange={(e) => handleBackgroundColorChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono w-28"
+                placeholder="#1a1a2e"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Custom Background Upload (Premium) */}
+        <div className="mt-6 pt-4 border-t border-gray-200">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-medium text-gray-900">
+              {getMessage('customBackground')}
+            </h3>
+            {!isPremium && (
+              <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
+                {getMessage('premium')}
+              </span>
+            )}
+          </div>
+          {isPremium ? (
+            <ImageUploader
+              value={draftDisplaySettings.customBackgroundData || null}
+              onChange={handleCustomBackgroundChange}
+            />
+          ) : (
+            <UpgradePrompt variant="inline" limitType="customBackground" />
+          )}
+        </div>
+      </Card>
+
+      {/* Font Customization */}
+      <Card>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          {getMessage('fontCustomization')}
+        </h2>
+        <FontPicker
+          value={draftDisplaySettings.fontSettings || DEFAULT_FONT_SETTINGS}
+          onChange={handleFontSettingsChange}
+          previewText={
+            draftDisplaySettings.goalText || getMessage('goalPlaceholder')
+          }
+        />
+      </Card>
+    </>
+  );
+}

--- a/src/components/options/styles/PresetSelector.tsx
+++ b/src/components/options/styles/PresetSelector.tsx
@@ -1,0 +1,271 @@
+import React from 'react';
+import { Check, Lock, Plus, Save, Target, Trash2 } from 'lucide-react';
+
+import { Button, Card } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import type { VisionSettings, DashboardDisplaySettings } from '~/types/storage';
+import type { FeatureLimits } from '~/types/premium';
+import type { UsePresetsReturn } from '~/hooks/usePresets';
+
+interface PresetSelectorProps {
+  presets: UsePresetsReturn;
+  vision: VisionSettings | undefined;
+  isPremium: boolean;
+  featureLimits: FeatureLimits;
+}
+
+export function PresetSelector({
+  presets,
+  vision,
+  isPremium,
+  featureLimits
+}: PresetSelectorProps) {
+  const {
+    draftPresets,
+    selectedPresetId,
+    draftDisplaySettings,
+    editingPresetName,
+    isDirty,
+    visionSaved,
+    setShowSavePresetModal,
+    handleSelectPreset,
+    handleDeletePreset,
+    handleApplyPreset,
+    handleSaveSelectedPreset
+  } = presets;
+
+  const selectedPreset = draftPresets.find((p) => p.id === selectedPresetId);
+
+  return (
+    <>
+      {/* Preset Selector */}
+      <Card>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {getMessage('dashboardPresets')}
+          </h2>
+          {!isPremium && (
+            <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
+              {getMessage('premium')}
+            </span>
+          )}
+        </div>
+
+        {/* Empty state or Preset tabs */}
+        {draftPresets.length === 0 ? (
+          <EmptyState onCreateClick={() => setShowSavePresetModal(true)} />
+        ) : (
+          <>
+            <PresetButtons
+              draftPresets={draftPresets}
+              vision={vision}
+              selectedPresetId={selectedPresetId}
+              isPremium={isPremium}
+              featureLimits={featureLimits}
+              onSelectPreset={handleSelectPreset}
+              onCreateClick={() => setShowSavePresetModal(true)}
+            />
+
+            {!isPremium && draftPresets.length >= featureLimits.maxPresets && (
+              <p className="text-xs text-amber-600 mt-2">
+                {getMessage(
+                  'maxPresetsReached',
+                  String(featureLimits.maxPresets)
+                )}
+              </p>
+            )}
+
+            {/* Warning if active preset is locked */}
+            {!isPremium &&
+              vision?.activePresetId &&
+              draftPresets.findIndex((p) => p.id === vision.activePresetId) >=
+                featureLimits.maxPresets && (
+                <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg mt-2">
+                  <Lock className="w-3.5 h-3.5 flex-shrink-0" />
+                  <span>{getMessage('lockedPresetWarning')}</span>
+                </div>
+              )}
+          </>
+        )}
+      </Card>
+
+      {/* Editing indicator and action buttons */}
+      {selectedPreset && (
+        <EditingIndicator
+          selectedPreset={selectedPreset}
+          selectedPresetId={selectedPresetId}
+          isDirty={isDirty}
+          visionSaved={visionSaved}
+          draftDisplaySettings={draftDisplaySettings}
+          editingPresetName={editingPresetName}
+          vision={vision}
+          onDeletePreset={handleDeletePreset}
+          onApplyPreset={handleApplyPreset}
+          onSavePreset={handleSaveSelectedPreset}
+        />
+      )}
+    </>
+  );
+}
+
+// --- Internal sub-components ---
+
+function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
+  return (
+    <div className="text-center py-6">
+      <div className="w-12 h-12 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-3">
+        <Target className="w-6 h-6 text-gray-400" />
+      </div>
+      <p className="text-sm font-medium text-gray-900 mb-1">
+        {getMessage('noPresetsTitle')}
+      </p>
+      <p className="text-xs text-gray-500 mb-4">
+        {getMessage('noPresetsDescription')}
+      </p>
+      <Button onClick={onCreateClick} size="sm">
+        <Plus className="w-4 h-4" />
+        {getMessage('createFirstPreset')}
+      </Button>
+    </div>
+  );
+}
+
+interface PresetButtonsProps {
+  draftPresets: UsePresetsReturn['draftPresets'];
+  vision: VisionSettings | undefined;
+  selectedPresetId: string | null;
+  isPremium: boolean;
+  featureLimits: FeatureLimits;
+  onSelectPreset: (presetId: string) => void;
+  onCreateClick: () => void;
+}
+
+function PresetButtons({
+  draftPresets,
+  vision,
+  selectedPresetId,
+  isPremium,
+  featureLimits,
+  onSelectPreset,
+  onCreateClick
+}: PresetButtonsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {draftPresets.map((preset, index) => {
+        const isActive = vision?.activePresetId === preset.id;
+        const isSelected = selectedPresetId === preset.id;
+        const isLocked = !isPremium && index >= featureLimits.maxPresets;
+        return (
+          <button
+            key={preset.id}
+            onClick={() => !isLocked && onSelectPreset(preset.id)}
+            disabled={isLocked}
+            title={isLocked ? getMessage('upgradeToUsePreset') : undefined}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5 ${
+              isLocked
+                ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+                : isSelected
+                  ? 'bg-blue-500 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            {isLocked && <Lock className="w-3.5 h-3.5 text-gray-400" />}
+            {!isLocked && isActive && (
+              <Check
+                className={`w-3.5 h-3.5 ${
+                  isSelected ? 'text-white' : 'text-green-600'
+                }`}
+              />
+            )}
+            {preset.name}
+          </button>
+        );
+      })}
+
+      {/* New preset button */}
+      {draftPresets.length < featureLimits.maxPresets && (
+        <button
+          onClick={onCreateClick}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors flex items-center gap-1"
+        >
+          <Plus className="w-4 h-4" />
+          {getMessage('newPreset')}
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface EditingIndicatorProps {
+  selectedPreset: { id: string; name: string };
+  selectedPresetId: string | null;
+  isDirty: boolean;
+  visionSaved: boolean;
+  draftDisplaySettings: DashboardDisplaySettings;
+  editingPresetName: string;
+  vision: VisionSettings | undefined;
+  onDeletePreset: (id: string) => Promise<void>;
+  onApplyPreset: () => Promise<void>;
+  onSavePreset: () => Promise<void>;
+}
+
+function EditingIndicator({
+  selectedPreset,
+  selectedPresetId,
+  isDirty,
+  visionSaved,
+  draftDisplaySettings,
+  editingPresetName,
+  vision,
+  onDeletePreset,
+  onApplyPreset,
+  onSavePreset
+}: EditingIndicatorProps) {
+  return (
+    <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+      <div className="flex items-center gap-2">
+        <Target className="w-5 h-5 text-blue-600" />
+        <span className="text-sm font-medium text-blue-900">
+          {getMessage('editingPreset', selectedPreset.name)}
+        </span>
+        {isDirty && (
+          <span className="text-xs text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full">
+            {getMessage('unsavedChanges')}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onDeletePreset(selectedPreset.id)}
+        >
+          <Trash2 className="w-4 h-4 text-red-500" />
+        </Button>
+        {vision?.activePresetId === selectedPresetId ? (
+          <span className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-green-700 bg-green-100 rounded-lg">
+            <Check className="w-4 h-4" />
+            {getMessage('activePreset')}
+          </span>
+        ) : (
+          <Button variant="secondary" onClick={onApplyPreset} size="sm">
+            <Check className="w-4 h-4" />
+            {getMessage('applyPreset')}
+          </Button>
+        )}
+        <Button
+          onClick={onSavePreset}
+          disabled={
+            !draftDisplaySettings.goalText.trim() ||
+            !editingPresetName.trim() ||
+            !isDirty
+          }
+          size="sm"
+        >
+          <Save className="w-4 h-4" />
+          {visionSaved ? getMessage('saved') : getMessage('save')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/options/styles/index.ts
+++ b/src/components/options/styles/index.ts
@@ -1,0 +1,2 @@
+export { PresetSelector } from './PresetSelector';
+export { DisplaySettingsForm } from './DisplaySettingsForm';

--- a/src/hooks/usePresets.ts
+++ b/src/hooks/usePresets.ts
@@ -17,7 +17,7 @@ interface UsePresetsOptions {
   setVision: (vision: VisionSettings) => void;
 }
 
-interface UsePresetsReturn {
+export interface UsePresetsReturn {
   // State
   draftDisplaySettings: DashboardDisplaySettings;
   draftPresets: DashboardPreset[];

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -18,7 +18,6 @@ import {
   AnalyticsTab,
   PremiumTab,
   HelpTab,
-  NewPresetModal,
   ScheduleModal
 } from '~/components/options';
 import {
@@ -26,7 +25,6 @@ import {
   useBlocklist,
   useLicense,
   useSchedules,
-  usePresets,
   usePremiumStatus
 } from '~/hooks';
 import { getMessage, setCurrentLanguage } from '~/lib/i18n';
@@ -83,7 +81,6 @@ function OptionsApp() {
   const blocklist = useBlocklist({ settings, setSettings });
   const license = useLicense();
   const schedules = useSchedules({ settings, setSettings });
-  const presets = usePresets({ vision, setVision });
 
   // Sync language setting with i18n module
   useEffect(() => {
@@ -209,31 +206,7 @@ function OptionsApp() {
 
         {/* Styles Tab */}
         {activeTab === TABS.STYLES && (
-          <StylesTab
-            vision={vision}
-            draftPresets={presets.draftPresets}
-            selectedPresetId={presets.selectedPresetId}
-            draftDisplaySettings={presets.draftDisplaySettings}
-            editingPresetName={presets.editingPresetName}
-            isDirty={presets.isDirty}
-            visionSaved={presets.visionSaved}
-            isPremium={isPremium}
-            featureLimits={featureLimits}
-            onSelectPreset={presets.handleSelectPreset}
-            onCreatePresetClick={() => presets.setShowSavePresetModal(true)}
-            onDeletePreset={presets.handleDeletePreset}
-            onApplyPreset={presets.handleApplyPreset}
-            onSavePreset={presets.handleSaveSelectedPreset}
-            onPresetNameChange={presets.handlePresetNameChange}
-            onGoalTextChange={presets.handleGoalTextChange}
-            onGoalSubTextChange={presets.handleGoalSubTextChange}
-            onTextColorChange={presets.handleTextColorChange}
-            onBackgroundTypeChange={presets.handleBackgroundTypeChange}
-            onBackgroundChange={presets.handleBackgroundChange}
-            onBackgroundColorChange={presets.handleBackgroundColorChange}
-            onCustomBackgroundChange={presets.handleCustomBackgroundChange}
-            onFontSettingsChange={presets.handleFontSettingsChange}
-          />
+          <StylesTab isPremium={isPremium} featureLimits={featureLimits} />
         )}
 
         {/* Block List Tab */}
@@ -309,15 +282,6 @@ function OptionsApp() {
           />
         )}
       </main>
-
-      {/* New Preset Modal */}
-      <NewPresetModal
-        isOpen={presets.showSavePresetModal}
-        onClose={() => presets.setShowSavePresetModal(false)}
-        presetName={presets.presetName}
-        onPresetNameChange={presets.setPresetName}
-        onCreate={presets.handleCreatePreset}
-      />
 
       {/* Schedule Modal */}
       <ScheduleModal


### PR DESCRIPTION
## Summary
- StylesTab.tsxのprop drilling(20+ props)を解消し、2 propsに削減
- PresetSelector / DisplaySettingsForm をサブコンポーネントとしてstyles/ディレクトリに抽出
- StylesTab内でusePresetsフックを直接呼び出す構造に変更
- NewPresetModalをoptions.tsxからStylesTabに移動
- StylesTab: 541行 -> 146行に削減

## Changes
- **New:** `src/components/options/styles/PresetSelector.tsx` - プリセット選択UI
- **New:** `src/components/options/styles/DisplaySettingsForm.tsx` - 表示設定フォーム
- **New:** `src/components/options/styles/index.ts` - barrel export
- **Modified:** `src/components/options/StylesTab.tsx` - usePresetsを内部で呼び出し、サブコンポーネントに分割
- **Modified:** `src/options.tsx` - usePresets/NewPresetModal関連のコード削除
- **Modified:** `src/hooks/usePresets.ts` - UsePresetsReturn型をexport

## Test plan
- [ ] プリセット作成・選択・削除が正常動作する
- [ ] 表示設定（ゴールテキスト、背景、フォント）の変更が反映される
- [ ] プレビューがリアルタイムで更新される
- [ ] Premium/Free制限が正しく適用される
- [ ] npm run build が成功する

Closes #93
