### PR TITLE
refactor: usePresets.tsの状態管理をuseReducerに統合

### DIFF
--- a/src/hooks/usePresets.ts
+++ b/src/hooks/usePresets.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer } from 'react';
 
 import { storage } from '~/lib/storage';
 import { presetToDisplaySettings } from '~/lib/presetUtils';
@@ -18,7 +18,6 @@ interface UsePresetsOptions {
 }
 
 export interface UsePresetsReturn {
-  // State
   draftDisplaySettings: DashboardDisplaySettings;
   draftPresets: DashboardPreset[];
   selectedPresetId: string | null;
@@ -27,20 +26,14 @@ export interface UsePresetsReturn {
   visionSaved: boolean;
   showSavePresetModal: boolean;
   presetName: string;
-
-  // Modal controls
   setShowSavePresetModal: (show: boolean) => void;
   setPresetName: (name: string) => void;
-
-  // Preset handlers
   handleSelectPreset: (presetId: string) => void;
   handlePresetNameChange: (name: string) => void;
   handleDeletePreset: (id: string) => Promise<void>;
   handleSaveSelectedPreset: () => Promise<void>;
   handleApplyPreset: () => Promise<void>;
   handleCreatePreset: () => Promise<void>;
-
-  // Display settings handlers
   handleGoalTextChange: (text: string) => void;
   handleGoalSubTextChange: (text: string) => void;
   handleTextColorChange: (color: string) => void;
@@ -51,158 +44,254 @@ export interface UsePresetsReturn {
   handleFontSettingsChange: (fontSettings: FontSettings) => void;
 }
 
+// ============ Reducer ============
+
+interface PresetState {
+  draftDisplaySettings: DashboardDisplaySettings;
+  draftPresets: DashboardPreset[];
+  selectedPresetId: string | null;
+  editingPresetName: string;
+  isDirty: boolean;
+  visionSaved: boolean;
+  showSavePresetModal: boolean;
+  presetName: string;
+}
+
+type PresetAction =
+  | {
+      type: 'INITIALIZE';
+      presets: DashboardPreset[];
+      selectedPresetId: string | null;
+      editingPresetName: string;
+      displaySettings: DashboardDisplaySettings;
+    }
+  | { type: 'UPDATE_DISPLAY'; patch: Partial<DashboardDisplaySettings> }
+  | {
+      type: 'SELECT_PRESET';
+      presetId: string;
+      name: string;
+      displaySettings: DashboardDisplaySettings;
+    }
+  | { type: 'UPDATE_PRESET_NAME'; name: string }
+  | {
+      type: 'DELETE_PRESET';
+      remainingPresets: DashboardPreset[];
+      wasSelected: boolean;
+      fallbackSettings: DashboardDisplaySettings;
+    }
+  | { type: 'SAVE_PRESETS'; updatedPresets: DashboardPreset[] }
+  | { type: 'SET_VISION_SAVED'; saved: boolean }
+  | {
+      type: 'CREATE_PRESET';
+      preset: DashboardPreset;
+      updatedPresets: DashboardPreset[];
+    }
+  | { type: 'SET_SHOW_MODAL'; show: boolean }
+  | { type: 'SET_PRESET_NAME'; name: string };
+
+const INITIAL_STATE: PresetState = {
+  draftDisplaySettings: DEFAULT_DISPLAY_SETTINGS,
+  draftPresets: [],
+  selectedPresetId: null,
+  editingPresetName: '',
+  isDirty: false,
+  visionSaved: false,
+  showSavePresetModal: false,
+  presetName: ''
+};
+
+function presetReducer(state: PresetState, action: PresetAction): PresetState {
+  switch (action.type) {
+    case 'INITIALIZE':
+      return {
+        ...state,
+        draftPresets: action.presets,
+        selectedPresetId: action.selectedPresetId,
+        editingPresetName: action.editingPresetName,
+        draftDisplaySettings: action.displaySettings
+      };
+    case 'UPDATE_DISPLAY':
+      return {
+        ...state,
+        draftDisplaySettings: {
+          ...state.draftDisplaySettings,
+          ...action.patch
+        },
+        isDirty: true
+      };
+    case 'SELECT_PRESET':
+      return {
+        ...state,
+        selectedPresetId: action.presetId,
+        editingPresetName: action.name,
+        draftDisplaySettings: action.displaySettings,
+        isDirty: false
+      };
+    case 'UPDATE_PRESET_NAME':
+      return { ...state, editingPresetName: action.name, isDirty: true };
+    case 'DELETE_PRESET':
+      return {
+        ...state,
+        draftPresets: action.remainingPresets,
+        selectedPresetId: action.wasSelected ? null : state.selectedPresetId,
+        draftDisplaySettings: action.wasSelected
+          ? action.fallbackSettings
+          : state.draftDisplaySettings,
+        isDirty: false
+      };
+    case 'SAVE_PRESETS':
+      return { ...state, draftPresets: action.updatedPresets, isDirty: false };
+    case 'SET_VISION_SAVED':
+      return { ...state, visionSaved: action.saved };
+    case 'CREATE_PRESET':
+      return {
+        ...state,
+        draftPresets: action.updatedPresets,
+        selectedPresetId: action.preset.id,
+        editingPresetName: action.preset.name,
+        draftDisplaySettings: presetToDisplaySettings(action.preset),
+        showSavePresetModal: false,
+        presetName: '',
+        isDirty: false
+      };
+    case 'SET_SHOW_MODAL':
+      return { ...state, showSavePresetModal: action.show };
+    case 'SET_PRESET_NAME':
+      return { ...state, presetName: action.name };
+  }
+}
+
+// ============ Hook ============
+
+const SAVED_FEEDBACK_MS = 2000;
+
 export function usePresets({
   vision,
   setVision
 }: UsePresetsOptions): UsePresetsReturn {
-  // Draft display settings (for preview, saved on button click)
-  const [draftDisplaySettings, setDraftDisplaySettings] =
-    useState<DashboardDisplaySettings>(DEFAULT_DISPLAY_SETTINGS);
-  const [draftPresets, setDraftPresets] = useState<DashboardPreset[]>([]);
-  const [visionSaved, setVisionSaved] = useState(false);
-  const [isDirty, setIsDirty] = useState(false);
+  const [state, dispatch] = useReducer(presetReducer, INITIAL_STATE);
 
-  // Selected preset state
-  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
-
-  // Preset modal state
-  const [presetName, setPresetName] = useState('');
-  const [showSavePresetModal, setShowSavePresetModal] = useState(false);
-  const [editingPresetName, setEditingPresetName] = useState('');
-
-  // Initialize from storage (run once on mount)
   useEffect(() => {
     const initialize = async () => {
       const storedVision = (await storage.get('vision')) as
         | VisionSettings
         | undefined;
       const visionData = storedVision || DEFAULT_VISION;
-
       const presets = visionData.presets || [];
-      setDraftPresets(presets);
 
       if (presets.length > 0) {
         const activePreset = visionData.activePresetId
           ? presets.find((p) => p.id === visionData.activePresetId)
           : presets[0];
-        const presetToSelect = activePreset || presets[0];
-        setSelectedPresetId(presetToSelect.id);
-        setEditingPresetName(presetToSelect.name);
-        setDraftDisplaySettings(presetToDisplaySettings(presetToSelect));
+        const target = activePreset || presets[0];
+        dispatch({
+          type: 'INITIALIZE',
+          presets,
+          selectedPresetId: target.id,
+          editingPresetName: target.name,
+          displaySettings: presetToDisplaySettings(target)
+        });
       } else {
-        setDraftDisplaySettings(
-          visionData.defaultSettings || DEFAULT_DISPLAY_SETTINGS
-        );
-        setSelectedPresetId(null);
+        dispatch({
+          type: 'INITIALIZE',
+          presets: [],
+          selectedPresetId: null,
+          editingPresetName: '',
+          displaySettings:
+            visionData.defaultSettings || DEFAULT_DISPLAY_SETTINGS
+        });
       }
     };
-
     initialize();
   }, []);
 
-  // Load Google Font when fontSettings changes
+  const { fontSettings: currentFontSettings } = state.draftDisplaySettings;
   useEffect(() => {
-    if (draftDisplaySettings.fontSettings) {
-      const fontDef = getFontDefinition(
-        draftDisplaySettings.fontSettings.family
-      );
-      if (fontDef.googleFont) {
-        loadGoogleFont(fontDef.googleFont);
-      }
-    }
-  }, [draftDisplaySettings.fontSettings]);
+    if (!currentFontSettings) return;
+    const fontDef = getFontDefinition(currentFontSettings.family);
+    if (fontDef.googleFont) loadGoogleFont(fontDef.googleFont);
+  }, [currentFontSettings]);
 
-  // ============ Display Settings Handlers ============
-  const handleGoalTextChange = useCallback((text: string) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, goalText: text }));
-    setIsDirty(true);
-  }, []);
-
-  const handleGoalSubTextChange = useCallback((text: string) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, goalSubText: text }));
-    setIsDirty(true);
-  }, []);
-
-  const handleTextColorChange = useCallback((color: string) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, textColor: color }));
-    setIsDirty(true);
-  }, []);
-
-  const handleBackgroundChange = useCallback((bgId: string) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, backgroundImage: bgId }));
-    setIsDirty(true);
-  }, []);
-
-  const handleBackgroundTypeChange = useCallback((type: 'image' | 'color') => {
-    setDraftDisplaySettings((prev) => ({ ...prev, backgroundType: type }));
-    setIsDirty(true);
-  }, []);
-
-  const handleBackgroundColorChange = useCallback((color: string) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, backgroundColor: color }));
-    setIsDirty(true);
-  }, []);
-
-  const handleCustomBackgroundChange = useCallback((dataUrl: string | null) => {
-    setDraftDisplaySettings((prev) => ({
-      ...prev,
-      customBackgroundData: dataUrl
-    }));
-    setIsDirty(true);
-  }, []);
-
-  const handleFontSettingsChange = useCallback((fontSettings: FontSettings) => {
-    setDraftDisplaySettings((prev) => ({ ...prev, fontSettings }));
-    setIsDirty(true);
-  }, []);
-
-  // ============ Preset Handlers ============
-  const handleSelectPreset = useCallback(
-    (presetId: string) => {
-      const preset = draftPresets.find((p) => p.id === presetId);
-      if (preset) {
-        setSelectedPresetId(presetId);
-        setEditingPresetName(preset.name);
-        setDraftDisplaySettings(presetToDisplaySettings(preset));
-        setIsDirty(false);
-      }
-    },
-    [draftPresets]
+  // Display settings handlers -- dispatch is stable so no deps needed
+  const displayHandlers = useMemo(
+    () => ({
+      handleGoalTextChange: (text: string) =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { goalText: text } }),
+      handleGoalSubTextChange: (text: string) =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { goalSubText: text } }),
+      handleTextColorChange: (color: string) =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { textColor: color } }),
+      handleBackgroundTypeChange: (type: 'image' | 'color') =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { backgroundType: type } }),
+      handleBackgroundChange: (bgId: string) =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { backgroundImage: bgId } }),
+      handleBackgroundColorChange: (color: string) =>
+        dispatch({
+          type: 'UPDATE_DISPLAY',
+          patch: { backgroundColor: color }
+        }),
+      handleCustomBackgroundChange: (dataUrl: string | null) =>
+        dispatch({
+          type: 'UPDATE_DISPLAY',
+          patch: { customBackgroundData: dataUrl }
+        }),
+      handleFontSettingsChange: (fontSettings: FontSettings) =>
+        dispatch({ type: 'UPDATE_DISPLAY', patch: { fontSettings } }),
+      handlePresetNameChange: (name: string) =>
+        dispatch({ type: 'UPDATE_PRESET_NAME', name }),
+      setShowSavePresetModal: (show: boolean) =>
+        dispatch({ type: 'SET_SHOW_MODAL', show }),
+      setPresetName: (name: string) =>
+        dispatch({ type: 'SET_PRESET_NAME', name })
+    }),
+    []
   );
 
