### PR TITLE
fix: chrome.notifications APIのTypeError修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "tabs",
       "declarativeNetRequest",
       "alarms",
-      "webNavigation"
+      "webNavigation",
+      "notifications"
     ],
     "web_accessible_resources": [
       {

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -47,6 +47,11 @@ export function clearExpiredNotifications(): void {
   }
 }
 
+// Check if chrome.notifications API is available
+function isNotificationsApiAvailable(): boolean {
+  return !!chrome?.notifications?.create;
+}
+
 // Show a time limit notification
 async function showTimeLimitNotification(
   domain: string,
@@ -54,6 +59,11 @@ async function showTimeLimitNotification(
   totalMinutes: number,
   type: 'daily' | 'hourly'
 ): Promise<void> {
+  // Guard: skip if chrome.notifications API is unavailable
+  if (!isNotificationsApiAvailable()) {
+    return;
+  }
+
   const typeLabel =
     type === 'daily' ? getMessage('perDay') : getMessage('perHour');
 


### PR DESCRIPTION
## Summary
- manifestにnotificationsパーミッションを追加（不足していたためchrome.notificationsがundefinedになりTypeErrorが発生）
- chrome.notifications APIの存在チェックガード関数を追加し、APIが利用不可な状況でもTypeErrorが発生しないよう防御的に対策

Closes #155

## Test plan
- [ ] Chrome拡張をビルドし、時間制限付きドメインにアクセスして通知が正常に表示されることを確認
- [ ] back/forwardキャッシュ遷移時にTypeErrorが発生しないことをDevToolsコンソールで確認
- [ ] manifest.jsonにnotificationsパーミッションが含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)