### PR TITLE
feat: ヘルプコンテンツを充実させる

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1243,6 +1243,22 @@
     "message": "Personalize your new tab page with your goals, background images, and fonts to stay motivated.",
     "description": "Help dashboard description"
   },
+  "helpTimeLimits": {
+    "message": "Set Time Limits",
+    "description": "Help time limits title"
+  },
+  "helpTimeLimitsDescription": {
+    "message": "Instead of fully blocking a site, set daily or hourly time limits. Once your allotted time is used up, the site will be blocked for the rest of the period.",
+    "description": "Help time limits description"
+  },
+  "helpAnalytics": {
+    "message": "Track Your Progress",
+    "description": "Help analytics title"
+  },
+  "helpAnalyticsDescription": {
+    "message": "View your blocking statistics in the Analytics tab. See which sites you block most, track daily trends, and categorize sites as Waste, Invest, or Neutral.",
+    "description": "Help analytics description"
+  },
   "helpFaq": {
     "message": "FAQ",
     "description": "Help FAQ title"
@@ -1274,6 +1290,94 @@
   "helpFaqPresetsAnswer": {
     "message": "Styles save your dashboard settings (goal, background, fonts) so you can quickly switch between different configurations for work, study, or relaxation.",
     "description": "Help FAQ styles answer"
+  },
+  "helpFaqTimeLimit": {
+    "message": "How do time limits work?",
+    "description": "Help FAQ time limit question"
+  },
+  "helpFaqTimeLimitAnswer": {
+    "message": "Time limits let you allow a site for a set amount of time per day or per hour. Once you reach the limit, the site is blocked until the period resets. You can configure this in the block list by selecting 'Daily Limit' or 'Hourly Limit' instead of 'Always Blocked'.",
+    "description": "Help FAQ time limit answer"
+  },
+  "helpFaqPassword": {
+    "message": "How does password protection work?",
+    "description": "Help FAQ password question"
+  },
+  "helpFaqPasswordAnswer": {
+    "message": "Password protection prevents accidental or impulsive changes to your block settings. When enabled, you'll need to enter your password to pause blocking, remove sites from the block list, or disable blocking rules. Set it up in the Help tab under Password Protection.",
+    "description": "Help FAQ password answer"
+  },
+  "helpFaqBackup": {
+    "message": "How do I back up or restore my settings?",
+    "description": "Help FAQ backup question"
+  },
+  "helpFaqBackupAnswer": {
+    "message": "Use the Settings Backup section in the Help tab. Export saves your block list, schedules, styles, and preferences as a JSON file. Import merges the saved settings with your current ones, so you won't lose any existing data.",
+    "description": "Help FAQ backup answer"
+  },
+  "helpFaqPremium": {
+    "message": "What's included in Premium?",
+    "description": "Help FAQ premium question"
+  },
+  "helpFaqPremiumAnswer": {
+    "message": "Premium unlocks unlimited block list entries (Free: 5), up to 5 dashboard styles (Free: 1), custom backgrounds, wallpaper downloads, full analytics history (Free: 7 days), and weekly/monthly reports. Check the Premium tab for details.",
+    "description": "Help FAQ premium answer"
+  },
+  "helpFaqDataStorage": {
+    "message": "Where is my data stored?",
+    "description": "Help FAQ data storage question"
+  },
+  "helpFaqDataStorageAnswer": {
+    "message": "All your data (block list, schedules, statistics, settings) is stored locally in Chrome's storage on your device. Nothing is sent to external servers. If you opt in to anonymous usage statistics, only aggregated feature usage data is shared via Google Analytics — no personal information.",
+    "description": "Help FAQ data storage answer"
+  },
+  "helpFaqBlockLimit": {
+    "message": "Why can't I add more sites to the block list?",
+    "description": "Help FAQ block limit question"
+  },
+  "helpFaqBlockLimitAnswer": {
+    "message": "The free plan allows up to 5 blocked sites. Upgrade to Premium for unlimited block list entries. You can still use wildcards (*.example.com) to block entire domains and their subdomains with a single entry.",
+    "description": "Help FAQ block limit answer"
+  },
+  "helpTroubleshooting": {
+    "message": "Troubleshooting",
+    "description": "Help troubleshooting title"
+  },
+  "helpTroubleshootingDescription": {
+    "message": "Common issues and how to fix them",
+    "description": "Help troubleshooting description"
+  },
+  "helpTroubleshootSiteNotBlocked": {
+    "message": "A site isn't being blocked",
+    "description": "Help troubleshoot site not blocked title"
+  },
+  "helpTroubleshootSiteNotBlockedAnswer": {
+    "message": "Make sure the domain is in your block list and enabled. Check that blocking isn't paused (look for the Paused toggle in the popup). If the site uses a subdomain (e.g., m.example.com), add a wildcard entry (*.example.com) to cover all subdomains. Also verify that your schedule is active for the current time and day.",
+    "description": "Help troubleshoot site not blocked answer"
+  },
+  "helpTroubleshootNewTab": {
+    "message": "The new tab page isn't showing",
+    "description": "Help troubleshoot new tab title"
+  },
+  "helpTroubleshootNewTabAnswer": {
+    "message": "Check that VisionFocus is enabled in chrome://extensions. Another extension may be overriding the new tab page — try disabling other new-tab extensions temporarily. If the issue persists, try removing and reinstalling VisionFocus.",
+    "description": "Help troubleshoot new tab answer"
+  },
+  "helpTroubleshootSchedule": {
+    "message": "My schedule isn't working",
+    "description": "Help troubleshoot schedule title"
+  },
+  "helpTroubleshootScheduleAnswer": {
+    "message": "Verify that the schedule is enabled (toggle is on). Check the time range and selected days — schedules use your local timezone. If you have multiple schedules, make sure they don't conflict. Note that changes take effect immediately, no restart is needed.",
+    "description": "Help troubleshoot schedule answer"
+  },
+  "helpTroubleshootSettingsReset": {
+    "message": "My settings were reset",
+    "description": "Help troubleshoot settings reset title"
+  },
+  "helpTroubleshootSettingsResetAnswer": {
+    "message": "Settings may reset if Chrome clears extension storage (e.g., clearing all browsing data). To prevent data loss, regularly export your settings using the Settings Backup feature. If you have a backup file, you can restore your settings by importing it.",
+    "description": "Help troubleshoot settings reset answer"
   },
   "helpSupport": {
     "message": "Support",

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1243,6 +1243,22 @@
     "message": "目標、背景画像、フォントで新しいタブページをカスタマイズして、モチベーションを維持しましょう。",
     "description": "ヘルプダッシュボード説明"
   },
+  "helpTimeLimits": {
+    "message": "時間制限を設定",
+    "description": "ヘルプ時間制限タイトル"
+  },
+  "helpTimeLimitsDescription": {
+    "message": "サイトを完全にブロックする代わりに、1日または1時間ごとの使用時間を制限できます。制限時間を使い切ると、その期間中はサイトがブロックされます。",
+    "description": "ヘルプ時間制限説明"
+  },
+  "helpAnalytics": {
+    "message": "進捗を確認",
+    "description": "ヘルプ統計タイトル"
+  },
+  "helpAnalyticsDescription": {
+    "message": "統計タブでブロック状況を確認できます。最もブロックしたサイトの確認、日次のトレンド追跡、サイトの「浪費」「投資」「中立」カテゴリ分けが可能です。",
+    "description": "ヘルプ統計説明"
+  },
   "helpFaq": {
     "message": "よくある質問",
     "description": "ヘルプFAQタイトル"
@@ -1274,6 +1290,94 @@
   "helpFaqPresetsAnswer": {
     "message": "スタイルはダッシュボード設定（目標、背景、フォント）を保存し、仕事、勉強、リラックスなど、異なる設定をすぐに切り替えられるようにします。",
     "description": "ヘルプFAQスタイル回答"
+  },
+  "helpFaqTimeLimit": {
+    "message": "時間制限はどう機能しますか？",
+    "description": "ヘルプFAQ時間制限質問"
+  },
+  "helpFaqTimeLimitAnswer": {
+    "message": "時間制限を使うと、1日または1時間あたりの使用時間を設定できます。制限時間に達すると、リセットされるまでサイトがブロックされます。ブロックリストで「常時ブロック」の代わりに「1日の制限」または「1時間の制限」を選択して設定できます。",
+    "description": "ヘルプFAQ時間制限回答"
+  },
+  "helpFaqPassword": {
+    "message": "パスワード保護はどう機能しますか？",
+    "description": "ヘルプFAQパスワード質問"
+  },
+  "helpFaqPasswordAnswer": {
+    "message": "パスワード保護を有効にすると、ブロック設定の変更（一時停止、サイトの削除、ブロックルールの無効化）にパスワードが必要になります。衝動的な設定変更を防ぐのに効果的です。ヘルプタブの「パスワード保護」から設定できます。",
+    "description": "ヘルプFAQパスワード回答"
+  },
+  "helpFaqBackup": {
+    "message": "設定のバックアップ・復元方法は？",
+    "description": "ヘルプFAQバックアップ質問"
+  },
+  "helpFaqBackupAnswer": {
+    "message": "ヘルプタブの「設定バックアップ」セクションを使用します。エクスポートでブロックリスト、スケジュール、スタイル、設定をJSONファイルとして保存できます。インポートは既存の設定とマージされるため、現在のデータが失われることはありません。",
+    "description": "ヘルプFAQバックアップ回答"
+  },
+  "helpFaqPremium": {
+    "message": "Premium版には何が含まれますか？",
+    "description": "ヘルプFAQプレミアム質問"
+  },
+  "helpFaqPremiumAnswer": {
+    "message": "Premiumでは、ブロックリスト無制限（無料版：5件）、スタイル最大5個（無料版：1個）、カスタム背景、壁紙ダウンロード、全期間の統計履歴（無料版：7日間）、週次・月次レポートが利用できます。詳しくはPremiumタブをご確認ください。",
+    "description": "ヘルプFAQプレミアム回答"
+  },
+  "helpFaqDataStorage": {
+    "message": "データはどこに保存されますか？",
+    "description": "ヘルプFAQデータ保存場所質問"
+  },
+  "helpFaqDataStorageAnswer": {
+    "message": "すべてのデータ（ブロックリスト、スケジュール、統計、設定）はChromeのストレージにローカル保存されます。外部サーバーには送信されません。匿名使用統計をオプトインした場合のみ、集計された機能使用データがGoogle Analytics経由で共有されます（個人情報は含まれません）。",
+    "description": "ヘルプFAQデータ保存場所回答"
+  },
+  "helpFaqBlockLimit": {
+    "message": "ブロックリストにサイトを追加できないのはなぜ？",
+    "description": "ヘルプFAQブロック上限質問"
+  },
+  "helpFaqBlockLimitAnswer": {
+    "message": "無料プランではブロックリストに最大5件まで登録できます。Premiumにアップグレードすると無制限になります。ワイルドカード（*.example.com）を使えば、1つのエントリでドメインとすべてのサブドメインをブロックできます。",
+    "description": "ヘルプFAQブロック上限回答"
+  },
+  "helpTroubleshooting": {
+    "message": "トラブルシューティング",
+    "description": "ヘルプトラブルシューティングタイトル"
+  },
+  "helpTroubleshootingDescription": {
+    "message": "よくある問題と解決方法",
+    "description": "ヘルプトラブルシューティング説明"
+  },
+  "helpTroubleshootSiteNotBlocked": {
+    "message": "サイトがブロックされない",
+    "description": "ヘルプトラブルシューティングブロックされない"
+  },
+  "helpTroubleshootSiteNotBlockedAnswer": {
+    "message": "ブロックリストにドメインが登録され有効になっていることを確認してください。ポップアップの「一時停止」がオンになっていないか確認してください。サブドメイン（例：m.example.com）を使用している場合は、ワイルドカード（*.example.com）を追加してください。また、現在の時間帯と曜日にスケジュールが有効か確認してください。",
+    "description": "ヘルプトラブルシューティングブロックされない回答"
+  },
+  "helpTroubleshootNewTab": {
+    "message": "新しいタブページが表示されない",
+    "description": "ヘルプトラブルシューティング新しいタブ"
+  },
+  "helpTroubleshootNewTabAnswer": {
+    "message": "chrome://extensions でVisionFocusが有効になっていることを確認してください。他の拡張機能が新しいタブページを上書きしている可能性があります。他の新しいタブ系の拡張機能を一時的に無効にしてみてください。問題が解決しない場合は、VisionFocusを再インストールしてください。",
+    "description": "ヘルプトラブルシューティング新しいタブ回答"
+  },
+  "helpTroubleshootSchedule": {
+    "message": "スケジュールが動作しない",
+    "description": "ヘルプトラブルシューティングスケジュール"
+  },
+  "helpTroubleshootScheduleAnswer": {
+    "message": "スケジュールが有効（トグルがオン）であることを確認してください。時間範囲と選択した曜日を確認してください（ローカルタイムゾーンが使用されます）。複数のスケジュールがある場合、競合していないか確認してください。変更は即座に反映され、再起動は不要です。",
+    "description": "ヘルプトラブルシューティングスケジュール回答"
+  },
+  "helpTroubleshootSettingsReset": {
+    "message": "設定がリセットされた",
+    "description": "ヘルプトラブルシューティング設定リセット"
+  },
+  "helpTroubleshootSettingsResetAnswer": {
+    "message": "Chromeが拡張機能のストレージをクリアした場合（例：閲覧データの全削除）、設定がリセットされることがあります。データ損失を防ぐため、定期的に「設定バックアップ」機能でエクスポートしておくことをお勧めします。バックアップファイルがあれば、インポートで復元できます。",
+    "description": "ヘルプトラブルシューティング設定リセット回答"
   },
   "helpSupport": {
     "message": "サポート",

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -9,7 +9,8 @@ import {
   HardDrive,
   Check,
   AlertTriangle,
-  BarChart3
+  BarChart3,
+  Wrench
 } from 'lucide-react';
 
 import { Button, Card, Toggle } from '~/components/ui';
@@ -200,6 +201,18 @@ export function HelpTab({
             </h3>
             <p>{getMessage('helpDashboardDescription')}</p>
           </div>
+          <div>
+            <h3 className="font-medium text-gray-800 mb-1">
+              {getMessage('helpTimeLimits')}
+            </h3>
+            <p>{getMessage('helpTimeLimitsDescription')}</p>
+          </div>
+          <div>
+            <h3 className="font-medium text-gray-800 mb-1">
+              {getMessage('helpAnalytics')}
+            </h3>
+            <p>{getMessage('helpAnalyticsDescription')}</p>
+          </div>
         </div>
       </Card>
 
@@ -242,6 +255,106 @@ export function HelpTab({
             </summary>
             <p className="mt-2 text-sm text-gray-600 pl-4">
               {getMessage('helpFaqPresetsAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqTimeLimit')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqTimeLimitAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqPassword')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqPasswordAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqBackup')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqBackupAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqPremium')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqPremiumAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqDataStorage')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqDataStorageAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpFaqBlockLimit')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpFaqBlockLimitAnswer')}
+            </p>
+          </details>
+        </div>
+      </Card>
+
+      {/* Troubleshooting */}
+      <Card>
+        <div className="flex items-center gap-3 mb-4">
+          <div className="w-10 h-10 bg-danger-100 rounded-lg flex items-center justify-center">
+            <Wrench className="w-5 h-5 text-danger-600" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900">
+              {getMessage('helpTroubleshooting')}
+            </h2>
+            <p className="text-sm text-gray-500">
+              {getMessage('helpTroubleshootingDescription')}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpTroubleshootSiteNotBlocked')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpTroubleshootSiteNotBlockedAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpTroubleshootNewTab')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpTroubleshootNewTabAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpTroubleshootSchedule')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpTroubleshootScheduleAnswer')}
+            </p>
+          </details>
+          <details className="group">
+            <summary className="cursor-pointer text-sm font-medium text-gray-800 hover:text-info-600">
+              {getMessage('helpTroubleshootSettingsReset')}
+            </summary>
+            <p className="mt-2 text-sm text-gray-600 pl-4">
+              {getMessage('helpTroubleshootSettingsResetAnswer')}
             </p>
           </details>
         </div>


### PR DESCRIPTION
## Summary
- Getting Startedに「時間制限を設定」「進捗を確認」の2項目を追加
- FAQに6問追加（時間制限、パスワード保護、バックアップ・復元、Premium機能、データ保存先、ブロック上限）
- トラブルシューティングセクションを新設（サイトがブロックされない、新しいタブが表示されない、スケジュールが動作しない、設定がリセットされた）
- en/ja両言語のi18nメッセージを追加（26メッセージ × 2言語）

## #11（プロダクトサイト）との棲み分け
- HelpTab: 拡張機能を使いながら参照する操作手順・設定方法に特化
- プロダクトサイト: まだ使っていない人向けの機能紹介・マーケティング・スクリーンショット
- スクリーンショットはパッケージサイズを考慮しHelpTabには追加せず、プロダクトサイト側で活用

## Test plan
- [ ] HelpTab の Getting Started に「時間制限を設定」「進捗を確認」が表示される
- [ ] FAQ に新しい6つの質問が表示され、クリックで展開される
- [ ] トラブルシューティングセクションが表示され、4つの項目がクリックで展開される
- [ ] 英語・日本語の両言語で正しく表示される

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)