### PR TITLE
feat: サポートセクションに問い合わせフォームリンクを追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1287,9 +1287,9 @@
     "message": "Report an issue on GitHub",
     "description": "Help report issue link"
   },
-  "helpComingSoon": {
-    "message": "More help resources coming soon...",
-    "description": "Help coming soon text"
+  "helpContactUs": {
+    "message": "Send us feedback",
+    "description": "Help contact form link"
   },
   "todayBlocks": {
     "message": "Today's Blocks",

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1287,9 +1287,9 @@
     "message": "GitHubで問題を報告する",
     "description": "ヘルプ問題報告リンク"
   },
-  "helpComingSoon": {
-    "message": "その他のヘルプリソースは近日公開予定...",
-    "description": "ヘルプ近日公開テキスト"
+  "helpContactUs": {
+    "message": "フィードバックを送る",
+    "description": "ヘルプお問い合わせフォームリンク"
   },
   "todayBlocks": {
     "message": "今日のブロック",

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -463,7 +463,7 @@ export function HelpTab({
             {getMessage('helpReportIssue')}
           </a>
           <a
-            href="https://forms.gle/PLACEHOLDER"
+            href="https://docs.google.com/forms/d/e/1FAIpQLSf3yxG71Z4YQWkoZqBMFuUb0Zxvj0DQFS9FEODjUVDQSnzXhg/viewform"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-2 text-sm text-info-600 hover:text-info-800"

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -454,7 +454,7 @@ export function HelpTab({
 
         <div className="space-y-3">
           <a
-            href="https://github.com/user/vision-focus/issues"
+            href="https://github.com/machina-gg/vision-focus/issues"
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-2 text-sm text-info-600 hover:text-info-800"
@@ -462,9 +462,15 @@ export function HelpTab({
             <ExternalLink className="w-4 h-4" />
             {getMessage('helpReportIssue')}
           </a>
-          <p className="text-xs text-gray-400">
-            {getMessage('helpComingSoon')}
-          </p>
+          <a
+            href="https://forms.gle/PLACEHOLDER"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 text-sm text-info-600 hover:text-info-800"
+          >
+            <ExternalLink className="w-4 h-4" />
+            {getMessage('helpContactUs')}
+          </a>
         </div>
       </Card>
 


### PR DESCRIPTION
## Summary
- HelpTabのサポートセクションにGoogle Formsへの問い合わせリンクを追加
- GitHub IssuesのURLを正しいリポジトリ（machina-gg/vision-focus）に修正
- 「Coming soon」プレースホルダーを削除し、フィードバックリンクに置換
- i18nメッセージ追加（英語・日本語）

## 備考
- Google FormsのURLはプレースホルダー（`https://forms.gle/PLACEHOLDER`）です。フォーム作成後に実際のURLに差し替えが必要です

Closes #9