### PR TITLE
refactor: マジックナンバーを定数ファイルに集約

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -8,6 +8,13 @@ import {
 import { startExtPayBackgroundListener } from '~/lib/extpay';
 import { getFeatureLimits } from '~/lib/license';
 import { extractDomain } from '~/lib/domain';
+import {
+  STORAGE_SETTLE_DELAY_MS,
+  ALARM_DAILY_CLEANUP_MINUTES,
+  ALARM_CHECK_SCHEDULE_MINUTES,
+  ALARM_TIME_LIMIT_RESET_MINUTES,
+  MAX_HISTORY_DAYS_FALLBACK
+} from '~/constants/intervals';
 
 import { updateBlockRules } from './blocker';
 import { startTracking } from './tracker';
@@ -22,7 +29,9 @@ startExtPayBackgroundListener();
 storage.watch({
   settings: async () => {
     // Small delay to ensure storage is fully updated
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) =>
+      setTimeout(resolve, STORAGE_SETTLE_DELAY_MS)
+    );
     await updateBlockRules();
   }
 });
@@ -63,9 +72,15 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 });
 
 // Set up alarms
-chrome.alarms.create('daily-cleanup', { periodInMinutes: 60 });
-chrome.alarms.create('check-schedule', { periodInMinutes: 1 });
-chrome.alarms.create('time-limit-reset', { periodInMinutes: 1 });
+chrome.alarms.create('daily-cleanup', {
+  periodInMinutes: ALARM_DAILY_CLEANUP_MINUTES
+});
+chrome.alarms.create('check-schedule', {
+  periodInMinutes: ALARM_CHECK_SCHEDULE_MINUTES
+});
+chrome.alarms.create('time-limit-reset', {
+  periodInMinutes: ALARM_TIME_LIMIT_RESET_MINUTES
+});
 
 // Track blocked navigations and increment site block count
 // Uses centralized BlockService for consistent state checking
