### PR TITLE
chore: vibe-coding-utilsを最新化（update/cleanupコマンド追加）

### DIFF
--- a/.claude/commands/project/cleanup.md
+++ b/.claude/commands/project/cleanup.md
@@ -1,0 +1,63 @@
+---
+description: マージ済みブランチと worktree をクリーンアップする
+---
+
+以下の手順でマージ済みブランチと worktree のクリーンアップを行ってください：
+
+## 1. リモートの最新状態を取得
+
+```bash
+git fetch origin --prune
+```
+
+## 2. マージ済みブランチの検出
+
+develop にマージ済みの `feature/#*` ブランチを一覧取得する：
+
+```bash
+git branch --merged origin/develop --list 'feature/#*'
+```
+
+## 3. 対象一覧の表示とユーザー確認
+
+検出結果をユーザーに表示する：
+
+- マージ済みブランチ一覧（削除対象）
+- 対応する worktree の有無
+- 未マージのブランチがあれば警告として表示（削除しない）
+
+未マージブランチの確認：
+
+```bash
+git branch --no-merged origin/develop --list 'feature/#*'
+```
+
+**ユーザーの確認を得てから次のステップに進むこと。**
+
+## 4. worktree の削除
+
+マージ済みブランチに対応する worktree が存在する場合、削除する：
+
+```bash
+git worktree list
+```
+
+対応する worktree があれば：
+
+```bash
+git worktree remove ../プロジェクト名-XX
+```
+
+## 5. ローカルブランチの削除
+
+マージ済みブランチを削除する：
+
+```bash
+git branch -d feature/#XX
+```
+
+## 6. 結果の報告
+
+- 削除した worktree の一覧
+- 削除したブランチの一覧
+- 未マージのため残したブランチの一覧（該当する場合）

--- a/.claude/commands/project/implement.md
+++ b/.claude/commands/project/implement.md
@@ -43,8 +43,7 @@ git worktree add ../プロジェクト名-XX -b feature/#XX origin/develop
 package.json が存在する場合：
 
 ```bash
-cd ../プロジェクト名-XX
-pnpm install
+pnpm --dir ../プロジェクト名-XX install
 ```
 
 ### 3. GitHub Issue の内容を確認
@@ -71,10 +70,10 @@ pnpm install
 ### 7. lint / format / テスト実行
 
 ```bash
-pnpm format
-pnpm lint
-pnpm test
-pnpm test:e2e
+pnpm --dir ../プロジェクト名-XX format
+pnpm --dir ../プロジェクト名-XX lint
+pnpm --dir ../プロジェクト名-XX test
+pnpm --dir ../プロジェクト名-XX test:e2e
 ```
 
 ### 8. ドキュメント更新（該当する場合）
@@ -85,6 +84,7 @@ pnpm test:e2e
 
 ### 9. コミット・プッシュ・PR作成
 
+- `git -C ../プロジェクト名-XX` でコマンドを実行する
 - コミットメッセージに `Closes #XX` を含める
 - 例: `Prettier設定を変更 Closes #34`
 - PR を作成する（PRマージ時にIssueが自動クローズされる）
@@ -98,12 +98,10 @@ gh pr checks <PR番号> --watch
 - **成功**: 次のステップへ
 - **失敗**: エラー内容を確認し、修正してプッシュ → 再度CIを待つ
 
-### 11. worktree を削除
+### 11. 完了
 
-```bash
-cd ../プロジェクト名
-git worktree remove ../プロジェクト名-XX
-```
+- worktree はこのタイミングでは削除しない（CI失敗時の追加修正に備える）
+- マージ後のクリーンアップは `/project:cleanup` で一括実行する
 
 ## コミットメッセージ規則
 

--- a/.claude/commands/project/update.md
+++ b/.claude/commands/project/update.md
@@ -1,0 +1,51 @@
+---
+description: vibe-coding-utils を最新化する
+---
+
+以下の手順で vibe-coding-utils サブモジュールを最新化し、コマンドと CLAUDE.md を再生成してください：
+
+## 1. サブモジュールの更新
+
+```bash
+git submodule update --remote .claude/vibe-coding-utils
+```
+
+## 2. 更新内容の確認
+
+更新前後のコミット差分をユーザーに表示する：
+
+```bash
+git diff --submodule .claude/vibe-coding-utils
+```
+
+更新がない場合は「すでに最新です」と報告して終了。
+
+## 3. フレームワークの判定
+
+CLAUDE.md の技術スタックセクションからフレームワークを判定する：
+
+- `Plasmo` → `chrome-extension`
+- `Next.js` → `nextjs`
+
+## 4. セットアップスクリプトの再実行
+
+```bash
+bash .claude/vibe-coding-utils/scripts/setup-framework.sh <framework>
+```
+
+## 5. 差分の確認
+
+再生成されたファイルの差分を確認する：
+
+```bash
+git diff
+```
+
+変更内容をユーザーに報告する。
+
+## 6. コミット
+
+変更をコミットする：
+
+- サブモジュールの更新と再生成ファイルをまとめて1コミット
+- コミットメッセージ例: `chore: vibe-coding-utilsを最新化`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,8 @@
 | `/project:status`                | 現在の状況を確認                           |
 | `/project:review`                | コードレビューと修正                       |
 | `/project:deploy`                | デプロイを行う                             |
+| `/project:cleanup`               | マージ済みブランチと worktree をクリーンアップ |
+| `/project:update`                | vibe-coding-utils を最新化                 |
 
 詳細は `.claude/commands/` 配下の各ファイルを参照。
 


### PR DESCRIPTION
## Summary

- vibe-coding-utils サブモジュールを `688f1ae` に更新
- `setup-framework.sh` を再実行してコマンドと CLAUDE.md を再生成
- `/project:update` `/project:cleanup` コマンドが利用可能に
- `implement.md` の worktree 操作を改善（cd 不要に変更）

Closes #135
