### PR TITLE
fix: 時間制限超過時にサイトをブロックルールに追加

### DIFF
--- a/src/background/messages/tracker-heartbeat.ts
+++ b/src/background/messages/tracker-heartbeat.ts
@@ -16,6 +16,8 @@ import { recordTimeLimitUsage, findBlockItemForDomain } from '../time-limit';
 import { checkTimeLimitNotification } from '../notifications';
 import { recordYouTubeTimeLimitUsage } from '~/lib/youtubeBlockService';
 import { checkYouTubeTimeLimitNotification } from '../notifications';
+import { hasExceededTimeLimit } from '~/lib/timeLimitService';
+import { updateBlockRules, blockExistingTabs } from '../blocker';
 import { TrackerHeartbeatBodySchema } from '~/types/messageSchemas';
 
 // Track active pages and their last heartbeat
@@ -127,6 +129,12 @@ async function recordTime(domain: string, seconds: number): Promise<void> {
     await recordTimeLimitUsage(domain, seconds);
     // Check if we need to send a notification about time running low
     await checkTimeLimitNotification(domain);
+
+    // If time limit is now exceeded, update block rules immediately
+    if (await hasExceededTimeLimit(domain, blockItem)) {
+      await updateBlockRules();
+      await blockExistingTabs();
+    }
     // Don't return here - also track in analytics if it's an unblocked site
   }
 

--- a/src/lib/blockService.ts
+++ b/src/lib/blockService.ts
@@ -10,11 +10,15 @@
  * @see docs/BLOCK_STATE_MACHINE.md for state transition diagrams
  */
 
-import { getSettings } from '~/lib/storage';
+import { getSettings, getAnalytics } from '~/lib/storage';
 import { extractDomain, matchesDomain } from '~/lib/domain';
 import { isWithinSchedule } from '~/lib/time';
 import type { AppSettings, BlockItem, Schedule } from '~/types/storage';
-import { hasExceededTimeLimit, getRemainingTime } from '~/lib/timeLimitService';
+import {
+  hasExceededTimeLimit,
+  getRemainingTime,
+  checkTimeLimitExceeded
+} from '~/lib/timeLimitService';
 
 // Block reason type - matches the state machine documentation
 export type BlockReason = 'always_blocked' | 'time_limit_exceeded' | null;
@@ -164,7 +168,7 @@ const YOUTUBE_DOMAINS = ['youtube.com', 'www.youtube.com'];
 
 /**
  * Get list of domains that should be actively blocked via declarativeNetRequest
- * Only includes always-blocked sites (no time limit) that are enabled and within schedule
+ * Includes always-blocked sites and time-limited sites that have exceeded their limit
  * Also includes YouTube domains when YouTube blockAccess is enabled
  */
 export async function getActiveBlockedDomains(): Promise<string[]> {
@@ -180,10 +184,21 @@ export async function getActiveBlockedDomains(): Promise<string[]> {
     return [];
   }
 
-  // Only include always-blocked sites (enabled and no time limit)
+  // Always-blocked sites (enabled and no time limit)
   const blockedDomains = settings.blockList
     .filter((item) => item.enabled && !item.timeLimit)
     .map((item) => item.domain);
+
+  // Also include time-limited sites that have exceeded their limit
+  const analytics = await getAnalytics();
+  for (const item of settings.blockList) {
+    if (!item.enabled || !item.timeLimit) continue;
+    if (blockedDomains.includes(item.domain)) continue;
+
+    if (checkTimeLimitExceeded(item.domain, item.timeLimit, analytics)) {
+      blockedDomains.push(item.domain);
+    }
+  }
 
   // Add YouTube domains if YouTube blockAccess is enabled
   if (settings.youtube?.enabled && settings.youtube?.blockAccess) {


### PR DESCRIPTION
## Summary
- `getActiveBlockedDomains()` が時間制限付きサイトを `!item.timeLimit` で全て除外していたため、時間制限超過時も `declarativeNetRequest` のブロックルールに追加されず、サイトが閲覧可能なままだった
- 時間制限超過したドメインもブロック対象に含めるよう修正
- heartbeat で時間記録後に制限超過を検知した場合、即座に `updateBlockRules()` + `blockExistingTabs()` を実行して既存タブもブロック

## 変更ファイル
- `src/lib/blockService.ts`: `getActiveBlockedDomains()` に時間制限超過チェックを追加
- `src/background/messages/tracker-heartbeat.ts`: 時間記録後に制限超過時の即時ブロック処理を追加

## Test plan
- [ ] サイトに時間制限（例: 1分/時間）を設定
- [ ] 制限時間分閲覧する
- [ ] 時間制限超過後、サイトがブロックされブロックページにリダイレクトされることを確認
- [ ] 常時ブロック（時間制限なし）のサイトが従来通りブロックされることを確認
- [ ] ポーズ中は時間制限超過サイトもブロックされないことを確認

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)