### PR TITLE
fix: YouTube ホームフィード非表示機能を修正

### DIFF
--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -28,7 +28,9 @@ const SELECTORS = {
     'ytd-guide-entry-renderer a[title="Shorts"], ytd-guide-entry-renderer a[href="/shorts"]',
 
   // Recommendations (Home page)
-  homeFeed: 'ytd-browse[page-subtype="home"] #contents',
+  // ホームフィードの動画一覧を確実に非表示にするため、複数のセレクタを使用
+  homeFeed: 'ytd-browse[page-subtype="home"] ytd-rich-grid-renderer',
+  homeFeedContents: 'ytd-browse[page-subtype="home"] #contents',
   homeChips: 'ytd-feed-filter-chip-bar-renderer',
 
   // Recommendations (Watch page)
@@ -165,13 +167,14 @@ function generateCSS(settings: YouTubeSettings): string {
   if (settings.hideHomeFeed) {
     rules.push(`
       /* Hide home feed - show only search bar */
-      ytd-browse[page-subtype="home"] ${SELECTORS.homeFeed},
-      ytd-browse[page-subtype="home"] ${SELECTORS.homeChips} {
+      ${SELECTORS.homeFeed},
+      ${SELECTORS.homeFeedContents},
+      ${SELECTORS.homeChips} {
         display: none !important;
       }
       /* Show a message instead */
       ytd-browse[page-subtype="home"]::after {
-        content: 'Home feed is hidden. Use search to find specific videos.';
+        content: 'ホームフィードが隠れています';
         display: block;
         text-align: center;
         padding: 100px 20px;


### PR DESCRIPTION
## Summary
- YouTube の現在の DOM 構造に合わせて CSS セレクタを更新
- ホームフィードの動画一覧を確実に非表示にする

## Changes
- `ytd-rich-grid-renderer` を直接ターゲットに追加
- `#contents` と `ytd-rich-grid-renderer` の両方を非表示にすることで動画一覧を確実に隠す
- 表示メッセージを日本語化（「ホームフィードが隠れています」）

## Test plan
- [ ] Chrome 拡張機能をビルドして読み込む
- [ ] YouTube のホームページを開く
- [ ] 設定で「ホームフィードを非表示」を有効化
- [ ] 動画一覧が完全に非表示になり、「ホームフィードが隠れています」メッセージが表示されることを確認
- [ ] カテゴリタブも非表示になることを確認

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)