### PR TITLE
分析タブ: グラフの表示条件をisPremiumのみに修正

### DIFF
--- a/src/components/options/AnalyticsTab.tsx
+++ b/src/components/options/AnalyticsTab.tsx
@@ -48,10 +48,6 @@ export function AnalyticsTab({
     }
   };
 
-  const hasUnblockedSites = Object.values(unblockHistory.sites).some(
-    (s) => s.status === 'unblocked'
-  );
-
   return (
     <div className="space-y-6">
       <AnalyticsExportBar
@@ -59,7 +55,6 @@ export function AnalyticsTab({
         analyticsData={analyticsData}
         unblockHistory={unblockHistory}
         isPremium={isPremium}
-        hasUnblockedSites={hasUnblockedSites}
         onRefresh={onRefresh}
         onReset={onReset}
       />

--- a/src/components/options/analytics/AnalyticsExportBar.tsx
+++ b/src/components/options/analytics/AnalyticsExportBar.tsx
@@ -40,7 +40,6 @@ interface AnalyticsExportBarProps {
   analyticsData: AnalyticsData;
   unblockHistory: UnblockHistory;
   isPremium: boolean;
-  hasUnblockedSites: boolean;
   onRefresh: () => Promise<void>;
   onReset: () => void;
 }
@@ -50,7 +49,6 @@ export function AnalyticsExportBar({
   analyticsData,
   unblockHistory,
   isPremium,
-  hasUnblockedSites,
   onRefresh,
   onReset
 }: AnalyticsExportBarProps) {
@@ -269,7 +267,7 @@ export function AnalyticsExportBar({
       </Card>
 
       {/* Analytics Chart (Premium only) */}
-      {hasUnblockedSites && isPremium && (
+      {isPremium && (
         <Card>
           <div className="flex items-center justify-between mb-4">
             <h3 className="text-lg font-semibold text-gray-900">


### PR DESCRIPTION
## Summary
- 分析タブのグラフ表示条件を `hasUnblockedSites && isPremium` から `isPremium` のみに変更
- プレミアムユーザーにはブロック解除サイトの有無に関わらず常にグラフを表示
- 不要になった `hasUnblockedSites` プロパティを `AnalyticsExportBar` から削除

## 変更ファイル
- `src/components/options/analytics/AnalyticsExportBar.tsx` — 表示条件変更、プロパティ削除
- `src/components/options/AnalyticsTab.tsx` — 不要な変数定義・プロパティ受け渡し削除

Closes #124