### PR TITLE
fix: ブロック登録済みドメインのサブドメインマッチングを修正

### DIFF
--- a/src/lib/__tests__/domain.test.ts
+++ b/src/lib/__tests__/domain.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesDomain, extractDomain } from '~/lib/domain';
+import type { BlockItem } from '~/types/storage';
+
+function makeBlockItem(domain: string, isWildcard: boolean): BlockItem {
+  return {
+    id: 'test-id',
+    domain,
+    isWildcard,
+    createdAt: '2024-01-01T00:00:00Z',
+    enabled: true
+  };
+}
+
+describe('matchesDomain', () => {
+  describe('exact (non-wildcard) domains', () => {
+    it('matches exact domain', () => {
+      const item = makeBlockItem('youtube.com', false);
+      expect(matchesDomain('youtube.com', item)).toBe(true);
+    });
+
+    it('matches subdomain of the blocked domain', () => {
+      const item = makeBlockItem('youtube.com', false);
+      expect(matchesDomain('www.youtube.com', item)).toBe(true);
+    });
+
+    it('matches nested subdomain', () => {
+      const item = makeBlockItem('youtube.com', false);
+      expect(matchesDomain('m.youtube.com', item)).toBe(true);
+    });
+
+    it('does not match unrelated domain with same suffix', () => {
+      const item = makeBlockItem('youtube.com', false);
+      expect(matchesDomain('notyoutube.com', item)).toBe(false);
+    });
+
+    it('does not match a different domain entirely', () => {
+      const item = makeBlockItem('youtube.com', false);
+      expect(matchesDomain('reddit.com', item)).toBe(false);
+    });
+
+    it('matches case-insensitively', () => {
+      const item = makeBlockItem('YouTube.com', false);
+      expect(matchesDomain('WWW.YOUTUBE.COM', item)).toBe(true);
+    });
+
+    it('www.youtube.com does not match youtube.com tab', () => {
+      const item = makeBlockItem('www.youtube.com', false);
+      expect(matchesDomain('youtube.com', item)).toBe(false);
+    });
+
+    it('www.youtube.com matches www.youtube.com exactly', () => {
+      const item = makeBlockItem('www.youtube.com', false);
+      expect(matchesDomain('www.youtube.com', item)).toBe(true);
+    });
+  });
+
+  describe('wildcard domains', () => {
+    it('matches subdomain', () => {
+      const item = makeBlockItem('*.youtube.com', true);
+      expect(matchesDomain('www.youtube.com', item)).toBe(true);
+    });
+
+    it('matches base domain', () => {
+      const item = makeBlockItem('*.youtube.com', true);
+      expect(matchesDomain('youtube.com', item)).toBe(true);
+    });
+
+    it('matches nested subdomain', () => {
+      const item = makeBlockItem('*.youtube.com', true);
+      expect(matchesDomain('sub.www.youtube.com', item)).toBe(true);
+    });
+
+    it('does not match unrelated domain', () => {
+      const item = makeBlockItem('*.youtube.com', true);
+      expect(matchesDomain('notyoutube.com', item)).toBe(false);
+    });
+  });
+});
+
+describe('extractDomain', () => {
+  it('extracts hostname from HTTPS URL', () => {
+    expect(extractDomain('https://www.youtube.com/watch?v=abc')).toBe(
+      'www.youtube.com'
+    );
+  });
+
+  it('extracts hostname from HTTP URL', () => {
+    expect(extractDomain('http://reddit.com/r/all')).toBe('reddit.com');
+  });
+
+  it('returns null for invalid URL', () => {
+    expect(extractDomain('not-a-url')).toBeNull();
+  });
+});

--- a/src/lib/domain.ts
+++ b/src/lib/domain.ts
@@ -23,8 +23,8 @@ export function matchesDomain(domain: string, blockItem: BlockItem): boolean {
     return target.endsWith('.' + baseDomain) || target === baseDomain;
   }
 
-  // Exact match
-  return target === pattern;
+  // Exact match or subdomain match (consistent with declarativeNetRequest ||domain behavior)
+  return target === pattern || target.endsWith('.' + pattern);
 }
 
 // Check if domain is blocked by any item in the list


### PR DESCRIPTION
## Summary
- `matchesDomain` が完全一致のみだったため、`youtube.com` でブロック登録しても `www.youtube.com` の既存タブがブロックされないバグを修正
- `declarativeNetRequest` の `||domain` 動作と一致するようサブドメインマッチングを追加
- `matchesDomain` のユニットテストを追加

## 変更内容
- `src/lib/domain.ts`: 非ワイルドカードドメインでもサブドメインマッチを行うように修正（1行変更）
- `src/lib/__tests__/domain.test.ts`: `matchesDomain` と `extractDomain` のユニットテストを新規追加

## 原因
| 操作 | DNR ルール (`||youtube.com`) | `matchesDomain('www.youtube.com', 'youtube.com')` |
|------|:---:|:---:|
| 修正前 | マッチ | **不一致** |
| 修正後 | マッチ | マッチ |

DNR ルールは新規ナビゲーションをブロックするが、`blockExistingTabs()` は `matchesDomain` を使うため、既存タブのリダイレクトが失敗していた。

## Test plan
- [x] `matchesDomain` ユニットテスト（15件）全通過
- [ ] `youtube.com` をブロックリストに追加し、既に開いている `www.youtube.com` タブがブロックされることを確認
- [ ] `www.youtube.com` でブロック登録した場合、`youtube.com` や `m.youtube.com` はブロックされないことを確認
- [ ] ワイルドカード (`*.youtube.com`) の既存動作が変わらないことを確認

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)