### PR TITLE
feat: 全コンポーネントの直接色指定をセマンティックトークンに移行

### DIFF
--- a/src/components/features/AnalyticsChart/AnalyticsChart.tsx
+++ b/src/components/features/AnalyticsChart/AnalyticsChart.tsx
@@ -328,14 +328,14 @@ export function AnalyticsChart({
       className={`space-y-4 ${disabled ? 'opacity-50 pointer-events-none' : ''}`}
     >
       {/* Summary */}
-      <div className="p-4 bg-orange-50 rounded-lg border border-orange-100">
-        <p className="text-sm text-orange-600 font-medium">
+      <div className="p-4 bg-block-50 rounded-lg border border-block-100">
+        <p className="text-sm text-block-600 font-medium">
           {getMessage('totalTimeOnUnblockedSites')}
         </p>
-        <p className="text-2xl font-bold text-orange-700">
+        <p className="text-2xl font-bold text-block-700">
           {formatTime(totalTime)}
         </p>
-        <p className="text-xs text-orange-500 mt-1">
+        <p className="text-xs text-block-500 mt-1">
           {getMessage('chartSiteCount', String(unblockedDomains.length))}
         </p>
       </div>

--- a/src/components/features/DownloadButton/DownloadButton.tsx
+++ b/src/components/features/DownloadButton/DownloadButton.tsx
@@ -68,8 +68,9 @@ export function DownloadButton({
   };
 
   const getButtonColor = () => {
-    if (downloadStatus === 'success') return 'bg-green-500 hover:bg-green-600';
-    if (downloadStatus === 'error') return 'bg-red-500 hover:bg-red-600';
+    if (downloadStatus === 'success')
+      return 'bg-success-500 hover:bg-success-600';
+    if (downloadStatus === 'error') return 'bg-danger-500 hover:bg-danger-600';
     return 'bg-black/50 hover:bg-black/70';
   };
 

--- a/src/components/features/ImageUploader/ImageUploader.tsx
+++ b/src/components/features/ImageUploader/ImageUploader.tsx
@@ -184,7 +184,7 @@ export function ImageUploader({
         )}
       </div>
 
-      {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+      {error && <p className="text-sm text-danger-500 text-center">{error}</p>}
     </div>
   );
 }

--- a/src/components/features/PasswordModal/PasswordModal.tsx
+++ b/src/components/features/PasswordModal/PasswordModal.tsx
@@ -44,9 +44,9 @@ export function PasswordModal({
           </button>
         </div>
         <div className="p-4 space-y-4">
-          <div className="flex items-center gap-3 p-3 bg-amber-50 rounded-lg">
-            <Lock className="w-5 h-5 text-amber-600 flex-shrink-0" />
-            <p className="text-sm text-amber-800">
+          <div className="flex items-center gap-3 p-3 bg-warning-50 rounded-lg">
+            <Lock className="w-5 h-5 text-warning-600 flex-shrink-0" />
+            <p className="text-sm text-warning-800">
               {getMessage('passwordRequiredForPause')}
             </p>
           </div>
@@ -82,7 +82,7 @@ export function PasswordModal({
               </button>
             </div>
             {passwordError && (
-              <p className="text-sm text-red-600">{passwordError}</p>
+              <p className="text-sm text-danger-600">{passwordError}</p>
             )}
           </div>
 

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -35,7 +35,7 @@ interface MonthlyReportCardProps {
 function TrendIcon({ trend }: { trend: 'improving' | 'declining' | 'stable' }) {
   if (trend === 'improving') {
     return (
-      <div className="flex items-center gap-1 text-green-600">
+      <div className="flex items-center gap-1 text-success-600">
         <TrendingUp className="w-4 h-4" />
         <span className="text-sm font-medium">{getMessage('improving')}</span>
       </div>
@@ -43,7 +43,7 @@ function TrendIcon({ trend }: { trend: 'improving' | 'declining' | 'stable' }) {
   }
   if (trend === 'declining') {
     return (
-      <div className="flex items-center gap-1 text-red-600">
+      <div className="flex items-center gap-1 text-danger-600">
         <TrendingDown className="w-4 h-4" />
         <span className="text-sm font-medium">{getMessage('declining')}</span>
       </div>
@@ -69,30 +69,30 @@ function StatsGrid({
 }) {
   return (
     <div className="grid grid-cols-3 gap-4">
-      <div className="text-center p-3 bg-red-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-red-600 mb-1">
+      <div className="text-center p-3 bg-danger-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-danger-600 mb-1">
           <Clock className="w-4 h-4" />
         </div>
-        <p className="text-lg font-bold text-red-700">
+        <p className="text-lg font-bold text-danger-700">
           {formatTime(wasteTime)}
         </p>
-        <p className="text-xs text-red-600">{getMessage('wasteTime')}</p>
+        <p className="text-xs text-danger-600">{getMessage('wasteTime')}</p>
       </div>
-      <div className="text-center p-3 bg-green-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-green-600 mb-1">
+      <div className="text-center p-3 bg-success-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-success-600 mb-1">
           <Clock className="w-4 h-4" />
         </div>
-        <p className="text-lg font-bold text-green-700">
+        <p className="text-lg font-bold text-success-700">
           {formatTime(investTime)}
         </p>
-        <p className="text-xs text-green-600">{getMessage('investTime')}</p>
+        <p className="text-xs text-success-600">{getMessage('investTime')}</p>
       </div>
-      <div className="text-center p-3 bg-blue-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-blue-600 mb-1">
+      <div className="text-center p-3 bg-info-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-info-600 mb-1">
           <Shield className="w-4 h-4" />
         </div>
-        <p className="text-lg font-bold text-blue-700">{blockCount}</p>
-        <p className="text-xs text-blue-600">{getMessage('blockedCount')}</p>
+        <p className="text-lg font-bold text-info-700">{blockCount}</p>
+        <p className="text-xs text-info-600">{getMessage('blockedCount')}</p>
       </div>
     </div>
   );
@@ -114,8 +114,8 @@ function TopSitesList({
     );
   }
 
-  const bgColor = type === 'waste' ? 'bg-red-50' : 'bg-green-50';
-  const textColor = type === 'waste' ? 'text-red-600' : 'text-green-600';
+  const bgColor = type === 'waste' ? 'bg-danger-50' : 'bg-success-50';
+  const textColor = type === 'waste' ? 'text-danger-600' : 'text-success-600';
 
   return (
     <div className="space-y-2">
@@ -166,12 +166,12 @@ function MiniBarChart({
           <div key={index} className="flex flex-col items-center flex-1">
             <div className="flex gap-0.5 items-end h-16 w-full justify-center">
               <div
-                className="w-2 bg-red-400 rounded-t"
+                className="w-2 bg-danger-400 rounded-t"
                 style={{ height: `${Math.max(wasteHeight, 2)}%` }}
                 title={`${getMessage('waste')}: ${formatTime(item.wasteTime)}`}
               />
               <div
-                className="w-2 bg-green-400 rounded-t"
+                className="w-2 bg-success-400 rounded-t"
                 style={{ height: `${Math.max(investHeight, 2)}%` }}
                 title={`${getMessage('invest')}: ${formatTime(item.investTime)}`}
               />
@@ -264,13 +264,13 @@ export function WeeklyReportCard({
           {/* Top Sites */}
           <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-100">
             <div>
-              <h4 className="text-sm font-medium text-red-700 mb-2">
+              <h4 className="text-sm font-medium text-danger-700 mb-2">
                 {getMessage('topWasteSites')}
               </h4>
               <TopSitesList sites={report.topWasteSites} type="waste" />
             </div>
             <div>
-              <h4 className="text-sm font-medium text-green-700 mb-2">
+              <h4 className="text-sm font-medium text-success-700 mb-2">
                 {getMessage('topInvestSites')}
               </h4>
               <TopSitesList sites={report.topInvestSites} type="invest" />
@@ -344,13 +344,13 @@ export function MonthlyReportCard({
           {/* Top Sites */}
           <div className="grid grid-cols-2 gap-4 pt-4 border-t border-gray-100">
             <div>
-              <h4 className="text-sm font-medium text-red-700 mb-2">
+              <h4 className="text-sm font-medium text-danger-700 mb-2">
                 {getMessage('topWasteSites')}
               </h4>
               <TopSitesList sites={report.topWasteSites} type="waste" />
             </div>
             <div>
-              <h4 className="text-sm font-medium text-green-700 mb-2">
+              <h4 className="text-sm font-medium text-success-700 mb-2">
                 {getMessage('topInvestSites')}
               </h4>
               <TopSitesList sites={report.topInvestSites} type="invest" />

--- a/src/components/features/StatsCard/StatsCard.tsx
+++ b/src/components/features/StatsCard/StatsCard.tsx
@@ -14,9 +14,17 @@ const typeStyles: Record<
   StatsType,
   { bg: string; text: string; icon: string }
 > = {
-  waste: { bg: 'bg-red-50', text: 'text-red-600', icon: 'text-red-500' },
-  invest: { bg: 'bg-green-50', text: 'text-green-600', icon: 'text-green-500' },
-  block: { bg: 'bg-amber-50', text: 'text-amber-600', icon: 'text-amber-500' },
+  waste: {
+    bg: 'bg-danger-50',
+    text: 'text-danger-600',
+    icon: 'text-danger-500'
+  },
+  invest: {
+    bg: 'bg-success-50',
+    text: 'text-success-600',
+    icon: 'text-success-500'
+  },
+  block: { bg: 'bg-block-50', text: 'text-block-600', icon: 'text-block-500' },
   neutral: { bg: 'bg-gray-50', text: 'text-gray-600', icon: 'text-gray-500' }
 };
 

--- a/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
+++ b/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
@@ -27,15 +27,15 @@ export function TimeLimitBadge({
 
   if (isExceeded) {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-danger-100 text-danger-700 text-xs rounded-full">
         <AlertTriangle className="w-3 h-3" />
         {getMessage('timeLimitReached')}
       </span>
     );
   }
 
-  const bgColor = isLow ? 'bg-amber-100' : 'bg-blue-100';
-  const textColor = isLow ? 'text-amber-700' : 'text-blue-700';
+  const bgColor = isLow ? 'bg-warning-100' : 'bg-info-100';
+  const textColor = isLow ? 'text-warning-700' : 'text-info-700';
 
   const timeDisplay = formatTime(remainingSeconds);
   const suffix =

--- a/src/components/features/UpgradePrompt/UpgradePrompt.tsx
+++ b/src/components/features/UpgradePrompt/UpgradePrompt.tsx
@@ -54,12 +54,12 @@ export function UpgradePrompt({
 
   if (variant === 'inline') {
     return (
-      <div className="flex items-center gap-2 text-sm text-amber-600 bg-amber-50 px-3 py-2 rounded-lg">
+      <div className="flex items-center gap-2 text-sm text-block-600 bg-block-50 px-3 py-2 rounded-lg">
         <Crown className="w-4 h-4 flex-shrink-0" />
         <span>{message || defaultMessage}</span>
         <button
           onClick={handleUpgradeClick}
-          className="text-amber-700 font-medium hover:underline ml-auto"
+          className="text-block-700 font-medium hover:underline ml-auto"
         >
           {getMessage('upgradeToPremium')}
         </button>
@@ -117,7 +117,7 @@ export function UpgradePrompt({
                     key={index}
                     className="flex items-center gap-2 text-sm text-gray-600"
                   >
-                    <Check className="w-4 h-4 text-green-500 flex-shrink-0" />
+                    <Check className="w-4 h-4 text-success-500 flex-shrink-0" />
                     {feature}
                   </li>
                 )

--- a/src/components/newtab/BlockedSitesList.tsx
+++ b/src/components/newtab/BlockedSitesList.tsx
@@ -36,8 +36,8 @@ export function BlockedSitesList({
         className="w-full flex items-center justify-between px-5 py-3 bg-white/10 hover:bg-white/15 backdrop-blur-sm rounded-xl border border-white/10 transition-all duration-200"
       >
         <div className="flex items-center gap-3">
-          <div className="p-1.5 bg-red-500/20 rounded-lg">
-            <Shield className="w-4 h-4 text-red-400" />
+          <div className="p-1.5 bg-danger-500/20 rounded-lg">
+            <Shield className="w-4 h-4 text-danger-400" />
           </div>
           <span className="text-sm font-medium text-white/90">
             {getMessage('blockedSites')} ({enabledBlockList.length})
@@ -62,7 +62,7 @@ export function BlockedSitesList({
                   className="px-5 py-3 flex items-center justify-between hover:bg-white/5 transition-colors"
                 >
                   <div className="flex items-center gap-3 min-w-0">
-                    <span className="w-2 h-2 rounded-full bg-red-400 flex-shrink-0 shadow-[0_0_6px_rgba(248,113,113,0.5)]" />
+                    <span className="w-2 h-2 rounded-full bg-danger-400 flex-shrink-0 shadow-[0_0_6px_rgba(248,113,113,0.5)]" />
                     <span className="text-sm text-white/80 truncate font-medium">
                       {item.domain}
                     </span>

--- a/src/components/newtab/MiniStats.tsx
+++ b/src/components/newtab/MiniStats.tsx
@@ -21,25 +21,25 @@ export function MiniStats({
       <div className="flex justify-center gap-4">
         {/* Today's Blocks */}
         <div className="bg-white/90 backdrop-blur-sm rounded-xl px-6 py-4 min-w-[120px]">
-          <div className="flex items-center justify-center gap-2 text-amber-500 mb-1">
+          <div className="flex items-center justify-center gap-2 text-block-500 mb-1">
             <Ban className="w-4 h-4" />
             <span className="text-xs font-medium">
               {getMessage('todayBlocks')}
             </span>
           </div>
-          <p className="text-xl font-bold text-amber-600">{blockCount}</p>
+          <p className="text-xl font-bold text-block-600">{blockCount}</p>
         </div>
 
         {/* Blocking Days */}
         {blockingDays !== null && (
           <div className="bg-white/90 backdrop-blur-sm rounded-xl px-6 py-4 min-w-[120px]">
-            <div className="flex items-center justify-center gap-2 text-blue-500 mb-1">
+            <div className="flex items-center justify-center gap-2 text-info-500 mb-1">
               <Calendar className="w-4 h-4" />
               <span className="text-xs font-medium">
                 {getMessage('blockingDays')}
               </span>
             </div>
-            <p className="text-xl font-bold text-blue-600">
+            <p className="text-xl font-bold text-info-600">
               {getMessage('blockedForDays', blockingDays.toString())}
             </p>
           </div>

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -135,7 +135,7 @@ export function BlocklistTab({
           </Button>
         </div>
         {blockError && (
-          <p className="mt-2 text-sm text-red-600">{blockError}</p>
+          <p className="mt-2 text-sm text-danger-600">{blockError}</p>
         )}
       </Card>
 
@@ -181,7 +181,7 @@ export function BlocklistTab({
 
       {/* Password Protection Indicator */}
       {isPasswordProtected && (
-        <div className="flex items-center gap-2 text-sm text-amber-600">
+        <div className="flex items-center gap-2 text-sm text-block-600">
           <Lock className="w-4 h-4" />
           <span>{getMessage('passwordProtectionActive')}</span>
         </div>

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -161,8 +161,8 @@ export function HelpTab({
       {/* Getting Started */}
       <Card>
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-            <BookOpen className="w-5 h-5 text-blue-600" />
+          <div className="w-10 h-10 bg-info-100 rounded-lg flex items-center justify-center">
+            <BookOpen className="w-5 h-5 text-info-600" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
@@ -199,8 +199,8 @@ export function HelpTab({
       {/* FAQ */}
       <Card>
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-            <MessageCircle className="w-5 h-5 text-green-600" />
+          <div className="w-10 h-10 bg-success-100 rounded-lg flex items-center justify-center">
+            <MessageCircle className="w-5 h-5 text-success-600" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
@@ -214,7 +214,7 @@ export function HelpTab({
 
         <div className="space-y-4">
           <details className="group">
-            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-blue-600">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
               {getMessage('helpFaqWildcard')}
             </summary>
             <p className="mt-2 text-sm text-gray-600 pl-4">
@@ -222,7 +222,7 @@ export function HelpTab({
             </p>
           </details>
           <details className="group">
-            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-blue-600">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
               {getMessage('helpFaqPause')}
             </summary>
             <p className="mt-2 text-sm text-gray-600 pl-4">
@@ -230,7 +230,7 @@ export function HelpTab({
             </p>
           </details>
           <details className="group">
-            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-blue-600">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
               {getMessage('helpFaqPresets')}
             </summary>
             <p className="mt-2 text-sm text-gray-600 pl-4">
@@ -251,8 +251,8 @@ export function HelpTab({
       {/* Settings Backup */}
       <Card>
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
-            <HardDrive className="w-5 h-5 text-amber-600" />
+          <div className="w-10 h-10 bg-warning-100 rounded-lg flex items-center justify-center">
+            <HardDrive className="w-5 h-5 text-warning-600" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
@@ -305,7 +305,7 @@ export function HelpTab({
               </Button>
             </div>
             {exportWarning && (
-              <div className="mt-3 flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg">
+              <div className="mt-3 flex items-center gap-2 text-xs text-warning-600 bg-warning-50 px-3 py-2 rounded-lg">
                 <AlertTriangle className="w-4 h-4 flex-shrink-0" />
                 <span>{exportWarning}</span>
               </div>
@@ -358,8 +358,8 @@ export function HelpTab({
               <div
                 className={`mt-3 flex items-center gap-2 text-xs px-3 py-2 rounded-lg ${
                   importStatus === 'success'
-                    ? 'text-green-600 bg-green-50'
-                    : 'text-red-600 bg-red-50'
+                    ? 'text-success-600 bg-success-50'
+                    : 'text-danger-600 bg-danger-50'
                 }`}
               >
                 {importStatus === 'success' ? (
@@ -375,7 +375,7 @@ export function HelpTab({
                 {importWarnings.map((warning, index) => (
                   <div
                     key={index}
-                    className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg"
+                    className="flex items-center gap-2 text-xs text-warning-600 bg-warning-50 px-3 py-2 rounded-lg"
                   >
                     <AlertTriangle className="w-4 h-4 flex-shrink-0" />
                     <span>{warning}</span>
@@ -390,8 +390,8 @@ export function HelpTab({
       {/* Support */}
       <Card>
         <div className="flex items-center gap-3 mb-4">
-          <div className="w-10 h-10 bg-purple-100 rounded-lg flex items-center justify-center">
-            <Mail className="w-5 h-5 text-purple-600" />
+          <div className="w-10 h-10 bg-premium-100 rounded-lg flex items-center justify-center">
+            <Mail className="w-5 h-5 text-premium-600" />
           </div>
           <div>
             <h2 className="text-lg font-semibold text-gray-900">
@@ -408,7 +408,7 @@ export function HelpTab({
             href="https://github.com/user/vision-focus/issues"
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-2 text-sm text-blue-600 hover:text-blue-800"
+            className="flex items-center gap-2 text-sm text-info-600 hover:text-info-800"
           >
             <ExternalLink className="w-4 h-4" />
             {getMessage('helpReportIssue')}

--- a/src/components/options/PasswordSettingsSection.tsx
+++ b/src/components/options/PasswordSettingsSection.tsx
@@ -144,8 +144,8 @@ export function PasswordSettingsSection({
   return (
     <Card>
       <div className="flex items-center gap-3 mb-4">
-        <div className="w-10 h-10 bg-amber-100 rounded-lg flex items-center justify-center">
-          <Lock className="w-5 h-5 text-amber-600" />
+        <div className="w-10 h-10 bg-warning-100 rounded-lg flex items-center justify-center">
+          <Lock className="w-5 h-5 text-warning-600" />
         </div>
         <div className="flex-1">
           <h2 className="text-lg font-semibold text-gray-900">
@@ -163,14 +163,14 @@ export function PasswordSettingsSection({
       {mode === 'view' && (
         <div
           className={`flex items-center gap-2 p-3 rounded-lg ${
-            isEnabled ? 'bg-green-50' : 'bg-gray-50'
+            isEnabled ? 'bg-success-50' : 'bg-gray-50'
           }`}
         >
           <Shield
-            className={`w-4 h-4 ${isEnabled ? 'text-green-600' : 'text-gray-400'}`}
+            className={`w-4 h-4 ${isEnabled ? 'text-success-600' : 'text-gray-400'}`}
           />
           <span
-            className={`text-sm ${isEnabled ? 'text-green-700' : 'text-gray-500'}`}
+            className={`text-sm ${isEnabled ? 'text-success-700' : 'text-gray-500'}`}
           >
             {isEnabled
               ? getMessage('passwordProtectionEnabled')
@@ -179,7 +179,7 @@ export function PasswordSettingsSection({
           {isEnabled && (
             <button
               onClick={() => setMode('change')}
-              className="ml-auto text-sm text-blue-600 hover:text-blue-800"
+              className="ml-auto text-sm text-info-600 hover:text-info-800"
             >
               {getMessage('changePassword')}
             </button>
@@ -189,8 +189,8 @@ export function PasswordSettingsSection({
 
       {mode === 'set' && (
         <div className="space-y-4">
-          <div className="p-3 bg-blue-50 rounded-lg">
-            <p className="text-sm text-blue-700">
+          <div className="p-3 bg-info-50 rounded-lg">
+            <p className="text-sm text-info-700">
               {getMessage('passwordSetInstructions')}
             </p>
           </div>
@@ -269,8 +269,8 @@ export function PasswordSettingsSection({
 
       {mode === 'remove' && (
         <div className="space-y-4">
-          <div className="p-3 bg-amber-50 rounded-lg">
-            <p className="text-sm text-amber-700">
+          <div className="p-3 bg-warning-50 rounded-lg">
+            <p className="text-sm text-warning-700">
               {getMessage('passwordRemoveWarning')}
             </p>
           </div>

--- a/src/components/options/PremiumTab.tsx
+++ b/src/components/options/PremiumTab.tsx
@@ -72,15 +72,15 @@ export function PremiumTab({
               <h2 className="text-lg font-semibold text-gray-900">
                 {getMessage('currentPlan')}
               </h2>
-              <span className="inline-flex items-center gap-1 px-3 py-1.5 bg-gradient-to-r from-amber-400 to-yellow-500 text-white rounded-full text-sm font-bold shadow-sm">
+              <span className="inline-flex items-center gap-1 px-3 py-1.5 bg-gradient-to-r from-premium-400 to-premium-500 text-white rounded-full text-sm font-bold shadow-sm">
                 <Crown className="w-4 h-4" />
                 Premium
               </span>
             </div>
 
-            <div className="p-4 bg-gradient-to-br from-amber-50 to-yellow-50 border border-amber-200 rounded-xl">
+            <div className="p-4 bg-gradient-to-br from-premium-50 to-premium-50 border border-premium-200 rounded-xl">
               <div className="flex items-center gap-4">
-                <div className="w-12 h-12 bg-gradient-to-br from-amber-400 to-yellow-500 rounded-full flex items-center justify-center shadow-lg">
+                <div className="w-12 h-12 bg-gradient-to-br from-premium-400 to-premium-500 rounded-full flex items-center justify-center shadow-lg">
                   <Crown className="w-6 h-6 text-white" />
                 </div>
                 <div>
@@ -115,14 +115,14 @@ export function PremiumTab({
               {comparisonFeatures.map((feature, index) => (
                 <div
                   key={index}
-                  className="flex items-center justify-between p-3 bg-gradient-to-r from-amber-50/50 to-yellow-50/50 border border-amber-100 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-gradient-to-r from-premium-50/50 to-premium-50/50 border border-premium-100 rounded-lg"
                 >
                   <span className="text-gray-700">{feature.name}</span>
                   <div className="flex items-center gap-2">
                     {feature.premium === true ? (
-                      <Check className="w-5 h-5 text-green-500" />
+                      <Check className="w-5 h-5 text-success-500" />
                     ) : (
-                      <span className="font-medium text-amber-600">
+                      <span className="font-medium text-premium-600">
                         {feature.premium}
                       </span>
                     )}
@@ -173,9 +173,9 @@ export function PremiumTab({
           </Card>
 
           {/* Upgrade CTA with Price Anchoring */}
-          <Card className="bg-gradient-to-br from-sky-50 to-blue-100 border border-blue-200">
+          <Card className="bg-gradient-to-br from-info-50 to-info-100 border border-info-200">
             <div className="text-center">
-              <div className="inline-flex items-center gap-1 px-3 py-1 bg-blue-500 text-white rounded-full text-sm font-medium mb-3">
+              <div className="inline-flex items-center gap-1 px-3 py-1 bg-info-500 text-white rounded-full text-sm font-medium mb-3">
                 <Sparkles className="w-4 h-4" />
                 Premium
               </div>
@@ -185,7 +185,7 @@ export function PremiumTab({
               </h2>
 
               <div className="flex items-baseline justify-center gap-1 mb-1">
-                <span className="text-4xl font-bold text-blue-600">$1.99</span>
+                <span className="text-4xl font-bold text-info-600">$1.99</span>
                 <span className="text-gray-500">/月</span>
               </div>
 
@@ -198,7 +198,7 @@ export function PremiumTab({
 
               <Button
                 onClick={onUpgrade}
-                className="w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-3"
+                className="w-full bg-info-500 hover:bg-info-600 text-white font-bold py-3"
               >
                 <Crown className="w-5 h-5" />
                 {getMessage('upgradeToPremium')}
@@ -226,7 +226,7 @@ export function PremiumTab({
                     <th className="text-center py-3 px-3 font-medium text-gray-600 w-24">
                       Free
                     </th>
-                    <th className="text-center py-3 px-3 font-medium text-blue-600 w-24 bg-blue-50">
+                    <th className="text-center py-3 px-3 font-medium text-info-600 w-24 bg-info-50">
                       Premium
                     </th>
                   </tr>
@@ -235,7 +235,7 @@ export function PremiumTab({
                   {comparisonFeatures.map((feature, index) => (
                     <tr
                       key={index}
-                      className={feature.highlight ? 'bg-amber-50/50' : ''}
+                      className={feature.highlight ? 'bg-premium-50/50' : ''}
                     >
                       <td className="py-3 px-4 text-gray-700">
                         {feature.name}
@@ -247,11 +247,11 @@ export function PremiumTab({
                           <span className="text-gray-600">{feature.free}</span>
                         )}
                       </td>
-                      <td className="py-3 px-3 text-center bg-blue-50/50">
+                      <td className="py-3 px-3 text-center bg-info-50/50">
                         {feature.premium === true ? (
-                          <Check className="w-5 h-5 text-green-500 mx-auto" />
+                          <Check className="w-5 h-5 text-success-500 mx-auto" />
                         ) : (
-                          <span className="font-medium text-blue-600">
+                          <span className="font-medium text-info-600">
                             {feature.premium}
                           </span>
                         )}

--- a/src/components/options/SchedulesTab.tsx
+++ b/src/components/options/SchedulesTab.tsx
@@ -76,7 +76,7 @@ export function SchedulesTab({
                         key={day}
                         className={`text-xs px-1.5 py-0.5 rounded ${
                           schedule.days.includes(idx)
-                            ? 'bg-blue-100 text-blue-700'
+                            ? 'bg-info-100 text-info-700'
                             : 'bg-gray-200 text-gray-400'
                         }`}
                       >
@@ -105,7 +105,7 @@ export function SchedulesTab({
                     size="sm"
                     onClick={() => onDeleteSchedule(schedule.id)}
                   >
-                    <Trash2 className="w-4 h-4 text-red-500" />
+                    <Trash2 className="w-4 h-4 text-danger-500" />
                   </Button>
                 </div>
               </div>

--- a/src/components/options/StylesTab.tsx
+++ b/src/components/options/StylesTab.tsx
@@ -112,16 +112,16 @@ export function StylesTab({ isPremium, featureLimits }: StylesTabProps) {
                   )}
                   <div className="flex gap-2 mt-4">
                     <div className="bg-white/90 rounded-lg px-3 py-2 text-center">
-                      <p className="text-xs text-amber-500">
+                      <p className="text-xs text-premium-500">
                         {getMessage('todayBlocks')}
                       </p>
-                      <p className="text-sm font-bold text-amber-600">0</p>
+                      <p className="text-sm font-bold text-premium-600">0</p>
                     </div>
                     <div className="bg-white/90 rounded-lg px-3 py-2 text-center">
-                      <p className="text-xs text-blue-500">
+                      <p className="text-xs text-info-500">
                         {getMessage('blockingDays')}
                       </p>
-                      <p className="text-sm font-bold text-blue-600">
+                      <p className="text-sm font-bold text-info-600">
                         {getMessage('blockedForDays', '1')}
                       </p>
                     </div>

--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -7,14 +7,22 @@ import type { Schedule, VisionSettings } from '~/types/storage';
 
 // Predefined colors for schedule blocks
 const SCHEDULE_COLORS = [
-  { bg: 'bg-blue-100', border: 'border-blue-300', text: 'text-blue-800' },
-  { bg: 'bg-purple-100', border: 'border-purple-300', text: 'text-purple-800' },
-  { bg: 'bg-green-100', border: 'border-green-300', text: 'text-green-800' },
-  { bg: 'bg-orange-100', border: 'border-orange-300', text: 'text-orange-800' },
+  { bg: 'bg-info-100', border: 'border-info-300', text: 'text-info-800' },
+  {
+    bg: 'bg-premium-100',
+    border: 'border-premium-300',
+    text: 'text-premium-800'
+  },
+  {
+    bg: 'bg-success-100',
+    border: 'border-success-300',
+    text: 'text-success-800'
+  },
+  { bg: 'bg-block-100', border: 'border-block-300', text: 'text-block-800' },
   { bg: 'bg-pink-100', border: 'border-pink-300', text: 'text-pink-800' },
   { bg: 'bg-teal-100', border: 'border-teal-300', text: 'text-teal-800' },
   { bg: 'bg-indigo-100', border: 'border-indigo-300', text: 'text-indigo-800' },
-  { bg: 'bg-red-100', border: 'border-red-300', text: 'text-red-800' }
+  { bg: 'bg-danger-100', border: 'border-danger-300', text: 'text-danger-800' }
 ];
 
 const DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
@@ -148,7 +156,7 @@ export function WeeklyCalendar({
                 key={day}
                 className={`p-2 text-center text-xs font-medium border-r border-gray-200 last:border-r-0 ${
                   isToday
-                    ? 'text-red-600 bg-red-50 font-semibold'
+                    ? 'text-danger-600 bg-danger-50 font-semibold'
                     : 'text-gray-700'
                 }`}
               >
@@ -202,8 +210,8 @@ export function WeeklyCalendar({
                     style={{ top: `${currentTimePercent}%` }}
                   >
                     <div className="relative flex items-center">
-                      <div className="absolute -left-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                      <div className="w-full h-0.5 bg-red-500" />
+                      <div className="absolute -left-1 w-2.5 h-2.5 bg-danger-500 rounded-full" />
+                      <div className="w-full h-0.5 bg-danger-500" />
                     </div>
                   </div>
                 )}

--- a/src/components/options/analytics/AnalyticsDateFilter.tsx
+++ b/src/components/options/analytics/AnalyticsDateFilter.tsx
@@ -74,8 +74,8 @@ export function AnalyticsDateFilter({
   return (
     <Card>
       <div className="flex items-start gap-3">
-        <div className="p-2 bg-purple-100 rounded-lg">
-          <BarChart3 className="w-5 h-5 text-purple-600" />
+        <div className="p-2 bg-premium-100 rounded-lg">
+          <BarChart3 className="w-5 h-5 text-premium-600" />
         </div>
         <div className="flex-1">
           <h3 className="text-lg font-semibold text-gray-900">

--- a/src/components/options/analytics/AnalyticsExportBar.tsx
+++ b/src/components/options/analytics/AnalyticsExportBar.tsx
@@ -192,8 +192,8 @@ export function AnalyticsExportBar({
       <Card>
         <div className="flex items-start justify-between">
           <div className="flex items-start gap-3">
-            <div className="p-2 bg-blue-100 rounded-lg">
-              <Shield className="w-5 h-5 text-blue-600" />
+            <div className="p-2 bg-info-100 rounded-lg">
+              <Shield className="w-5 h-5 text-info-600" />
             </div>
             <div>
               <h2 className="text-lg font-semibold text-gray-900">
@@ -308,7 +308,7 @@ export function AnalyticsExportBar({
                 variant="secondary"
                 size="sm"
                 onClick={() => setShowResetModal(true)}
-                className="flex items-center gap-1.5 text-gray-500 hover:text-red-500"
+                className="flex items-center gap-1.5 text-gray-500 hover:text-danger-500"
               >
                 <Trash2 className="w-4 h-4" />
                 {getMessage('reset')}
@@ -320,8 +320,8 @@ export function AnalyticsExportBar({
             <div
               className={`mb-4 p-3 rounded-lg text-sm ${
                 shareMessage.type === 'success'
-                  ? 'bg-green-50 text-green-700'
-                  : 'bg-red-50 text-red-700'
+                  ? 'bg-success-50 text-success-700'
+                  : 'bg-danger-50 text-danger-700'
               }`}
             >
               {shareMessage.text}

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -68,7 +68,7 @@ export function AnalyticsSummary({
       {!hasTrackedSites && (
         <Card>
           <div className="text-center py-12">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <div className="w-16 h-16 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <span className="text-3xl">&#10003;</span>
             </div>
             <h3 className="text-lg font-medium text-gray-900 mb-2">
@@ -85,7 +85,7 @@ export function AnalyticsSummary({
       {blockedSites.length > 0 && (
         <Card>
           <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <Lock className="w-4 h-4 text-green-600" />
+            <Lock className="w-4 h-4 text-success-600" />
             {getMessage('statusBlocked')} ({blockedSites.length})
           </h3>
           <div className="space-y-3">
@@ -100,7 +100,7 @@ export function AnalyticsSummary({
       {unblockedSites.length > 0 && (
         <Card>
           <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-orange-500" />
+            <AlertTriangle className="w-4 h-4 text-block-500" />
             {getMessage('statusUnblocked')} ({unblockedSites.length})
           </h3>
           <div className="space-y-3">
@@ -116,12 +116,12 @@ export function AnalyticsSummary({
 
             {/* Total time (Premium only) */}
             {isPremium && unblockedSites.length > 1 && (
-              <div className="pt-4 border-t border-orange-200">
+              <div className="pt-4 border-t border-block-200">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-gray-700">
                     {getMessage('totalTimeOnUnblockedSites')}
                   </span>
-                  <span className="text-lg font-bold text-orange-600">
+                  <span className="text-lg font-bold text-block-600">
                     {formatTime(totalTimeSpent)}
                   </span>
                 </div>
@@ -150,15 +150,15 @@ export function AnalyticsSummary({
 
 function BlockedSiteItem({ site }: { site: TrackedSite }) {
   return (
-    <div className="p-3 bg-green-50 rounded-lg border border-green-100">
+    <div className="p-3 bg-success-50 rounded-lg border border-success-100">
       <div className="flex items-center justify-between">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-green-500 rounded-full" />
+            <div className="w-2 h-2 bg-success-500 rounded-full" />
             <span className="font-medium text-gray-900 truncate">
               {site.domain}
             </span>
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-700">
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-100 text-success-700">
               {getMessage('statusBlocked')}
             </span>
           </div>
@@ -167,7 +167,7 @@ function BlockedSiteItem({ site }: { site: TrackedSite }) {
           </p>
         </div>
         <div className="text-right">
-          <span className="text-lg font-bold text-green-600">
+          <span className="text-lg font-bold text-success-600">
             0{getMessage('time') === 'Time' ? 'm' : '\u5206'}
           </span>
           <p className="text-xs text-gray-500">{getMessage('timeSaved')}</p>
@@ -191,15 +191,15 @@ function UnblockedSiteItem({
   onStopTracking
 }: UnblockedSiteItemProps) {
   return (
-    <div className="p-4 bg-orange-50 rounded-lg border border-orange-100">
+    <div className="p-4 bg-block-50 rounded-lg border border-block-100">
       <div className="flex items-start justify-between">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-orange-500 rounded-full" />
+            <div className="w-2 h-2 bg-block-500 rounded-full" />
             <span className="font-medium text-gray-900 truncate">
               {site.domain}
             </span>
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-700">
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-block-100 text-block-700">
               {getMessage('statusUnblocked')}
             </span>
           </div>
@@ -212,7 +212,7 @@ function UnblockedSiteItem({
           <div className="flex items-center gap-2 mt-2">
             <Clock className="w-4 h-4 text-gray-400" />
             {isPremium ? (
-              <span className="text-sm font-medium text-orange-600">
+              <span className="text-sm font-medium text-block-600">
                 {getMessage('timeSpentSinceUnblock')}:{' '}
                 {formatTime(site.timeAfterUnblock)}
               </span>

--- a/src/components/options/analytics/SiteRankingList.tsx
+++ b/src/components/options/analytics/SiteRankingList.tsx
@@ -22,7 +22,7 @@ export function SiteRankingList({ analyticsData }: SiteRankingListProps) {
   return (
     <Card>
       <div className="flex items-center gap-2 mb-4">
-        <Shield className="w-5 h-5 text-red-500" />
+        <Shield className="w-5 h-5 text-danger-500" />
         <h3 className="text-lg font-semibold text-gray-900">
           {getMessage('topBlockedSites')}
         </h3>
@@ -39,7 +39,7 @@ export function SiteRankingList({ analyticsData }: SiteRankingListProps) {
               </span>
               <span className="font-medium text-gray-900">{site.domain}</span>
             </div>
-            <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-red-100 text-red-700 text-sm font-medium rounded-full">
+            <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-danger-100 text-danger-700 text-sm font-medium rounded-full">
               <Shield className="w-3.5 h-3.5" />
               {getMessage('blockedTimesShort', site.count.toString())}
             </span>

--- a/src/components/options/blocklist/DomainListItem.tsx
+++ b/src/components/options/blocklist/DomainListItem.tsx
@@ -38,7 +38,7 @@ export function DomainListItem({
             >
               {item.isWildcard && (
                 <span
-                  className={item.enabled ? 'text-blue-600' : 'text-blue-300'}
+                  className={item.enabled ? 'text-info-600' : 'text-info-300'}
                 >
                   *.
                 </span>
@@ -50,14 +50,14 @@ export function DomainListItem({
             </p>
           </div>
           {blockCount > 0 && (
-            <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-red-100 text-red-700 text-xs rounded-full">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-danger-100 text-danger-700 text-xs rounded-full">
               <Shield className="w-3 h-3" />
               {getMessage('blockedTimesShort', blockCount.toString())}
             </span>
           )}
         </div>
         <Button variant="ghost" size="sm" onClick={() => onRemove(item.id)}>
-          <Trash2 className="w-4 h-4 text-red-500" />
+          <Trash2 className="w-4 h-4 text-danger-500" />
         </Button>
       </div>
 

--- a/src/components/options/blocklist/NotificationSettingsSection.tsx
+++ b/src/components/options/blocklist/NotificationSettingsSection.tsx
@@ -58,7 +58,7 @@ export function NotificationSettingsSection({
   return (
     <Card>
       <div className="flex items-center gap-3 mb-4">
-        <Bell className="w-5 h-5 text-blue-500" />
+        <Bell className="w-5 h-5 text-info-500" />
         <h2 className="text-lg font-semibold text-gray-900">
           {getMessage('notificationSettings')}
         </h2>

--- a/src/components/options/blocklist/YouTubeFeatureToggle.tsx
+++ b/src/components/options/blocklist/YouTubeFeatureToggle.tsx
@@ -25,12 +25,12 @@ export function YouTubeFeatureToggle({
         disabled
           ? 'bg-gray-50 opacity-60'
           : checked
-            ? 'bg-red-50'
+            ? 'bg-danger-50'
             : 'bg-gray-50 hover:bg-gray-100'
       }`}
     >
       <div
-        className={`p-1.5 rounded-lg ${checked && !disabled ? 'bg-red-100 text-red-600' : 'bg-gray-200 text-gray-500'}`}
+        className={`p-1.5 rounded-lg ${checked && !disabled ? 'bg-danger-100 text-danger-600' : 'bg-gray-200 text-gray-500'}`}
       >
         {icon}
       </div>

--- a/src/components/options/blocklist/YouTubeSection.tsx
+++ b/src/components/options/blocklist/YouTubeSection.tsx
@@ -68,8 +68,8 @@ export function YouTubeSection({
   return (
     <Card>
       <div className="flex items-start gap-3 mb-4">
-        <div className="p-2 bg-red-100 rounded-lg">
-          <Youtube className="w-5 h-5 text-red-600" />
+        <div className="p-2 bg-danger-100 rounded-lg">
+          <Youtube className="w-5 h-5 text-danger-600" />
         </div>
         <div className="flex-1">
           <h2 className="text-lg font-semibold text-gray-900">
@@ -102,9 +102,9 @@ export function YouTubeSection({
 
       {/* Feature Toggles */}
       {!isEnabled && (
-        <div className="mb-3 p-2 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-2">
-          <Info className="w-4 h-4 text-amber-600 flex-shrink-0" />
-          <p className="text-xs text-amber-700">
+        <div className="mb-3 p-2 bg-block-50 border border-block-200 rounded-lg flex items-center gap-2">
+          <Info className="w-4 h-4 text-block-600 flex-shrink-0" />
+          <p className="text-xs text-block-700">
             {getMessage('youtubeDisabledNote')}
           </p>
         </div>

--- a/src/components/options/modals/PasswordModal.tsx
+++ b/src/components/options/modals/PasswordModal.tsx
@@ -78,9 +78,9 @@ export function PasswordModal({
       size="sm"
     >
       <div className="space-y-4">
-        <div className="flex items-center gap-3 p-4 bg-amber-50 rounded-lg">
-          <Lock className="w-5 h-5 text-amber-600 flex-shrink-0" />
-          <p className="text-sm text-amber-800">
+        <div className="flex items-center gap-3 p-4 bg-warning-50 rounded-lg">
+          <Lock className="w-5 h-5 text-warning-600 flex-shrink-0" />
+          <p className="text-sm text-warning-800">
             {description || getMessage('passwordRequiredDescription')}
           </p>
         </div>
@@ -111,7 +111,7 @@ export function PasswordModal({
               )}
             </button>
           </div>
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p className="text-sm text-danger-600">{error}</p>}
         </div>
 
         <div className="flex gap-3 pt-2">

--- a/src/components/options/modals/ScheduleModal.tsx
+++ b/src/components/options/modals/ScheduleModal.tsx
@@ -71,7 +71,7 @@ export function ScheduleModal({
               onChange={(e) =>
                 onFormChange({ ...scheduleForm, startTime: e.target.value })
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
           <div>
@@ -84,7 +84,7 @@ export function ScheduleModal({
               onChange={(e) =>
                 onFormChange({ ...scheduleForm, endTime: e.target.value })
               }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
         </div>
@@ -100,7 +100,7 @@ export function ScheduleModal({
                 onClick={() => toggleDay(idx)}
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                   scheduleForm.days.includes(idx)
-                    ? 'bg-blue-500 text-white'
+                    ? 'bg-info-500 text-white'
                     : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
                 }`}
               >
@@ -120,7 +120,7 @@ export function ScheduleModal({
             onChange={(e) =>
               onFormChange({ ...scheduleForm, presetId: e.target.value })
             }
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm"
           >
             <option value="">{getMessage('noPresetSelected')}</option>
             {vision?.presets?.map((preset, index) => {
@@ -141,7 +141,7 @@ export function ScheduleModal({
             vision?.presets &&
             vision.presets.findIndex((p) => p.id === scheduleForm.presetId) >=
               featureLimits.maxPresets && (
-              <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg mt-2">
+              <div className="flex items-center gap-2 text-xs text-warning-600 bg-warning-50 px-3 py-2 rounded-lg mt-2">
                 <Lock className="w-3.5 h-3.5 flex-shrink-0" />
                 <span>{getMessage('scheduleLockedPresetWarning')}</span>
               </div>

--- a/src/components/options/password/FormFeedback.tsx
+++ b/src/components/options/password/FormFeedback.tsx
@@ -11,13 +11,13 @@ export function FormFeedback({ error, success }: FormFeedbackProps) {
   return (
     <>
       {error && (
-        <div className="flex items-center gap-2 text-sm text-red-600">
+        <div className="flex items-center gap-2 text-sm text-danger-600">
           <AlertTriangle className="w-4 h-4" />
           <span>{error}</span>
         </div>
       )}
       {success && (
-        <div className="flex items-center gap-2 text-sm text-green-600">
+        <div className="flex items-center gap-2 text-sm text-success-600">
           <Check className="w-4 h-4" />
           <span>{success}</span>
         </div>

--- a/src/components/options/styles/DisplaySettingsForm.tsx
+++ b/src/components/options/styles/DisplaySettingsForm.tsx
@@ -94,7 +94,7 @@ export function DisplaySettingsForm({
               placeholder={getMessage('goalSubTextPlaceholder')}
               maxLength={100}
               rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none text-sm"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none text-sm"
             />
             <p className="text-xs text-gray-400 mt-1 text-right">
               {draftDisplaySettings.goalSubText.length} / 100
@@ -141,7 +141,7 @@ export function DisplaySettingsForm({
               onClick={() => handleBackgroundTypeChange('image')}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 (draftDisplaySettings.backgroundType || 'image') === 'image'
-                  ? 'bg-blue-500 text-white'
+                  ? 'bg-info-500 text-white'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
@@ -151,7 +151,7 @@ export function DisplaySettingsForm({
               onClick={() => handleBackgroundTypeChange('color')}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 draftDisplaySettings.backgroundType === 'color'
-                  ? 'bg-blue-500 text-white'
+                  ? 'bg-info-500 text-white'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
               }`}
             >
@@ -169,7 +169,7 @@ export function DisplaySettingsForm({
                 onClick={() => handleBackgroundChange(bg.id)}
                 className={`relative aspect-video rounded-lg overflow-hidden border-2 transition-colors ${
                   draftDisplaySettings.backgroundImage === bg.id
-                    ? 'border-blue-500'
+                    ? 'border-info-500'
                     : 'border-gray-200 hover:border-gray-300'
                 }`}
               >
@@ -217,7 +217,7 @@ export function DisplaySettingsForm({
               {getMessage('customBackground')}
             </h3>
             {!isPremium && (
-              <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
+              <span className="text-xs text-premium-600 bg-premium-50 px-2 py-1 rounded-full">
                 {getMessage('premium')}
               </span>
             )}

--- a/src/components/options/styles/PresetSelector.tsx
+++ b/src/components/options/styles/PresetSelector.tsx
@@ -45,7 +45,7 @@ export function PresetSelector({
             {getMessage('dashboardPresets')}
           </h2>
           {!isPremium && (
-            <span className="text-xs text-amber-600 bg-amber-50 px-2 py-1 rounded-full">
+            <span className="text-xs text-premium-600 bg-premium-50 px-2 py-1 rounded-full">
               {getMessage('premium')}
             </span>
           )}
@@ -67,7 +67,7 @@ export function PresetSelector({
             />
 
             {!isPremium && draftPresets.length >= featureLimits.maxPresets && (
-              <p className="text-xs text-amber-600 mt-2">
+              <p className="text-xs text-premium-600 mt-2">
                 {getMessage(
                   'maxPresetsReached',
                   String(featureLimits.maxPresets)
@@ -80,7 +80,7 @@ export function PresetSelector({
               vision?.activePresetId &&
               draftPresets.findIndex((p) => p.id === vision.activePresetId) >=
                 featureLimits.maxPresets && (
-                <div className="flex items-center gap-2 text-xs text-amber-600 bg-amber-50 px-3 py-2 rounded-lg mt-2">
+                <div className="flex items-center gap-2 text-xs text-premium-600 bg-premium-50 px-3 py-2 rounded-lg mt-2">
                   <Lock className="w-3.5 h-3.5 flex-shrink-0" />
                   <span>{getMessage('lockedPresetWarning')}</span>
                 </div>
@@ -165,7 +165,7 @@ function PresetButtons({
               isLocked
                 ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
                 : isSelected
-                  ? 'bg-blue-500 text-white'
+                  ? 'bg-info-500 text-white'
                   : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
             }`}
           >
@@ -173,7 +173,7 @@ function PresetButtons({
             {!isLocked && isActive && (
               <Check
                 className={`w-3.5 h-3.5 ${
-                  isSelected ? 'text-white' : 'text-green-600'
+                  isSelected ? 'text-white' : 'text-success-600'
                 }`}
               />
             )}
@@ -222,14 +222,14 @@ function EditingIndicator({
   onSavePreset
 }: EditingIndicatorProps) {
   return (
-    <div className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-lg px-4 py-3">
+    <div className="flex items-center justify-between bg-info-50 border border-info-200 rounded-lg px-4 py-3">
       <div className="flex items-center gap-2">
-        <Target className="w-5 h-5 text-blue-600" />
-        <span className="text-sm font-medium text-blue-900">
+        <Target className="w-5 h-5 text-info-600" />
+        <span className="text-sm font-medium text-info-900">
           {getMessage('editingPreset', selectedPreset.name)}
         </span>
         {isDirty && (
-          <span className="text-xs text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full">
+          <span className="text-xs text-premium-600 bg-premium-100 px-2 py-0.5 rounded-full">
             {getMessage('unsavedChanges')}
           </span>
         )}
@@ -240,10 +240,10 @@ function EditingIndicator({
           size="sm"
           onClick={() => onDeletePreset(selectedPreset.id)}
         >
-          <Trash2 className="w-4 h-4 text-red-500" />
+          <Trash2 className="w-4 h-4 text-danger-500" />
         </Button>
         {vision?.activePresetId === selectedPresetId ? (
-          <span className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-green-700 bg-green-100 rounded-lg">
+          <span className="inline-flex items-center gap-1 px-3 py-1.5 text-sm font-medium text-success-700 bg-success-100 rounded-lg">
             <Check className="w-4 h-4" />
             {getMessage('activePreset')}
           </span>

--- a/src/newtab.tsx
+++ b/src/newtab.tsx
@@ -202,8 +202,8 @@ function NewtabApp() {
         <div className="relative z-10 w-full max-w-md px-8 text-center">
           {/* Block Icon */}
           <div className="mb-6">
-            <div className="w-24 h-24 mx-auto bg-red-500/20 rounded-full flex items-center justify-center">
-              <ShieldX className="w-12 h-12 text-red-400" />
+            <div className="w-24 h-24 mx-auto bg-danger-500/20 rounded-full flex items-center justify-center">
+              <ShieldX className="w-12 h-12 text-danger-400" />
             </div>
           </div>
 
@@ -217,14 +217,14 @@ function NewtabApp() {
               </h1>
               <p className="text-gray-300 mb-4">{blockedInfo.domain}</p>
               {blockReason === 'time_limit_exceeded' ? (
-                <p className="text-amber-300 text-sm">
+                <p className="text-warning-300 text-sm">
                   {getMessage(
                     'timeLimitReachedDescription',
                     blockedInfo.domain
                   )}
                 </p>
               ) : (
-                <p className="text-red-300 text-sm">
+                <p className="text-danger-300 text-sm">
                   {getMessage('blockedTimes', blockedInfo.count.toString())}
                 </p>
               )}
@@ -259,7 +259,7 @@ function NewtabApp() {
             </p>
             <button
               onClick={handleSettingsClick}
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 bg-info-600 hover:bg-info-700 text-white font-medium rounded-lg transition-colors"
             >
               <Settings className="w-4 h-4" />
               {getMessage('createFirstPreset')}
@@ -301,14 +301,14 @@ function NewtabApp() {
             <div
               className={`inline-flex items-center gap-3 ${
                 blockReason === 'time_limit_exceeded'
-                  ? 'bg-amber-500/20 border-amber-500/30'
-                  : 'bg-red-500/20 border-red-500/30'
+                  ? 'bg-warning-500/20 border-warning-500/30'
+                  : 'bg-danger-500/20 border-danger-500/30'
               } backdrop-blur-sm rounded-xl px-6 py-4 border`}
             >
               {blockReason === 'time_limit_exceeded' ? (
-                <Clock className="w-6 h-6 text-amber-400" />
+                <Clock className="w-6 h-6 text-warning-400" />
               ) : (
-                <ShieldX className="w-6 h-6 text-red-400" />
+                <ShieldX className="w-6 h-6 text-danger-400" />
               )}
               <div className="text-left">
                 <p className="text-white font-medium">
@@ -319,8 +319,8 @@ function NewtabApp() {
                 <p
                   className={`${
                     blockReason === 'time_limit_exceeded'
-                      ? 'text-amber-200'
-                      : 'text-red-200'
+                      ? 'text-warning-200'
+                      : 'text-danger-200'
                   } text-sm`}
                 >
                   {blockReason === 'time_limit_exceeded'

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -84,10 +84,10 @@ function PopupApp() {
           timeLimitInfo.remainingSeconds !== null &&
           timeLimitInfo.limitType &&
           timeLimitInfo.limitSeconds && (
-            <div className="bg-blue-50 rounded-xl p-3 flex items-center gap-3">
-              <Clock className="w-5 h-5 text-blue-500" />
+            <div className="bg-info-50 rounded-xl p-3 flex items-center gap-3">
+              <Clock className="w-5 h-5 text-info-500" />
               <div className="flex-1">
-                <p className="text-sm font-medium text-blue-700">
+                <p className="text-sm font-medium text-info-700">
                   {currentDomain}
                 </p>
                 <TimeLimitBadge
@@ -115,21 +115,21 @@ function PopupApp() {
             {getMessage('todaysSummary')}
           </h2>
           <div className="grid grid-cols-2 gap-3">
-            <div className="bg-amber-50 rounded-xl p-4">
+            <div className="bg-block-50 rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
-                <Ban className="w-4 h-4 text-amber-500" />
+                <Ban className="w-4 h-4 text-block-500" />
                 <span className="text-xs font-medium text-gray-500">
                   {getMessage('todayBlocks')}
                 </span>
               </div>
-              <p className="text-2xl font-bold text-amber-600">
+              <p className="text-2xl font-bold text-block-600">
                 {stats.blockCount}
               </p>
             </div>
 
-            <div className="bg-blue-50 rounded-xl p-4">
+            <div className="bg-info-50 rounded-xl p-4">
               <div className="flex items-center gap-2 mb-2">
-                <Shield className="w-4 h-4 text-blue-500" />
+                <Shield className="w-4 h-4 text-info-500" />
                 <span className="text-xs font-medium text-gray-500">
                   {getMessage('topBlockedSite')}
                 </span>
@@ -137,12 +137,12 @@ function PopupApp() {
               {stats.topBlockedSite ? (
                 <div>
                   <p
-                    className="text-sm font-bold text-blue-600 truncate"
+                    className="text-sm font-bold text-info-600 truncate"
                     title={stats.topBlockedSite.domain}
                   >
                     {stats.topBlockedSite.domain}
                   </p>
-                  <p className="text-xs text-blue-500">
+                  <p className="text-xs text-info-500">
                     {getMessage(
                       'blockedTimesShort',
                       stats.topBlockedSite.count.toString()
@@ -160,7 +160,7 @@ function PopupApp() {
           {isPremium && (
             <button
               onClick={handleAnalyticsClick}
-              className="mt-3 w-full flex items-center justify-center gap-2 py-2 text-sm text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-lg transition-colors"
+              className="mt-3 w-full flex items-center justify-center gap-2 py-2 text-sm text-info-600 hover:text-info-700 hover:bg-info-50 rounded-lg transition-colors"
             >
               <TrendingUp className="w-4 h-4" />
               {getMessage('viewAnalytics')}


### PR DESCRIPTION
## 概要

Issue #32（UIデザインの統一感・刷新）の**Phase 2: 全コンポーネントのセマンティックトークン移行**。

PR #122 で導入したセマンティックカラートークン（primary/success/warning/danger/block/premium/info）を、残りの全コンポーネントに適用。直接色指定（`red-500`, `green-500`, `blue-500` 等）をセマンティックトークンに統一。

## 変更内容

### Feature コンポーネント（8ファイル）

- **StatsCard**: red→danger, green→success, amber→block
- **TimeLimitBadge**: red→danger, amber→warning, blue→info
- **ReportCard**: red→danger, green→success, blue→info
- **DownloadButton**: red→danger, green→success
- **ImageUploader**: red→danger
- **UpgradePrompt**: green→success, amber→block
- **PasswordModal**: red→danger, amber→warning
- **AnalyticsChart**: orange Tailwind クラス→block（Chart.js hex カラーは保持）

### Options 画面コンポーネント（20ファイル）

- **BlocklistTab / SchedulesTab / StylesTab**: red→danger
- **PremiumTab**: amber→premium, green→success
- **HelpTab**: blue→primary/info
- **PasswordSettingsSection**: red→danger, green→success, amber→warning
- **WeeklyCalendar**: red→danger, green→success, blue→info
- **Analytics系**: blue→info, red→danger, green→success
- **Blocklist系**: red→danger, blue→info
- **Modals**: red→danger, blue→primary
- **Styles系**: blue→primary, purple→premium

### メインページ（4ファイル）

- **popup.tsx**: blue→info, amber→block
- **newtab.tsx**: red→danger, amber→warning, blue→info
- **MiniStats**: amber→block, blue→info
- **BlockedSitesList**: red→danger

## マッピングルール

| 旧（直接色指定） | 新（セマンティックトークン） | 用途 |
|---|---|---|
| `red-*` | `danger-*` | エラー、削除、警告 |
| `green-*` | `success-*` | 成功、投資時間 |
| `amber-*` | `warning-*` or `block-*` | 警告 or ブロック |
| `blue-*` | `info-*` or `primary-*` | 情報表示 or 主要アクション |
| `purple-*` / `violet-*` | `premium-*` | プレミアム機能 |
| `orange-*` | `block-*` | ブロック関連 |

## テスト計画

- [x] `pnpm type-check` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm format:check` 通過
- [ ] Storybook で各コンポーネントの新カラー表示を確認
- [ ] popup / newtab / options 画面の実機確認

Closes #32