-  const handlePresetNameChange = useCallback((name: string) => {
-    setEditingPresetName(name);
-    setIsDirty(true);
+  const showSavedFeedback = useCallback(() => {
+    dispatch({ type: 'SET_VISION_SAVED', saved: true });
+    setTimeout(
+      () => dispatch({ type: 'SET_VISION_SAVED', saved: false }),
+      SAVED_FEEDBACK_MS
+    );
   }, []);
+
+  const handleSelectPreset = useCallback(
+    (presetId: string) => {
+      const preset = state.draftPresets.find((p) => p.id === presetId);
+      if (!preset) return;
+      dispatch({
+        type: 'SELECT_PRESET',
+        presetId,
+        name: preset.name,
+        displaySettings: presetToDisplaySettings(preset)
+      });
+    },
+    [state.draftPresets]
+  );
 
   const handleDeletePreset = useCallback(
     async (id: string) => {
-      const remainingPresets = draftPresets.filter((p) => p.id !== id);
-      setDraftPresets(remainingPresets);
-
-      if (id === selectedPresetId) {
-        setSelectedPresetId(null);
-        const storedVision = vision || DEFAULT_VISION;
-        setDraftDisplaySettings(
-          storedVision.defaultSettings || DEFAULT_DISPLAY_SETTINGS
-        );
-      }
-
+      const remainingPresets = state.draftPresets.filter((p) => p.id !== id);
+      dispatch({
+        type: 'DELETE_PRESET',
+        remainingPresets,
+        wasSelected: id === state.selectedPresetId,
+        fallbackSettings: vision?.defaultSettings || DEFAULT_DISPLAY_SETTINGS
+      });
       const toSave: VisionSettings = {
         defaultSettings: vision?.defaultSettings || DEFAULT_DISPLAY_SETTINGS,
         presets: remainingPresets,
         activePresetId:
           vision?.activePresetId === id ? null : vision?.activePresetId || null
       };
-
       await storage.set('vision', toSave);
       setVision(toSave);
-      setIsDirty(false);
     },
-    [draftPresets, selectedPresetId, vision, setVision]
+    [state.draftPresets, state.selectedPresetId, vision, setVision]
   );
 
   const handleSaveSelectedPreset = useCallback(async () => {
+    const { selectedPresetId, draftDisplaySettings, editingPresetName } = state;
     if (
       !selectedPresetId ||
       !draftDisplaySettings.goalText.trim() ||
@@ -210,7 +299,7 @@ export function usePresets({
     )
       return;
 
-    const updatedPresets = draftPresets.map((p) =>
+    const updatedPresets = state.draftPresets.map((p) =>
       p.id === selectedPresetId
         ? {
             ...p,
@@ -226,48 +315,33 @@ export function usePresets({
           }
         : p
     );
-
-    setDraftPresets(updatedPresets);
-
+    dispatch({ type: 'SAVE_PRESETS', updatedPresets });
     const toSave: VisionSettings = {
       defaultSettings: vision?.defaultSettings || DEFAULT_DISPLAY_SETTINGS,
       presets: updatedPresets,
       activePresetId: vision?.activePresetId || null
     };
-
     await storage.set('vision', toSave);
     setVision(toSave);
-    setIsDirty(false);
-    setVisionSaved(true);
-    setTimeout(() => setVisionSaved(false), 2000);
-  }, [
-    selectedPresetId,
-    draftDisplaySettings,
-    draftPresets,
-    editingPresetName,
-    vision,
-    setVision
-  ]);
+    showSavedFeedback();
+  }, [state, vision, setVision, showSavedFeedback]);
 
   const handleApplyPreset = useCallback(async () => {
-    if (!selectedPresetId || !vision) return;
-
+    if (!state.selectedPresetId || !vision) return;
     const toSave: VisionSettings = {
       ...vision,
-      activePresetId: selectedPresetId
+      activePresetId: state.selectedPresetId
     };
     await storage.set('vision', toSave);
     setVision(toSave);
-    setVisionSaved(true);
-    setTimeout(() => setVisionSaved(false), 2000);
-  }, [selectedPresetId, vision, setVision]);
+    showSavedFeedback();
+  }, [state.selectedPresetId, vision, setVision, showSavedFeedback]);
 
   const handleCreatePreset = useCallback(async () => {
-    if (!presetName.trim()) return;
-
+    if (!state.presetName.trim()) return;
     const newPreset: DashboardPreset = {
       id: crypto.randomUUID(),
-      name: presetName.trim(),
+      name: state.presetName.trim(),
       goalText: DEFAULT_DISPLAY_SETTINGS.goalText,
       goalSubText: DEFAULT_DISPLAY_SETTINGS.goalSubText,
       textColor: DEFAULT_DISPLAY_SETTINGS.textColor,
@@ -278,58 +352,24 @@ export function usePresets({
       fontSettings: DEFAULT_FONT_SETTINGS,
       createdAt: new Date().toISOString()
     };
-
-    const updatedPresets = [...draftPresets, newPreset];
-    setDraftPresets(updatedPresets);
-
+    const updatedPresets = [...state.draftPresets, newPreset];
+    dispatch({ type: 'CREATE_PRESET', preset: newPreset, updatedPresets });
     const toSave: VisionSettings = {
       defaultSettings: vision?.defaultSettings || DEFAULT_DISPLAY_SETTINGS,
       presets: updatedPresets,
       activePresetId: vision?.activePresetId || null
     };
-
     await storage.set('vision', toSave);
     setVision(toSave);
-
-    setSelectedPresetId(newPreset.id);
-    setEditingPresetName(newPreset.name);
-    setDraftDisplaySettings(presetToDisplaySettings(newPreset));
-    setShowSavePresetModal(false);
-    setPresetName('');
-    setIsDirty(false);
-  }, [presetName, draftPresets, vision, setVision]);
+  }, [state.presetName, state.draftPresets, vision, setVision]);
 
   return {
-    // State
-    draftDisplaySettings,
-    draftPresets,
-    selectedPresetId,
-    editingPresetName,
-    isDirty,
-    visionSaved,
-    showSavePresetModal,
-    presetName,
-
-    // Modal controls
-    setShowSavePresetModal,
-    setPresetName,
-
-    // Preset handlers
+    ...state,
+    ...displayHandlers,
     handleSelectPreset,
-    handlePresetNameChange,
     handleDeletePreset,
     handleSaveSelectedPreset,
     handleApplyPreset,
-    handleCreatePreset,
-
-    // Display settings handlers
-    handleGoalTextChange,
-    handleGoalSubTextChange,
-    handleTextColorChange,
-    handleBackgroundTypeChange,
-    handleBackgroundChange,
-    handleBackgroundColorChange,
-    handleCustomBackgroundChange,
-    handleFontSettingsChange
+    handleCreatePreset
   };
 }


### PR DESCRIPTION
## Summary
- 8個の独立した`useState`を単一の`useReducer`に統合し、状態遷移をアトミックに管理
- プリセット選択・編集・名前変更・保存・削除の状態を一元化して整合性を向上
- Display settings関連の8つの`useCallback`ハンドラーを`useMemo`で集約して簡素化
- 公開API（`UsePresetsReturn`インターフェース）は完全に維持し、コンシューマーへの影響なし

## Changes
- `useState` x8 -> `useReducer` x1（`PresetState` + `PresetAction`型で型安全に管理）
- `UPDATE_DISPLAY`アクションで全display settings変更を統一的に処理
- `SELECT_PRESET`/`CREATE_PRESET`/`DELETE_PRESET`アクションで関連する複数状態を同時更新
- マジックナンバー`2000`を`SAVED_FEEDBACK_MS`定数に抽出

## Test plan
- [ ] ビルドが成功すること（`pnpm run build` -- 確認済み）
- [ ] Lintエラーがないこと（`pnpm run lint` -- 確認済み）
- [ ] プリセット一覧の表示が正常であること
- [ ] プリセット選択時に表示設定が切り替わること
- [ ] プリセット名変更・保存が動作すること
- [ ] 新規プリセット作成が動作すること
- [ ] プリセット削除が動作すること
- [ ] プリセット適用（activePresetId設定）が動作すること
- [ ] Display settings（テキスト、背景、フォント等）の変更が反映されること

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
