### PR TITLE
feat: ブロック解除時に確認ダイアログを表示(長押し5秒)

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1958,5 +1958,43 @@
   "analyticsShareStatsDescription": {
     "message": "Help us improve VisionFocus by sharing anonymous feature usage data. No personal information is collected.",
     "description": "Analytics toggle description"
+  },
+  "unblockConfirmTitle": {
+    "message": "Confirm Unblock",
+    "description": "Unblock confirmation dialog title"
+  },
+  "unblockConfirmDescription": {
+    "message": "You are about to unblock $DOMAIN$. Hold the button for 5 seconds to confirm.",
+    "description": "Unblock confirmation description",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      }
+    }
+  },
+  "deleteBlockConfirmDescription": {
+    "message": "You are about to delete the block for $DOMAIN$. Hold the button for 5 seconds to confirm.",
+    "description": "Delete block confirmation description",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      }
+    }
+  },
+  "unblockConfirmHoldButton": {
+    "message": "Hold to Confirm",
+    "description": "Long press button label"
+  },
+  "unblockConfirmBlockStyle": {
+    "message": "Block style: $STYLE$",
+    "description": "Block style display in confirmation dialog",
+    "placeholders": {
+      "style": {
+        "content": "$1",
+        "example": "Always Blocked"
+      }
+    }
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1958,5 +1958,43 @@
   "analyticsShareStatsDescription": {
     "message": "匿名の機能使用データを共有して、VisionFocusの改善にご協力ください。個人情報は一切収集されません。",
     "description": "アナリティクストグルの説明"
+  },
+  "unblockConfirmTitle": {
+    "message": "ブロック解除の確認",
+    "description": "ブロック解除確認ダイアログタイトル"
+  },
+  "unblockConfirmDescription": {
+    "message": "$DOMAIN$ のブロックを解除しようとしています。ボタンを5秒間長押しして確認してください。",
+    "description": "ブロック解除確認の説明",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      }
+    }
+  },
+  "deleteBlockConfirmDescription": {
+    "message": "$DOMAIN$ のブロックを削除しようとしています。ボタンを5秒間長押しして確認してください。",
+    "description": "ブロック削除確認の説明",
+    "placeholders": {
+      "domain": {
+        "content": "$1",
+        "example": "twitter.com"
+      }
+    }
+  },
+  "unblockConfirmHoldButton": {
+    "message": "長押しして確認",
+    "description": "長押しボタンラベル"
+  },
+  "unblockConfirmBlockStyle": {
+    "message": "ブロック方式: $STYLE$",
+    "description": "確認ダイアログのブロック方式表示",
+    "placeholders": {
+      "style": {
+        "content": "$1",
+        "example": "常時ブロック"
+      }
+    }
   }
 }

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -2,7 +2,10 @@ import React, { useState, useCallback } from 'react';
 import { Plus, Lock } from 'lucide-react';
 
 import { Button, Card, Input } from '~/components/ui';
