### PR TITLE
fix: 週間カレンダーの0:00と24:00の時刻ラベル文字切れを修正

### DIFF
--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -170,15 +170,23 @@ export function WeeklyCalendar({
         <div className="relative grid grid-cols-8" style={{ height: '400px' }}>
           {/* Time Labels Column */}
           <div className="relative border-r border-gray-200">
-            {HOURS.filter((h) => h % 3 === 0).map((hour) => (
-              <div
-                key={hour}
-                className="absolute left-0 right-0 text-right pr-2 text-xs text-gray-400 transform -translate-y-1/2"
-                style={{ top: `${(hour / 24) * 100}%` }}
-              >
-                {hour.toString().padStart(2, '0')}:00
-              </div>
-            ))}
+            {HOURS.filter((h) => h % 3 === 0).map((hour) => {
+              const translateClass =
+                hour === 0
+                  ? ''
+                  : hour === 24
+                    ? '-translate-y-full'
+                    : '-translate-y-1/2';
+              return (
+                <div
+                  key={hour}
+                  className={`absolute left-0 right-0 text-right pr-2 text-xs text-gray-400 transform ${translateClass}`}
+                  style={{ top: `${(hour / 24) * 100}%` }}
+                >
+                  {hour.toString().padStart(2, '0')}:00
+                </div>
+              );
+            })}
           </div>
 
           {/* Day Columns */}


### PR DESCRIPTION
## Summary
- 週間カレンダーの0:00と24:00の時刻ラベルが `overflow-hidden` と `-translate-y-1/2` の組み合わせで文字切れしていた問題を修正
- 0:00ラベルは上端に揃え、24:00ラベルは下端に揃え、中間ラベルは従来通り中央揃えにすることでクリッピングを防止

Closes #163

## Test plan
- [ ] 週間カレンダーで0:00の時刻ラベルが切れずに表示されることを確認
- [ ] 週間カレンダーで24:00の時刻ラベルが切れずに表示されることを確認
- [ ] 中間の時刻ラベル（3:00, 6:00, ..., 21:00）がグリッド線の中央に正しく配置されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)