### PR TITLE
feat: 分析の「節約した時間」にツールチップで算出方法の説明を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1051,6 +1051,10 @@
     "message": "Time saved",
     "description": "Time saved label for blocked sites"
   },
+  "timeSavedTooltip": {
+    "message": "Calculated as: blocked access attempts × avg. browsing time (5 min)",
+    "description": "Tooltip explaining how time saved is calculated"
+  },
   "noUnblockedSites": {
     "message": "No unblocked sites",
     "description": "No unblocked sites title"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1051,6 +1051,10 @@
     "message": "節約した時間",
     "description": "ブロック中サイトの節約時間ラベル"
   },
+  "timeSavedTooltip": {
+    "message": "ブロック中にアクセスを試みた回数 × 平均滞在時間（5分）で算出",
+    "description": "節約した時間の算出方法の説明ツールチップ"
+  },
   "noUnblockedSites": {
     "message": "ブロック解除したサイトはありません",
     "description": "ブロック解除サイトなしタイトル"

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -172,10 +172,14 @@ function BlockedSiteItem({ site }: { site: TrackedSite }) {
           </span>
           <p className="text-xs text-gray-500 inline-flex items-center gap-1">
             {getMessage('timeSaved')}
-            <Info
-              className="w-3 h-3 text-gray-400 cursor-help"
+            <button
+              type="button"
+              className="inline-flex text-gray-400 hover:text-gray-600"
               title={getMessage('timeSavedTooltip')}
-            />
+              aria-label={getMessage('timeSavedTooltip')}
+            >
+              <Info className="w-3 h-3" />
+            </button>
           </p>
         </div>
       </div>

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { AlertTriangle, Clock, Lock, RefreshCw, EyeOff } from 'lucide-react';
+import { AlertTriangle, Clock, Info, Lock, RefreshCw, EyeOff } from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
 import { UpgradePrompt } from '~/components/features';
@@ -170,7 +170,13 @@ function BlockedSiteItem({ site }: { site: TrackedSite }) {
           <span className="text-lg font-bold text-success-600">
             0{getMessage('time') === 'Time' ? 'm' : '\u5206'}
           </span>
-          <p className="text-xs text-gray-500">{getMessage('timeSaved')}</p>
+          <p className="text-xs text-gray-500 inline-flex items-center gap-1">
+            {getMessage('timeSaved')}
+            <Info
+              className="w-3 h-3 text-gray-400 cursor-help"
+              title={getMessage('timeSavedTooltip')}
+            />
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 分析タブの「節約した時間」の横に info アイコン（lucide-react の Info）を追加
- ホバーで算出方法の説明をツールチップで表示
- 日本語: 「ブロック中にアクセスを試みた回数 × 平均滞在時間（5分）で算出」
- 英語: "Calculated as: blocked access attempts × avg. browsing time (5 min)"

Closes #161

## Test plan
- [ ] 分析タブで「節約した時間」の横に info アイコンが表示されることを確認
- [ ] アイコンにホバーでツールチップが正しく表示されることを確認
- [ ] 日本語・英語の両方で正しいメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)