-import { PasswordModal } from '~/components/options/modals';
+import {
+  PasswordModal,
+  UnblockConfirmModal
+} from '~/components/options/modals';
 import { getMessage } from '~/lib/i18n';
 import {
   NotificationSettingsSection,
@@ -11,6 +14,7 @@ import {
 } from '~/components/options/blocklist';
 import type {
   AppSettings,
+  BlockItem,
   SiteBlockCount,
   TimeLimit,
   TimeLimitUsage,
@@ -54,34 +58,65 @@ export function BlocklistTab({
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
   const [pendingToggleId, setPendingToggleId] = useState<string | null>(null);
 
+  // Unblock confirmation modal state (for non-password flow)
+  const [showUnblockConfirm, setShowUnblockConfirm] = useState(false);
+  const [pendingAction, setPendingAction] = useState<'toggle' | 'delete'>(
+    'toggle'
+  );
+  const [pendingItem, setPendingItem] = useState<BlockItem | null>(null);
+
   const isPasswordProtected =
     settings?.password?.enabled && settings?.password?.passwordHash;
 
-  // Handle remove with password check
+  // Get block style label for a block item
+  const getBlockStyleLabel = useCallback((item: BlockItem): string => {
+    if (item.timeLimit) {
+      return item.timeLimit.type === 'daily'
+        ? getMessage('dailyLimit')
+        : getMessage('hourlyLimit');
+    }
+    return getMessage('alwaysBlocked');
+  }, []);
+
+  // Handle remove with password or confirmation check
   const handleRemoveClick = useCallback(
     (id: string) => {
       if (isPasswordProtected) {
         setPendingRemoveId(id);
         setShowPasswordModal(true);
       } else {
-        onRemoveDomain(id);
+        const item = settings?.blockList.find((b) => b.id === id);
+        if (item) {
+          setPendingItem(item);
+          setPendingAction('delete');
+          setShowUnblockConfirm(true);
+        }
       }
     },
-    [isPasswordProtected, onRemoveDomain]
+    [isPasswordProtected, settings?.blockList]
   );
 
-  // Handle toggle with password check (only when disabling)
+  // Handle toggle with password or confirmation check (only when disabling)
   const handleToggleClick = useCallback(
     (id: string, enabled: boolean) => {
-      // Only require password when disabling (turning off blocking)
-      if (!enabled && isPasswordProtected) {
-        setPendingToggleId(id);
-        setShowPasswordModal(true);
+      // Only require confirmation when disabling (turning off blocking)
+      if (!enabled) {
+        if (isPasswordProtected) {
+          setPendingToggleId(id);
+          setShowPasswordModal(true);
+        } else {
+          const item = settings?.blockList.find((b) => b.id === id);
+          if (item) {
+            setPendingItem(item);
+            setPendingAction('toggle');
+            setShowUnblockConfirm(true);
+          }
+        }
       } else {
         onToggleDomain(id, enabled);
       }
     },
-    [isPasswordProtected, onToggleDomain]
+    [isPasswordProtected, onToggleDomain, settings?.blockList]
   );
 
   // Handle password confirmation success
@@ -101,6 +136,23 @@ export function BlocklistTab({
     setShowPasswordModal(false);
     setPendingRemoveId(null);
     setPendingToggleId(null);
+  }, []);
+
+  // Handle unblock confirmation
+  const handleUnblockConfirm = useCallback(() => {
+    if (!pendingItem) return;
+
+    if (pendingAction === 'delete') {
+      onRemoveDomain(pendingItem.id);
+    } else {
+      onToggleDomain(pendingItem.id, false);
+    }
+  }, [pendingItem, pendingAction, onRemoveDomain, onToggleDomain]);
+
+  // Handle unblock confirm modal close
+  const handleUnblockConfirmClose = useCallback(() => {
+    setShowUnblockConfirm(false);
+    setPendingItem(null);
   }, []);
 
   // Check if any sites have time limits configured
@@ -196,6 +248,18 @@ export function BlocklistTab({
           passwordHash={settings.password.passwordHash}
           title={getMessage('passwordRequiredForUnblock')}
           description={getMessage('passwordRequiredForUnblockDescription')}
+        />
+      )}
+
+      {/* Unblock Confirmation Modal (non-password flow) */}
+      {pendingItem && (
+        <UnblockConfirmModal
+          isOpen={showUnblockConfirm}
+          onClose={handleUnblockConfirmClose}
+          onConfirm={handleUnblockConfirm}
+          domain={pendingItem.domain}
+          blockStyle={getBlockStyleLabel(pendingItem)}
+          action={pendingAction}
         />
       )}
     </div>

--- a/src/components/options/modals/UnblockConfirmModal/UnblockConfirmModal.tsx
+++ b/src/components/options/modals/UnblockConfirmModal/UnblockConfirmModal.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ShieldOff, Trash2 } from 'lucide-react';
+
+import { Modal, Button } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+
+const HOLD_DURATION_MS = 5000;
+
+type UnblockAction = 'toggle' | 'delete';
+
+interface UnblockConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  domain: string;
+  blockStyle: string;
+  action: UnblockAction;
+}
+
+export function UnblockConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  domain,
+  blockStyle,
+  action
+}: UnblockConfirmModalProps) {
+  const [progress, setProgress] = useState(0);
+  const [isHolding, setIsHolding] = useState(false);
+  const startTimeRef = useRef<number | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+
+  const resetProgress = useCallback(() => {
+    setProgress(0);
+    setIsHolding(false);
+    startTimeRef.current = null;
+    if (animationFrameRef.current !== null) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+  }, []);
+
+  // Reset state when modal opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      resetProgress();
+    }
+  }, [isOpen, resetProgress]);
+
+  const updateProgress = useCallback(() => {
+    if (startTimeRef.current === null) return;
+
+    const elapsed = Date.now() - startTimeRef.current;
+    const newProgress = Math.min((elapsed / HOLD_DURATION_MS) * 100, 100);
+    setProgress(newProgress);
+
+    if (newProgress >= 100) {
+      resetProgress();
+      onConfirm();
+      onClose();
+      return;
+    }
+
+    animationFrameRef.current = requestAnimationFrame(updateProgress);
+  }, [onConfirm, onClose, resetProgress]);
+
+  const handlePointerDown = useCallback(() => {
+    startTimeRef.current = Date.now();
+    setIsHolding(true);
+    animationFrameRef.current = requestAnimationFrame(updateProgress);
+  }, [updateProgress]);
+
+  const handlePointerUp = useCallback(() => {
+    resetProgress();
+  }, [resetProgress]);
+
+  const handlePointerLeave = useCallback(() => {
+    resetProgress();
+  }, [resetProgress]);
+
+  // Clean up animation frame on unmount
+  useEffect(() => {
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, []);
+
+  const description =
+    action === 'delete'
+      ? getMessage('deleteBlockConfirmDescription', domain)
+      : getMessage('unblockConfirmDescription', domain);
+
+  const Icon = action === 'delete' ? Trash2 : ShieldOff;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={getMessage('unblockConfirmTitle')}
+      size="sm"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 p-4 bg-warning-50 rounded-lg">
+          <Icon className="w-5 h-5 text-warning-600 flex-shrink-0" />
+          <div className="space-y-1">
+            <p className="text-sm text-warning-800">{description}</p>
+            <p className="text-xs text-warning-600">
+              {getMessage('unblockConfirmBlockStyle', blockStyle)}
+            </p>
+          </div>
+        </div>
+
+        {/* Long-press button */}
+        <div className="space-y-2">
+          <button
+            type="button"
+            onPointerDown={handlePointerDown}
+            onPointerUp={handlePointerUp}
+            onPointerLeave={handlePointerLeave}
+            className="relative w-full h-12 overflow-hidden rounded-lg border-2 border-danger-300 bg-danger-50 select-none touch-none cursor-pointer transition-colors hover:border-danger-400"
+          >
+            {/* Progress bar */}
+            <div
+              className="absolute inset-y-0 left-0 bg-danger-200 transition-none"
+              style={{ width: `${progress}%` }}
+            />
+            {/* Button text */}
+            <div className="relative flex items-center justify-center gap-2 h-full">
+              <Icon
+                className={`w-4 h-4 ${isHolding ? 'text-danger-700' : 'text-danger-500'}`}
+              />
+              <span
+                className={`text-sm font-medium ${isHolding ? 'text-danger-700' : 'text-danger-600'}`}
+              >
+                {getMessage('unblockConfirmHoldButton')}
+                {isHolding && ` (${Math.ceil(((100 - progress) / 100) * 5)}s)`}
+              </span>
+            </div>
+          </button>
+          <p className="text-xs text-gray-500 text-center">
+            {Math.round(progress)}%
+          </p>
+        </div>
+
+        <div className="pt-2">
+          <Button variant="secondary" onClick={onClose} className="w-full">
+            {getMessage('cancel')}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/options/modals/UnblockConfirmModal/index.ts
+++ b/src/components/options/modals/UnblockConfirmModal/index.ts
@@ -1,0 +1,1 @@
+export { UnblockConfirmModal } from './UnblockConfirmModal';

--- a/src/components/options/modals/index.ts
+++ b/src/components/options/modals/index.ts
@@ -2,3 +2,4 @@ export * from './AnalyticsOptInModal';
 export * from './NewPresetModal';
 export * from './ScheduleModal';
 export * from './PasswordModal';
+export * from './UnblockConfirmModal';


### PR DESCRIPTION
## Summary
- パスワード未設定時にブロック解除(トグルOFF/削除)を行う際、5秒間の長押し確認ダイアログを表示
- UnblockConfirmModalコンポーネントを新規作成
- onPointerDown/Up/Leave + requestAnimationFrameでプログレスバーを実装
- ブロック方式(常時ブロック/時間制限)とドメイン名をダイアログに表示
- パスワード保護が有効な場合は従来通りPasswordModalを使用
- i18nメッセージ(en/ja)を追加

Closes #182

## Test plan
- [ ] パスワード未設定状態でトグルOFFにすると確認ダイアログが表示される
- [ ] 削除ボタンを押すと確認ダイアログが表示される
- [ ] ボタンを5秒間長押しするとブロック解除/削除が実行される
- [ ] 長押し中に離すとプログレスがリセットされる
- [ ] パスワード保護有効時はパスワードモーダルが表示される
- [ ] トグルONは確認ダイアログなしで即座に有効化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)