### PR TITLE
fix: YouTube「おすすめを非表示」機能でサイドバーとエンドスクリーンを完全に隠す

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1724,7 +1724,7 @@
     "description": "Hide recommendations option"
   },
   "youtubeHideRecommendationsDescription": {
-    "message": "Hide video recommendations at the end of videos",
+    "message": "Hide end screen recommendations, related videos in sidebar, and autoplay",
     "description": "Hide recommendations description"
   },
   "youtubeHideComments": {

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1724,7 +1724,7 @@
     "description": "おすすめ非表示オプション"
   },
   "youtubeHideRecommendationsDescription": {
-    "message": "動画終了時のおすすめ動画を非表示にします",
+    "message": "エンドスクリーンのおすすめ動画・サイドバーの関連動画・自動再生を非表示にします",
     "description": "おすすめ非表示の説明"
   },
   "youtubeHideComments": {

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -1,5 +1,12 @@
 import React, { useMemo } from 'react';
-import { AlertTriangle, Clock, Info, Lock, RefreshCw, EyeOff } from 'lucide-react';
+import {
+  AlertTriangle,
+  Clock,
+  Info,
+  Lock,
+  RefreshCw,
+  EyeOff
+} from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
 import { UpgradePrompt } from '~/components/features';

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -138,6 +138,19 @@ function generateCSS(settings: YouTubeSettings): string {
       ${SELECTORS.endScreen} {
         display: none !important;
       }
+      /* Hide related videos in sidebar */
+      ytd-watch-flexy ${SELECTORS.relatedVideos},
+      ytd-watch-flexy ${SELECTORS.secondaryInner} #related {
+        display: none !important;
+      }
+      /* Hide autoplay toggle button */
+      ${SELECTORS.autoplayToggle} {
+        display: none !important;
+      }
+      /* Expand video player when recommendations are hidden */
+      ytd-watch-flexy[flexy][is-two-columns_] #primary {
+        max-width: 100% !important;
+      }
     `);
   }
 
@@ -224,7 +237,7 @@ function handleDynamicContent(): void {
       .forEach((el) => ((el as HTMLElement).style.display = 'none'));
   }
 
-  if (currentSettings.hideRecommendations && currentSettings.hideHomeFeed) {
+  if (currentSettings.hideRecommendations) {
     // Disable autoplay when recommendations are hidden
     const autoplayToggle = document.querySelector(
       SELECTORS.autoplayToggle

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -133,6 +133,10 @@ function generateCSS(settings: YouTubeSettings): string {
   }
 
   if (settings.hideRecommendations) {
+    // Note: This selector intentionally overlaps with hideSidebar setting.
+    // hideRecommendations targets end screen + sidebar related videos + autoplay.
+    // hideSidebar only targets sidebar related videos (no end screen/autoplay).
+    // This allows users to hide end screen without hiding sidebar if desired.
     rules.push(`
       /* Hide end screen recommendations */
       ${SELECTORS.endScreen} {


### PR DESCRIPTION
## Summary
- `hideRecommendations` 有効時に動画視聴中のサイドバー関連動画を非表示に追加
- エンドスクリーンのおすすめ動画を非表示（既存機能を維持）
- 自動再生トグルボタンを非表示に追加
- おすすめ非表示時にビデオプレイヤーを自動拡張
- 自動再生の自動オフ処理を `hideRecommendations` のみで実行（`hideHomeFeed` 条件を削除）

## Changes
### src/contents/youtube.ts
- `hideRecommendations` 設定で以下の要素を非表示に:
  - `.ytp-endscreen-content` (既存)
  - `#related` (サイドバーの関連動画 - 新規)
  - `.ytp-autonav-toggle-button` (自動再生ボタン - 新規)
- `hideRecommendations` と `hideSidebar` のセレクタが重複する場合、どちらが有効でも非表示になるように実装
- `handleDynamicContent` の自動再生オフ処理を `hideRecommendations` 単独で実行

## Test plan
- [ ] YouTube で動画を視聴し、「おすすめを非表示」を有効化
- [ ] サイドバーの関連動画が非表示になることを確認
- [ ] 動画終了後のエンドスクリーンおすすめが非表示になることを確認
- [ ] 自動再生トグルボタンが非表示になることを確認
- [ ] ビデオプレイヤーが横幅いっぱいに拡張されることを確認
- [ ] 自動再生が自動でオフになることを確認
- [ ] `hideSidebar` を有効化した場合も同様に動作することを確認

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)