### PR TITLE
fix: スケジュールの終了時刻0:00を24:00として扱えるようにする

### DIFF
--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Card } from '~/components/ui';
 import { CURRENT_TIME_REFRESH_MS } from '~/constants/intervals';
 import { getMessage } from '~/lib/i18n';
+import { normalizeEndTime } from '~/lib/time';
 import type { Schedule, VisionSettings } from '~/types/storage';
 
 // Predefined colors for schedule blocks
@@ -44,6 +45,8 @@ interface ScheduleBlock {
 }
 
 function parseTime(time: string): { hour: number; minute: number } {
+  // Handle "24:00" as end of day
+  if (time === '24:00') return { hour: 24, minute: 0 };
   const [hour, minute] = time.split(':').map(Number);
   return { hour, minute };
 }
@@ -57,7 +60,7 @@ function getScheduleBlocksForDay(
     .filter((s) => s.days.includes(dayIndex))
     .map((schedule) => {
       const start = parseTime(schedule.startTime);
-      const end = parseTime(schedule.endTime);
+      const end = parseTime(normalizeEndTime(schedule.endTime));
       return {
         schedule,
         startHour: start.hour,

--- a/src/components/options/modals/ScheduleModal.tsx
+++ b/src/components/options/modals/ScheduleModal.tsx
@@ -80,7 +80,11 @@ export function ScheduleModal({
             </label>
             <input
               type="time"
-              value={scheduleForm.endTime}
+              value={
+                scheduleForm.endTime === '24:00'
+                  ? '00:00'
+                  : scheduleForm.endTime
+              }
               onChange={(e) =>
                 onFormChange({ ...scheduleForm, endTime: e.target.value })
               }

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 
 import { trackFeatureUse } from '~/lib/analytics';
 import { storage } from '~/lib/storage';
+import { normalizeEndTime } from '~/lib/time';
 import type { AppSettings, Schedule } from '~/types/storage';
 
 export interface ScheduleFormData {
@@ -55,7 +56,7 @@ export function useSchedules({
       id: editingSchedule?.id || crypto.randomUUID(),
       name: scheduleForm.name,
       startTime: scheduleForm.startTime,
-      endTime: scheduleForm.endTime,
+      endTime: normalizeEndTime(scheduleForm.endTime),
       days: scheduleForm.days,
       enabled: true,
       presetId: scheduleForm.presetId || undefined

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -63,18 +63,26 @@ export function getLastNDays(n: number): string[] {
 }
 
 // Validate time string format (HH:mm)
+// Accepts 00:00-23:59 and 24:00 (end of day)
 export function isValidTimeString(time: string): boolean {
   if (!time || typeof time !== 'string') return false;
+  if (time === '24:00') return true;
   const match = time.match(/^([0-1]?[0-9]|2[0-3]):([0-5][0-9])$/);
   return match !== null;
 }
 
 // Parse time string (HH:mm) to minutes from midnight
 // Returns 0 if invalid time string
+// "24:00" returns 1440 (end of day)
 export function parseTimeToMinutes(time: string): number {
   if (!isValidTimeString(time)) return 0;
   const [hours, minutes] = time.split(':').map(Number);
   return hours * 60 + minutes;
+}
+
+// Normalize end time: convert "00:00" to "24:00" for end-of-day semantics
+export function normalizeEndTime(endTime: string): string {
+  return endTime === '00:00' ? '24:00' : endTime;
 }
 
 // Get current hour key in YYYY-MM-DD-HH format
@@ -101,8 +109,10 @@ export function isWithinSchedule(
   endTime: string,
   days: number[]
 ): boolean {
+  const normalizedEndTime = normalizeEndTime(endTime);
+
   // Validate inputs
-  if (!isValidTimeString(startTime) || !isValidTimeString(endTime)) {
+  if (!isValidTimeString(startTime) || !isValidTimeString(normalizedEndTime)) {
     return false;
   }
   if (!Array.isArray(days) || days.length === 0) {
@@ -119,10 +129,10 @@ export function isWithinSchedule(
 
   const currentMinutes = now.getHours() * 60 + now.getMinutes();
   const startMinutes = parseTimeToMinutes(startTime);
-  const endMinutes = parseTimeToMinutes(endTime);
+  const endMinutes = parseTimeToMinutes(normalizedEndTime);
 
   // Handle overnight schedules (e.g., 22:00 - 06:00)
-  if (endMinutes < startMinutes) {
+  if (endMinutes <= startMinutes) {
     return currentMinutes >= startMinutes || currentMinutes < endMinutes;
   }
 


### PR DESCRIPTION
## Summary
- スケジュールの終了時刻を0:00に設定すると保存しても正しく動作しない問題を修正
- 終了時刻 "00:00" を内部的に "24:00"（1日の終わり）として正規化する `normalizeEndTime` 関数を追加
- `isValidTimeString` と `parseTimeToMinutes` で "24:00" を有効な時刻として扱えるよう拡張
- `isWithinSchedule` で正規化後の終了時刻を使用するよう修正
- 週間カレンダーでも正規化後の時刻で正しいブロック描画を行うよう修正
- ScheduleModal の時刻入力では "24:00" → "00:00" に変換して `<input type="time">` と互換性を確保

Closes #162

## Test plan
- [ ] スケジュールの終了時刻を00:00に設定して保存できることを確認
- [ ] 保存後、週間カレンダーで該当スケジュールが正しく（開始時刻〜24:00）表示されることを確認
- [ ] 保存した終了時刻00:00のスケジュールを再編集時、時刻入力に00:00が表示されることを確認
- [ ] スケジュールの時間範囲内（例: 19:00〜24:00）で正しくブロッキングが動作することを確認
- [ ] 通常の時刻設定（例: 09:00〜17:00）が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)