### PR TITLE
fix: スケジュールのアップロード背景画像表示時のフリッカーを修正

### DIFF
--- a/src/hooks/useBackgroundPreload.ts
+++ b/src/hooks/useBackgroundPreload.ts
@@ -104,12 +104,16 @@ export function useBackgroundPreload({
     () =>
       isColorBackground
         ? { backgroundColor }
-        : {
-            backgroundImage: `url(${backgroundUrl})`,
-            backgroundSize: 'cover',
-            backgroundPosition: 'center'
-          },
-    [isColorBackground, backgroundColor, backgroundUrl]
+        : isBackgroundReady
+          ? {
+              backgroundImage: `url(${backgroundUrl})`,
+              backgroundSize: 'cover',
+              backgroundPosition: 'center'
+            }
+          : {
+              backgroundColor: '#1a1a2e'
+            },
+    [isColorBackground, backgroundColor, backgroundUrl, isBackgroundReady]
   );
 
   return {


### PR DESCRIPTION
## Summary
- アップロード画像読み込み中にデフォルト背景が一瞬表示されるフリッカーを修正
- `useBackgroundPreload` フックの `containerStyle` 計算で `isBackgroundReady` を条件に追加
- 画像読み込み完了前は暗い単色背景（`#1a1a2e`）を表示し、スムーズに遷移

Closes #166

## Test plan
- [ ] アップロード背景画像設定時にページリロードでフリッカーが発生しないことを確認
- [ ] デフォルト背景使用時に表示が正常であることを確認
- [ ] 背景画像未設定時に表示が正常であることを確認
- [ ] カラー背景設定時に表示が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)