### PR TITLE
feat: カレンダーでスケジュール名をメイン表示に変更

### DIFF
--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -243,11 +243,18 @@ export function WeeklyCalendar({
                       title={`${block.schedule.name}\n${block.schedule.startTime} - ${block.schedule.endTime}${presetName ? `\n${getMessage('presetLabel')}: ${presetName}` : ''}`}
                     >
                       <div
-                        className={`p-1 text-xs truncate ${colors.text} ${
+                        className={`p-1 text-xs ${colors.text} ${
                           !block.schedule.enabled ? 'line-through' : ''
                         }`}
                       >
-                        {presetName || block.schedule.name}
+                        <div className="truncate font-medium">
+                          {block.schedule.name}
+                        </div>
+                        {presetName && (
+                          <div className="truncate opacity-70 text-[10px] leading-tight">
+                            {presetName}
+                          </div>
+                        )}
                       </div>
                     </div>
                   );


### PR DESCRIPTION
## Summary
- カレンダーブロックの表示でスケジュール名を常にメインテキストとして表示するように変更
- プリセットが紐づいている場合はプリセット名をサブテキスト（小さいフォント・低い不透明度）として表示
- 凡例（Legend）とカレンダーブロックの表示が一致するようになった

## Test plan
- [ ] プリセットが紐づいていないスケジュールがカレンダー上でスケジュール名のみ表示されること
- [ ] プリセットが紐づいているスケジュールがカレンダー上でスケジュール名（メイン）+ プリセット名（サブ）表示されること
- [ ] ツールチップにスケジュール名・時間・プリセット名が正しく表示されること

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)