### PR TITLE
feat: ポップアップの制限サイト表示を「残りXX分」に変更

### DIFF
--- a/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
+++ b/src/components/features/TimeLimitBadge/TimeLimitBadge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Clock, AlertTriangle } from 'lucide-react';
 
-import { formatTime } from '~/lib/time';
+import { formatTime, formatTimeLocalized } from '~/lib/time';
 import { getMessage } from '~/lib/i18n';
 import { TIME_LIMIT_CONFIG } from '~/constants/limits';
 
@@ -38,6 +38,7 @@ export function TimeLimitBadge({
   const textColor = isLow ? 'text-warning-700' : 'text-info-700';
 
   const timeDisplay = formatTime(remainingSeconds);
+  const timeDisplayLocalized = formatTimeLocalized(remainingSeconds);
   const suffix =
     limitType === 'daily' ? getMessage('perDay') : getMessage('perHour');
 
@@ -47,7 +48,7 @@ export function TimeLimitBadge({
         className={`inline-flex items-center gap-1 px-2 py-0.5 ${bgColor} ${textColor} text-xs rounded-full`}
       >
         <Clock className="w-3 h-3" />
-        {timeDisplay}
+        {getMessage('timeLimitRemaining', timeDisplayLocalized)}
       </span>
     );
   }

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -16,6 +16,26 @@ export function formatTime(seconds: number): string {
   return `${minutes}m`;
 }
 
+// Format seconds to localized time string (e.g., "23分" for Japanese, "23 min" for English)
+export function formatTimeLocalized(seconds: number, language: 'ja' | 'en' = 'ja'): string {
+  if (seconds < 60) {
+    return language === 'ja' ? `${seconds}秒` : `${seconds} sec`;
+  }
+
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  if (hours > 0) {
+    if (language === 'ja') {
+      return minutes > 0 ? `${hours}時間${minutes}分` : `${hours}時間`;
+    } else {
+      return minutes > 0 ? `${hours} hr ${minutes} min` : `${hours} hr`;
+    }
+  }
+
+  return language === 'ja' ? `${minutes}分` : `${minutes} min`;
+}
+
 // Format seconds to short format (e.g., "1:23:45")
 export function formatTimeShort(seconds: number): string {
   const hours = Math.floor(seconds / 3600);

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,4 +1,5 @@
 import { MS_PER_DAY } from '~/constants/intervals';
+import { getCurrentLanguage } from '~/lib/i18n';
 
 // Format seconds to human readable string (e.g., "1h 23m")
 export function formatTime(seconds: number): string {
@@ -16,8 +17,10 @@ export function formatTime(seconds: number): string {
   return `${minutes}m`;
 }
 
-// Format seconds to localized time string (e.g., "23分" for Japanese, "23 min" for English)
-export function formatTimeLocalized(seconds: number, language: 'ja' | 'en' = 'ja'): string {
+// ローカライズされた時間表記（例: "23分" / "23 min"）
+export function formatTimeLocalized(seconds: number): string {
+  const language = getCurrentLanguage();
+
   if (seconds < 60) {
     return language === 'ja' ? `${seconds}秒` : `${seconds} sec`;
   }


### PR DESCRIPTION
## Summary
- コンパクトモードの時間表示を「⏱ 3m」→「⏱ 残り 3分」に変更
- `formatTimeLocalized()` 関数を追加し、日本語/英語でローカライズされた時間表記に対応
- 既存の i18n メッセージ `timeLimitRemaining`（「残り $TIME$」/「$TIME$ remaining」）を活用

Closes #153

## Test plan
- [ ] ポップアップでブロック中サイトの残り時間が「残り XX分」と表示されることを確認
- [ ] 英語環境で「XX min remaining」と表示されることを確認
- [ ] 制限時間の境界値（0秒、60秒未満、60分以上）で正しく表示されることを確認
- [ ] TimeLimitEditor での表示にも影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)