### PR TITLE
chore: READMEから直近やることセクションを削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-## 直近やること
-
-- [ ] ドキュメント類確認
-- [ ] ソースコード確認
-- [ ] あとはissueに沿ってやっていく
-
 <p align="center">
   <img src="assets/images/logo.png" alt="VisionFocus" width="400">
 </p>


### PR DESCRIPTION
## Summary
- READMEから「直近やること」セクションを削除
- タスク管理はGitHub Issuesで行っており不要

## Test plan
- [ ] READMEの先頭がロゴ画像から始まることを確認

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
