### PR TITLE
fix: スケジュールダイアログの曜日表記をi18n対応に修正

### DIFF
--- a/src/components/options/modals/ScheduleModal.tsx
+++ b/src/components/options/modals/ScheduleModal.tsx
@@ -7,7 +7,7 @@ import type { Schedule, VisionSettings } from '~/types/storage';
 import type { FeatureLimits } from '~/types/premium';
 import type { ScheduleFormData } from '~/hooks/useSchedules';
 
-const DAY_NAMES = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
 
 interface ScheduleModalProps {
   isOpen: boolean;
@@ -94,7 +94,7 @@ export function ScheduleModal({
             {getMessage('activeDays')}
           </label>
           <div className="flex gap-2">
-            {DAY_NAMES.map((day, idx) => (
+            {DAY_KEYS.map((day, idx) => (
               <button
                 key={day}
                 onClick={() => toggleDay(idx)}
@@ -104,7 +104,7 @@ export function ScheduleModal({
                     : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
                 }`}
               >
-                {day}
+                {getMessage(day)}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- スケジュール追加ダイアログの「有効な曜日」ボタンがハードコードの英語表記（Sun, Mon, Tue...）だった問題を修正
- WeeklyCalendar と同じ `DAY_KEYS` + `getMessage()` パターンを使用し、言語設定に応じた表記に統一

Closes #160

## Test plan
- [ ] 日本語設定でスケジュール追加ダイアログの曜日ボタンが日本語（日, 月, 火...）で表示されることを確認
- [ ] 英語設定でスケジュール追加ダイアログの曜日ボタンが英語（Sun, Mon, Tue...）で表示されることを確認
- [ ] 曜日ボタンのクリック機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)