### PR TITLE
refactor: メッセージハンドラのasキャストをZodバリデーションに置換

### DIFF
--- a/src/background/messages/get-remaining-time.ts
+++ b/src/background/messages/get-remaining-time.ts
@@ -1,15 +1,18 @@
 import type { PlasmoMessaging } from '@plasmohq/messaging';
 
+import { GetRemainingTimeBodySchema } from '~/types/messageSchemas';
 import { getTimeLimitInfoForUrl } from '../time-limit';
 
 // Message handler for getting remaining time for a URL
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-  const { url } = req.body as { url: string };
+  const parsed = GetRemainingTimeBodySchema.safeParse(req.body);
 
-  if (!url || typeof url !== 'string') {
+  if (!parsed.success) {
     res.send({ success: false, error: 'Invalid URL' });
     return;
   }
+
+  const { url } = parsed.data;
 
   const info = await getTimeLimitInfoForUrl(url);
 

--- a/src/background/messages/tracker-heartbeat.ts
+++ b/src/background/messages/tracker-heartbeat.ts
@@ -15,6 +15,7 @@ import { recordTimeLimitUsage, findBlockItemForDomain } from '../time-limit';
 import { checkTimeLimitNotification } from '../notifications';
 import { recordYouTubeTimeLimitUsage } from '~/lib/youtubeBlockService';
 import { checkYouTubeTimeLimitNotification } from '../notifications';
+import { TrackerHeartbeatBodySchema } from '~/types/messageSchemas';
 
 // Track active pages and their last heartbeat
 interface ActivePage {
@@ -181,40 +182,16 @@ async function recordTime(domain: string, seconds: number): Promise<void> {
   await setAnalytics(analytics);
 }
 
-// Valid status values
-const VALID_STATUSES = ['active', 'inactive', 'heartbeat'] as const;
-
 // Message handler
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-  const { url, status, timestamp } = req.body as {
-    url: string;
-    status: 'active' | 'inactive' | 'heartbeat';
-    timestamp: number;
-  };
+  const parsed = TrackerHeartbeatBodySchema.safeParse(req.body);
 
-  // Validate url
-  if (!url || typeof url !== 'string' || url.length > 2048) {
-    res.send({ success: false, error: 'Invalid URL' });
+  if (!parsed.success) {
+    res.send({ success: false, error: 'Invalid request body' });
     return;
   }
 
-  // Validate status
-  if (!status || !VALID_STATUSES.includes(status)) {
-    res.send({ success: false, error: 'Invalid status' });
-    return;
-  }
-
-  // Validate timestamp if provided
-  if (timestamp !== undefined) {
-    if (
-      typeof timestamp !== 'number' ||
-      !Number.isFinite(timestamp) ||
-      timestamp < 0
-    ) {
-      res.send({ success: false, error: 'Invalid timestamp' });
-      return;
-    }
-  }
+  const { url, status, timestamp } = parsed.data;
 
   // Extract domain from URL
   const domain = extractDomain(url);

--- a/src/background/messages/update-time-limit.ts
+++ b/src/background/messages/update-time-limit.ts
@@ -2,19 +2,18 @@ import type { PlasmoMessaging } from '@plasmohq/messaging';
 
 import { getSettings, setSettings } from '~/lib/storage';
 import { updateBlockRules } from '../blocker';
-import type { TimeLimit } from '~/types/storage';
+import { UpdateTimeLimitBodySchema } from '~/types/messageSchemas';
 
 // Message handler for updating time limit for a blocked site
 const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
-  const { id, timeLimit } = req.body as {
-    id: string;
-    timeLimit: TimeLimit | null;
-  };
+  const parsed = UpdateTimeLimitBodySchema.safeParse(req.body);
 
-  if (!id || typeof id !== 'string') {
-    res.send({ success: false, error: 'Invalid ID' });
+  if (!parsed.success) {
+    res.send({ success: false, error: 'Invalid request body' });
     return;
   }
+
+  const { id, timeLimit } = parsed.data;
 
   try {
     const settings = await getSettings();

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -278,9 +278,10 @@ async function loadTimeLimitState(): Promise<void> {
 // Load settings from storage
 async function loadSettings(): Promise<void> {
   try {
-    const stored = await storage.get('settings');
-    if (stored && typeof stored === 'object' && 'youtube' in stored) {
-      const raw = (stored as Record<string, unknown>).youtube;
+    const stored =
+      await storage.get<Record<string, unknown> | null>('settings');
+    if (stored && 'youtube' in stored) {
+      const raw = stored.youtube;
       const parsed = YouTubeSettingsSchema.safeParse(raw);
       if (parsed.success) {
         currentSettings = parsed.data;

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -2,12 +2,12 @@ import type { PlasmoCSConfig } from 'plasmo';
 
 import { Storage } from '@plasmohq/storage';
 
-import type {
-  YouTubeSettings,
-  TimeLimitUsage,
-  AnalyticsData
-} from '~/types/storage';
+import type { YouTubeSettings, TimeLimitUsage } from '~/types/storage';
 import { DEFAULT_YOUTUBE_SETTINGS } from '~/types/storage';
+import {
+  AnalyticsDataSchema,
+  YouTubeSettingsSchema
+} from '~/types/messageSchemas';
 
 // Run only on YouTube
 export const config: PlasmoCSConfig = {
@@ -262,10 +262,13 @@ function setupObserver(): void {
 // Load analytics to check time limit
 async function loadTimeLimitState(): Promise<void> {
   try {
-    const analytics = (await storage.get('analytics')) as
-      | AnalyticsData
-      | undefined;
-    const usage = analytics?.timeLimitUsage?.['youtube.com'];
+    const raw = await storage.get('analytics');
+    const parsed = AnalyticsDataSchema.safeParse(raw);
+    if (!parsed.success) {
+      timeLimitExceeded = false;
+      return;
+    }
+    const usage = parsed.data.timeLimitUsage['youtube.com'];
     timeLimitExceeded = checkTimeLimitExceeded(currentSettings, usage);
   } catch {
     timeLimitExceeded = false;
@@ -275,12 +278,13 @@ async function loadTimeLimitState(): Promise<void> {
 // Load settings from storage
 async function loadSettings(): Promise<void> {
   try {
-    const stored = (await storage.get('settings')) as Record<
-      string,
-      unknown
-    > | null;
-    if (stored && 'youtube' in stored) {
-      currentSettings = stored.youtube as YouTubeSettings;
+    const stored = await storage.get('settings');
+    if (stored && typeof stored === 'object' && 'youtube' in stored) {
+      const raw = (stored as Record<string, unknown>).youtube;
+      const parsed = YouTubeSettingsSchema.safeParse(raw);
+      if (parsed.success) {
+        currentSettings = parsed.data;
+      }
     }
   } catch {
     // Use default settings on error
@@ -297,21 +301,24 @@ function watchSettings(): void {
   storage.watch({
     settings: (change) => {
       if (change.newValue && typeof change.newValue === 'object') {
-        const newSettings = change.newValue as { youtube?: YouTubeSettings };
-        if (newSettings.youtube) {
-          currentSettings = newSettings.youtube;
-          // Re-check time limit when settings change
-          loadTimeLimitState().then(() => {
+        const raw = (change.newValue as Record<string, unknown>).youtube;
+        const parsed = YouTubeSettingsSchema.safeParse(raw);
+        if (parsed.success) {
+          currentSettings = parsed.data;
+          // Re-check time limit when settings change (async IIFE to avoid .then)
+          void (async () => {
+            await loadTimeLimitState();
             applyStyles(currentSettings);
             handleDynamicContent();
-          });
+          })();
         }
       }
     },
     analytics: (change) => {
       if (change.newValue && typeof change.newValue === 'object') {
-        const analytics = change.newValue as AnalyticsData;
-        const usage = analytics.timeLimitUsage?.['youtube.com'];
+        const parsed = AnalyticsDataSchema.safeParse(change.newValue);
+        if (!parsed.success) return;
+        const usage = parsed.data.timeLimitUsage['youtube.com'];
         const wasExceeded = timeLimitExceeded;
         timeLimitExceeded = checkTimeLimitExceeded(currentSettings, usage);
 

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -278,8 +278,9 @@ async function loadTimeLimitState(): Promise<void> {
 // Load settings from storage
 async function loadSettings(): Promise<void> {
   try {
-    const stored =
-      await storage.get<Record<string, unknown> | null>('settings');
+    const stored = await storage.get<Record<string, unknown> | null>(
+      'settings'
+    );
     if (stored && 'youtube' in stored) {
       const raw = stored.youtube;
       const parsed = YouTubeSettingsSchema.safeParse(raw);

--- a/src/types/messageSchemas.ts
+++ b/src/types/messageSchemas.ts
@@ -1,0 +1,83 @@
+/**
+ * Zod schemas for validating message handler request bodies.
+ * Replaces unsafe `as` type assertions with runtime validation.
+ */
+
+import * as z from 'zod';
+
+// Schema for get-remaining-time message handler
+export const GetRemainingTimeBodySchema = z.object({
+  url: z.string().min(1)
+});
+
+export type GetRemainingTimeBody = z.infer<typeof GetRemainingTimeBodySchema>;
+
+// Schema for tracker-heartbeat message handler
+export const TrackerHeartbeatBodySchema = z.object({
+  url: z.string().min(1).max(2048),
+  status: z.enum(['active', 'inactive', 'heartbeat']),
+  timestamp: z.number().finite().nonnegative().optional()
+});
+
+export type TrackerHeartbeatBody = z.infer<typeof TrackerHeartbeatBodySchema>;
+
+// Schema for update-time-limit message handler
+const TimeLimitSchema = z.object({
+  type: z.enum(['daily', 'hourly']),
+  limitSeconds: z.number().positive()
+});
+
+export const UpdateTimeLimitBodySchema = z.object({
+  id: z.string().min(1),
+  timeLimit: TimeLimitSchema.nullable()
+});
+
+export type UpdateTimeLimitBody = z.infer<typeof UpdateTimeLimitBodySchema>;
+
+// Schema for AnalyticsData validation (used in youtube.ts content script)
+const TimeLimitUsageSchema = z.object({
+  domain: z.string(),
+  dailyUsedSeconds: z.number(),
+  hourlyUsedSeconds: z.number(),
+  lastDailyReset: z.string(),
+  lastHourlyReset: z.string()
+});
+
+const DailyStatSchema = z.object({
+  date: z.string(),
+  wasteTime: z.number(),
+  investTime: z.number(),
+  blockCount: z.number()
+});
+
+const SiteTimeSchema = z.object({
+  domain: z.string(),
+  time: z.number(),
+  category: z.enum(['waste', 'invest', 'neutral']),
+  lastUpdated: z.string()
+});
+
+const SiteBlockCountSchema = z.object({
+  domain: z.string(),
+  count: z.number(),
+  lastBlocked: z.string()
+});
+
+export const AnalyticsDataSchema = z.object({
+  dailyStats: z.record(z.string(), DailyStatSchema),
+  siteTime: z.record(z.string(), SiteTimeSchema),
+  siteCategories: z.record(z.string(), z.enum(['waste', 'invest', 'neutral'])),
+  siteBlockCounts: z.record(z.string(), SiteBlockCountSchema),
+  timeLimitUsage: z.record(z.string(), TimeLimitUsageSchema)
+});
+
+// Schema for YouTubeSettings validation (used in youtube.ts content script)
+export const YouTubeSettingsSchema = z.object({
+  enabled: z.boolean(),
+  hideShorts: z.boolean(),
+  hideRecommendations: z.boolean(),
+  hideComments: z.boolean(),
+  hideSidebar: z.boolean(),
+  hideHomeFeed: z.boolean(),
+  timeLimit: TimeLimitSchema.nullable().optional()
+});


### PR DESCRIPTION
## 概要
- `src/types/messageSchemas.ts` を新規作成し、メッセージハンドラのリクエストボディとストレージデータ型のZodスキーマを定義
- `get-remaining-time.ts`、`tracker-heartbeat.ts`、`update-time-limit.ts`、`youtube.ts` の安全でない `as` 型アサーションを `safeParse` によるランタイムバリデーションに置換
- `youtube.ts` コンテンツスクリプトの `as AnalyticsData`、`as YouTubeSettings` キャストもZodバリデーションに置換
- `youtube.ts` の `watchSettings()` 内の `.then` チェーンを async/await（IIFE パターン）に修正
- DOM要素アクセスの `as HTMLElement` は許容範囲のため維持

## テスト計画
- [ ] メッセージハンドラが不正なリクエストボディを正しく拒否し、エラーレスポンスを返すことを確認
- [ ] `get-remaining-time` ハンドラが有効なURL入力で動作することを確認
- [ ] `tracker-heartbeat` ハンドラが有効なハートビートメッセージ（active/inactive/heartbeat）で動作することを確認
- [ ] `update-time-limit` ハンドラがブロックアイテムの時間制限を正しく更新することを確認
- [ ] YouTubeコンテンツスクリプトがストレージから設定・分析データを正しく読み込むことを確認
- [ ] YouTube時間制限の検出がZodバリデーション変更後も動作することを確認
- [ ] ビルドがエラーなく通ること（`pnpm run build`）

Closes #98