@@ -116,7 +131,10 @@ async function cleanupOldAnalytics() {
   const limits = await getFeatureLimits();
 
   // Determine max days based on tier
-  const maxDays = limits.historyDays === Infinity ? 365 : limits.historyDays;
+  const maxDays =
+    limits.historyDays === Infinity
+      ? MAX_HISTORY_DAYS_FALLBACK
+      : limits.historyDays;
   const cutoffDate = new Date();
   cutoffDate.setDate(cutoffDate.getDate() - maxDays);
   const cutoffKey = cutoffDate.toISOString().slice(0, 10);

--- a/src/background/messages/tracker-heartbeat.ts
+++ b/src/background/messages/tracker-heartbeat.ts
@@ -10,6 +10,7 @@ import {
 import type { BlockItem } from '~/types/storage';
 import { getTodayKey } from '~/lib/time';
 import { TRACKER_CONFIG } from '~/constants/limits';
+import { STALE_ENTRY_TIMEOUT_MS } from '~/constants/intervals';
 import type { DailyStat, SiteTime } from '~/types/storage';
 import { recordTimeLimitUsage, findBlockItemForDomain } from '../time-limit';
 import { checkTimeLimitNotification } from '../notifications';
@@ -57,9 +58,8 @@ function ensureRecordingTimer() {
     }
 
     // Clean up stale entries (no heartbeat for over 1 minute)
-    const STALE_TIMEOUT_MS = 60 * 1000;
     for (const [key, page] of activePages.entries()) {
-      if (now - page.lastHeartbeat > STALE_TIMEOUT_MS) {
+      if (now - page.lastHeartbeat > STALE_ENTRY_TIMEOUT_MS) {
         activePages.delete(key);
       }
     }

--- a/src/background/tracker.ts
+++ b/src/background/tracker.ts
@@ -1,6 +1,7 @@
 import { extractDomain } from '~/lib/domain';
 import { getAnalytics, setAnalytics } from '~/lib/storage';
 import { getTodayKey } from '~/lib/time';
+import { TRACKING_UPDATE_INTERVAL_MS } from '~/constants/intervals';
 import type { DailyStat, SiteTime } from '~/types/storage';
 
 let activeTabId: number | null = null;
@@ -15,7 +16,7 @@ export function startTracking(): void {
   }
 
   // Update every second
-  trackingInterval = setInterval(updateTracking, 1000);
+  trackingInterval = setInterval(updateTracking, TRACKING_UPDATE_INTERVAL_MS);
 
   // Listen for tab changes
   chrome.tabs.onActivated.addListener(handleTabActivated);

--- a/src/components/features/DownloadButton/DownloadButton.tsx
+++ b/src/components/features/DownloadButton/DownloadButton.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef } from 'react';
 
 import { Download, Check, X, ChevronDown } from 'lucide-react';
 
+import { STATUS_RESET_DELAY_MS } from '~/constants/intervals';
 import {
   downloadWallpaper,
   type Resolution,
@@ -42,10 +43,10 @@ export function DownloadButton({
         quality: 0.95
       });
       setDownloadStatus('success');
-      setTimeout(() => setDownloadStatus('idle'), 2000);
+      setTimeout(() => setDownloadStatus('idle'), STATUS_RESET_DELAY_MS);
     } catch {
       setDownloadStatus('error');
-      setTimeout(() => setDownloadStatus('idle'), 2000);
+      setTimeout(() => setDownloadStatus('idle'), STATUS_RESET_DELAY_MS);
     } finally {
       setIsDownloading(false);
     }

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -13,6 +13,10 @@ import {
 
 import { Button, Card } from '~/components/ui';
 import { PasswordSettingsSection } from '~/components/options/PasswordSettingsSection';
+import {
+  EXPORT_STATUS_DELAY_MS,
+  SHARE_MESSAGE_DELAY_MS
+} from '~/constants/intervals';
 import { getMessage } from '~/lib/i18n';
 import {
   exportSettings,
@@ -67,14 +71,14 @@ export function HelpTab({
       downloadSettings(data);
       setExportStatus('success');
 
-      // Reset status after 3 seconds
+      // Reset status after a short delay
       setTimeout(() => {
         setExportStatus('idle');
         setExportWarning(null);
-      }, 3000);
+      }, EXPORT_STATUS_DELAY_MS);
     } catch {
       setExportStatus('error');
-      setTimeout(() => setExportStatus('idle'), 3000);
+      setTimeout(() => setExportStatus('idle'), EXPORT_STATUS_DELAY_MS);
     }
   };
 
@@ -102,7 +106,7 @@ export function HelpTab({
         setTimeout(() => {
           setImportStatus('idle');
           setImportMessage(null);
-        }, 5000);
+        }, SHARE_MESSAGE_DELAY_MS);
         return;
       }
 
@@ -131,19 +135,19 @@ export function HelpTab({
       // Notify parent of settings change
       onSettingsChange?.();
 
-      // Reset status after 5 seconds
+      // Reset status after a short delay
       setTimeout(() => {
         setImportStatus('idle');
         setImportMessage(null);
         setImportWarnings([]);
-      }, 5000);
+      }, SHARE_MESSAGE_DELAY_MS);
     } catch {
       setImportStatus('error');
       setImportMessage(getMessage('importErrorInvalidFormat'));
       setTimeout(() => {
         setImportStatus('idle');
         setImportMessage(null);
-      }, 5000);
+      }, SHARE_MESSAGE_DELAY_MS);
     }
 
     // Reset file input

--- a/src/components/options/PasswordSettingsSection.tsx
+++ b/src/components/options/PasswordSettingsSection.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { Lock, Shield } from 'lucide-react';
 
 import { Card, Toggle } from '~/components/ui';
