### PR TITLE
feat: ヘルプタブからGitHub Issuesリンクを削除

### DIFF
--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -567,15 +567,6 @@ export function HelpTab({
 
         <div className="space-y-3">
           <a
-            href="https://github.com/machina-gg/vision-focus/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-sm text-info-600 hover:text-info-800"
-          >
-            <ExternalLink className="w-4 h-4" />
-            {getMessage('helpReportIssue')}
-          </a>
-          <a
             href="https://docs.google.com/forms/d/e/1FAIpQLSf3yxG71Z4YQWkoZqBMFuUb0Zxvj0DQFS9FEODjUVDQSnzXhg/viewform"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- ヘルプタブのサポートセクションにある「GitHubで問題を報告する」リンクを削除
- 一般ユーザー向けではないため、お問い合わせフォームのリンクのみ残す

Closes #156

## Test plan
- [ ] ヘルプタブのサポートセクションにGitHub Issuesリンクが表示されないことを確認
- [ ] お問い合わせフォームのリンクが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)