### PR TITLE
feat: ブロック追加時にAnalytics追跡を自動開始

### DIFF
--- a/src/background/messages/add-block.ts
+++ b/src/background/messages/add-block.ts
@@ -94,12 +94,20 @@ const handler: PlasmoMessaging.MessageHandler<
   }
   await setUnblockHistory(history);
 
-  // Clean up analytics data for this domain (reset time tracking)
+  // Initialize analytics tracking for this domain as 'waste' category
   const analytics = await getAnalytics();
-  if (analytics.siteTime[parsedDomain]) {
-    delete analytics.siteTime[parsedDomain];
-    await setAnalytics(analytics);
+  if (!analytics.siteTime[parsedDomain]) {
+    analytics.siteTime[parsedDomain] = {
+      domain: parsedDomain,
+      time: 0,
+      category: 'waste',
+      lastUpdated: now
+    };
+  } else {
+    analytics.siteTime[parsedDomain].category = 'waste';
   }
+  analytics.siteCategories[parsedDomain] = 'waste';
+  await setAnalytics(analytics);
 
   res.send({ success: true });
 };


### PR DESCRIPTION
## Summary
- ブロックリストにサイト追加時、siteTimeエントリを自動初期化（category='waste'）するように変更
- 既存のsiteTimeデータがある場合はカテゴリのみ更新し、追跡データを保持
- siteCategoriesにもwasteを設定し、Analytics画面で正しく分類表示

Closes #181

## Test plan
- [ ] ブロックリストに新規サイトを追加し、Analyticsタブで追跡対象として表示されることを確認
- [ ] 既にAnalyticsデータがあるサイトを再ブロックし、既存データが保持されることを確認
- [ ] ブロックされたサイトへのアクセス試行がblock countとしてAnalyticsに記録されることを確認
- [ ] ブロックリストからサイトを削除した際、追跡データが保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)