+import { STATUS_RESET_DELAY_MS } from '~/constants/intervals';
 import { getMessage } from '~/lib/i18n';
 import {
   hashPassword,
@@ -67,7 +68,7 @@ export function PasswordSettingsSection({
         const hash = await hashPassword(newPassword);
         await onUpdate({ enabled: true, passwordHash: hash });
         setSuccess(getMessage(successMessageKey));
-        setTimeout(resetForm, 2000);
+        setTimeout(resetForm, STATUS_RESET_DELAY_MS);
         return true;
       } catch {
         return false;
@@ -121,7 +122,7 @@ export function PasswordSettingsSection({
     try {
       await onUpdate({ enabled: false, passwordHash: null });
       setSuccess(getMessage('passwordRemovedSuccess'));
-      setTimeout(resetForm, 2000);
+      setTimeout(resetForm, STATUS_RESET_DELAY_MS);
     } catch {
       setError(getMessage('passwordRemoveFailed'));
     } finally {

--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 
 import { Card } from '~/components/ui';
+import { CURRENT_TIME_REFRESH_MS } from '~/constants/intervals';
 import { getMessage } from '~/lib/i18n';
 import type { Schedule, VisionSettings } from '~/types/storage';
 
@@ -77,7 +78,10 @@ function useCurrentTime(): Date {
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
-    const interval = setInterval(() => setNow(new Date()), 60000);
+    const interval = setInterval(
+      () => setNow(new Date()),
+      CURRENT_TIME_REFRESH_MS
+    );
     return () => clearInterval(interval);
   }, []);
 

--- a/src/components/options/analytics/AnalyticsExportBar.tsx
+++ b/src/components/options/analytics/AnalyticsExportBar.tsx
@@ -11,6 +11,10 @@ import {
 
 import { Card, Button, Modal } from '~/components/ui';
 import { AnalyticsChart } from '~/components/features';
+import {
+  REFRESH_SPINNER_DELAY_MS,
+  SHARE_MESSAGE_DELAY_MS
+} from '~/constants/intervals';
 import { getMessage } from '~/lib/i18n';
 import {
   exportBlockList,
@@ -62,7 +66,7 @@ export function AnalyticsExportBar({
   const handleRefresh = async () => {
     setIsRefreshing(true);
     await onRefresh();
-    setTimeout(() => setIsRefreshing(false), 500);
+    setTimeout(() => setIsRefreshing(false), REFRESH_SPINNER_DELAY_MS);
   };
 
   const hasBlockList = (settings?.blockList?.length ?? 0) > 0;
@@ -154,7 +158,7 @@ export function AnalyticsExportBar({
 
       shareToX(text);
 
-      setTimeout(() => setShareMessage(null), 5000);
+      setTimeout(() => setShareMessage(null), SHARE_MESSAGE_DELAY_MS);
     } catch {
       setShareMessage({ type: 'error', text: getMessage('shareError') });
     }

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Clock, Lock, RefreshCw, EyeOff } from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
 import { UpgradePrompt } from '~/components/features';
+import { MS_PER_DAY } from '~/constants/intervals';
 import { formatTime } from '~/lib/time';
 import { getMessage } from '~/lib/i18n';
 import type { UnblockHistory, TrackedSite } from '~/types/storage';
@@ -11,7 +12,7 @@ function formatRelativeTime(isoDate: string): string {
   const date = new Date(isoDate);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const diffDays = Math.floor(diffMs / MS_PER_DAY);
 
   if (diffDays === 0) {
     return getMessage('today');

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './backgrounds';
 export * from './fonts';
+export * from './intervals';
 export * from './limits';
 export * from './tabs';

--- a/src/constants/intervals.ts
+++ b/src/constants/intervals.ts
@@ -1,0 +1,80 @@
+/**
+ * Application-wide interval and timing constants
+ *
+ * All time-related magic numbers are centralized here
+ * to make tuning and maintenance easier.
+ */
+
+// ---------------------------------------------------------------------------
+//  Polling intervals (UI)
+// ---------------------------------------------------------------------------
+
+/** Polling interval for background stats in the popup (ms) */
+export const POPUP_STATS_POLLING_MS = 5_000;
+
+/** Polling interval for background stats in the new-tab page (ms) */
+export const NEWTAB_STATS_POLLING_MS = 10_000;
+
+/** Default polling interval for useBackgroundStats hook (ms) */
+export const DEFAULT_STATS_POLLING_MS = 10_000;
+
+/** Polling interval for current-domain / time-limit info in popup (ms) */
+export const DOMAIN_POLLING_MS = 10_000;
+
+/** Interval for refreshing the current time display in WeeklyCalendar (ms) */
+export const CURRENT_TIME_REFRESH_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+//  Background service delays
+// ---------------------------------------------------------------------------
+
+/** Small delay after storage write to ensure it is fully persisted (ms) */
+export const STORAGE_SETTLE_DELAY_MS = 100;
+
+/** Timeout to mark storage as loaded for first-time users (ms) */
+export const STORAGE_LOADED_TIMEOUT_MS = 100;
+
+/** Background tracker update interval — once per second (ms) */
+export const TRACKING_UPDATE_INTERVAL_MS = 1_000;
+
+/** Timeout threshold for stale heartbeat entries (ms) */
+export const STALE_ENTRY_TIMEOUT_MS = 60 * 1_000;
+
+// ---------------------------------------------------------------------------
+//  Chrome alarm periods
+// ---------------------------------------------------------------------------
+
+/** Period for the daily-cleanup alarm (minutes) */
+export const ALARM_DAILY_CLEANUP_MINUTES = 60;
+
+/** Period for the check-schedule alarm (minutes) */
+export const ALARM_CHECK_SCHEDULE_MINUTES = 1;
+
+/** Period for the time-limit-reset alarm (minutes) */
+export const ALARM_TIME_LIMIT_RESET_MINUTES = 1;
+
+// ---------------------------------------------------------------------------
+//  Analytics
+// ---------------------------------------------------------------------------
+
+/** Fallback maximum history retention when Infinity (days) */
+export const MAX_HISTORY_DAYS_FALLBACK = 365;
+
+/** Milliseconds in one day — used for date-diff calculations */
+export const MS_PER_DAY = 1_000 * 60 * 60 * 24;
+
+// ---------------------------------------------------------------------------
+//  UI feedback delays (status-reset timers)
+// ---------------------------------------------------------------------------
+
+/** How long a transient success/error message is shown before resetting (ms) */
+export const STATUS_RESET_DELAY_MS = 2_000;
+
+/** How long the analytics refresh spinner stays visible (ms) */
+export const REFRESH_SPINNER_DELAY_MS = 500;
+
+/** How long export/import status messages stay visible (ms) */
+export const EXPORT_STATUS_DELAY_MS = 3_000;
+
+/** How long share / import messages stay visible (ms) */
+export const SHARE_MESSAGE_DELAY_MS = 5_000;

--- a/src/hooks/useBackgroundPreload.ts
+++ b/src/hooks/useBackgroundPreload.ts
@@ -5,6 +5,7 @@ import {
   loadGoogleFont,
   FONT_WEIGHT_VALUE
 } from '~/constants';
+import { STORAGE_LOADED_TIMEOUT_MS } from '~/constants/intervals';
 import { storage } from '~/lib/storage';
 import type { DashboardDisplaySettings, VisionSettings } from '~/types/storage';
 import { getFontDefinition } from '~/types/font';
@@ -51,7 +52,7 @@ export function useBackgroundPreload({
   useEffect(() => {
     const timer = setTimeout(() => {
       setIsStorageLoaded(true);
-    }, 100);
+    }, STORAGE_LOADED_TIMEOUT_MS);
     return () => clearTimeout(timer);
   }, []);
 

--- a/src/hooks/useBackgroundStats.ts
+++ b/src/hooks/useBackgroundStats.ts
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react';
 
 import { sendToBackground } from '@plasmohq/messaging';
 
+import { DEFAULT_STATS_POLLING_MS } from '~/constants/intervals';
+
 export interface BackgroundStats {
   wasteTime: number;
   investTime: number;
@@ -18,9 +20,11 @@ const DEFAULT_STATS: BackgroundStats = {
 
 /**
  * Hook to fetch stats from background with polling
- * @param interval - Polling interval in milliseconds (default: 10000)
+ * @param interval - Polling interval in milliseconds (default: DEFAULT_STATS_POLLING_MS)
  */
-export function useBackgroundStats(interval = 10000): BackgroundStats {
+export function useBackgroundStats(
+  interval = DEFAULT_STATS_POLLING_MS
+): BackgroundStats {
   const [stats, setStats] = useState<BackgroundStats>(DEFAULT_STATS);
 
   useEffect(() => {

--- a/src/hooks/useCurrentDomain.ts
+++ b/src/hooks/useCurrentDomain.ts
@@ -2,10 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 
 import { sendToBackground } from '@plasmohq/messaging';
 
+import { DOMAIN_POLLING_MS } from '~/constants/intervals';
 import { getActiveTab } from '~/lib/chromeApi';
 import { extractDomain } from '~/lib/domain';
-
-const POLLING_INTERVAL_MS = 10000;
 
 export interface TimeLimitInfo {
   hasTimeLimit: boolean;
@@ -62,7 +61,7 @@ export function useCurrentDomain(): UseCurrentDomainReturn {
     // Refresh time limit info periodically
     const interval = setInterval(
       getCurrentDomainAndTimeLimit,
-      POLLING_INTERVAL_MS
+      DOMAIN_POLLING_MS
     );
     return () => clearInterval(interval);
   }, []);

--- a/src/hooks/usePresets.ts
+++ b/src/hooks/usePresets.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { storage } from '~/lib/storage';
 import { presetToDisplaySettings } from '~/lib/presetUtils';
 import { loadGoogleFont } from '~/constants/fonts';
+import { STATUS_RESET_DELAY_MS } from '~/constants/intervals';
 import type {
   VisionSettings,
   DashboardPreset,
@@ -239,7 +240,7 @@ export function usePresets({
     setVision(toSave);
     setIsDirty(false);
     setVisionSaved(true);
-    setTimeout(() => setVisionSaved(false), 2000);
+    setTimeout(() => setVisionSaved(false), STATUS_RESET_DELAY_MS);
   }, [
     selectedPresetId,
     draftDisplaySettings,
@@ -259,7 +260,7 @@ export function usePresets({
     await storage.set('vision', toSave);
     setVision(toSave);
     setVisionSaved(true);
-    setTimeout(() => setVisionSaved(false), 2000);
+    setTimeout(() => setVisionSaved(false), STATUS_RESET_DELAY_MS);
   }, [selectedPresetId, vision, setVision]);
 
   const handleCreatePreset = useCallback(async () => {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,3 +1,5 @@
+import { MS_PER_DAY } from '~/constants/intervals';
+
 // Format seconds to human readable string (e.g., "1h 23m")
 export function formatTime(seconds: number): string {
   if (seconds < 60) {
@@ -42,7 +44,7 @@ export function isWithinDays(dateKey: string, days: number): boolean {
   const date = new Date(dateKey);
   const now = new Date();
   const diffTime = now.getTime() - date.getTime();
-  const diffDays = diffTime / (1000 * 60 * 60 * 24);
+  const diffDays = diffTime / MS_PER_DAY;
   return diffDays <= days;
 }
 

--- a/src/newtab.tsx
+++ b/src/newtab.tsx
@@ -11,6 +11,7 @@ import { Settings, ShieldX, Clock } from 'lucide-react';
 
 import { DownloadButton } from '~/components/features';
 import { MiniStats, GoalDisplay, BlockedSitesList } from '~/components/newtab';
+import { NEWTAB_STATS_POLLING_MS, MS_PER_DAY } from '~/constants/intervals';
 import { openExtensionPage, openOptionsPage } from '~/lib/chromeApi';
 import {
   useBackgroundPreload,
@@ -60,7 +61,7 @@ function NewtabApp() {
     },
     DEFAULT_ANALYTICS
   );
-  const stats = useBackgroundStats(10000);
+  const stats = useBackgroundStats(NEWTAB_STATS_POLLING_MS);
   const { isPremium, isLoading: isPremiumLoading } = usePremiumStatus();
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState('');
@@ -130,7 +131,7 @@ function NewtabApp() {
     const createdDate = new Date(blockItem.createdAt);
     const now = new Date();
     const diffTime = now.getTime() - createdDate.getTime();
-    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+    const diffDays = Math.floor(diffTime / MS_PER_DAY);
 
     return Math.max(1, diffDays);
   }, [blockedInfo?.domain, settings?.blockList]);

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -10,6 +10,7 @@ import {
   TimeLimitBadge
 } from '~/components/features';
 import { PasswordModal } from '~/components/options/modals';
+import { POPUP_STATS_POLLING_MS } from '~/constants/intervals';
 import {
   useBackgroundStats,
   useCurrentDomain,
@@ -33,7 +34,7 @@ function PopupApp() {
     { key: 'vision', instance: storage },
     DEFAULT_VISION
   );
-  const stats = useBackgroundStats(5000);
+  const stats = useBackgroundStats(POPUP_STATS_POLLING_MS);
   const { isPremium } = usePremiumStatus();
   const { currentDomain, timeLimitInfo, clearDomain } = useCurrentDomain();
 


### PR DESCRIPTION
## Summary
- `src/constants/intervals.ts` を新規作成し、プロジェクト全体に散在していたインターバル値・タイムアウト値・アラーム周期・日数計算定数などのマジックナンバーを UPPER_SNAKE_CASE の名前付き定数として一元管理
- 対象ファイル 17 件（popup.tsx, newtab.tsx, background/index.ts, hooks, components 等）のハードコード値を定数参照に置換
- format / lint / build すべて通過済み

## Changes
| カテゴリ | 定数例 | 元の値 |
|----------|--------|--------|
| UI ポーリング | `POPUP_STATS_POLLING_MS`, `NEWTAB_STATS_POLLING_MS` | 5000, 10000 |
| BG サービス遅延 | `STORAGE_SETTLE_DELAY_MS`, `TRACKING_UPDATE_INTERVAL_MS` | 100, 1000 |
| Chrome アラーム | `ALARM_DAILY_CLEANUP_MINUTES` 等 | 60, 1 |
| 日数計算 | `MS_PER_DAY`, `MAX_HISTORY_DAYS_FALLBACK` | 1000*60*60*24, 365 |
| UI フィードバック | `STATUS_RESET_DELAY_MS`, `SHARE_MESSAGE_DELAY_MS` 等 | 2000, 3000, 5000 |

## Test plan
- [ ] `pnpm run build` が成功することを確認
- [ ] `pnpm run lint` がエラーなしで通ることを確認
- [ ] popup を開いてブロック統計がポーリングされることを確認
- [ ] newtab ページの統計表示が動作することを確認
- [ ] 設定変更後にブロックルールが更新されることを確認
- [ ] パスワード設定のフィードバック表示が正常に消えることを確認

Closes #99
