### PR TITLE
fix: YouTube hideComments を拡張してライブチャットにも対応

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1732,7 +1732,7 @@
     "description": "Hide comments option"
   },
   "youtubeHideCommentsDescription": {
-    "message": "Hide the comment section below videos",
+    "message": "Hide the comment section below videos and live chat",
     "description": "Hide comments description"
   },
   "youtubeHideSidebar": {

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1732,7 +1732,7 @@
     "description": "コメント非表示オプション"
   },
   "youtubeHideCommentsDescription": {
-    "message": "動画下のコメント欄を非表示にします",
+    "message": "動画下のコメント欄とライブチャットを非表示にします",
     "description": "コメント非表示の説明"
   },
   "youtubeHideSidebar": {

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -40,6 +40,7 @@ const SELECTORS = {
 
   // Comments
   comments: 'ytd-comments#comments',
+  liveChat: 'ytd-live-chat-frame#chat',
 
   // Sidebar (related videos on watch page)
   sidebar: '#secondary #related',
@@ -160,8 +161,9 @@ function generateCSS(settings: YouTubeSettings): string {
 
   if (settings.hideComments) {
     rules.push(`
-      /* Hide comments section */
-      ${SELECTORS.comments} {
+      /* Hide comments section and live chat */
+      ${SELECTORS.comments},
+      ${SELECTORS.liveChat} {
         display: none !important;
       }
     `);


### PR DESCRIPTION
## 修正内容

Issue #148 で報告されたバグを修正しました。

**現象:**
- 「コメントを非表示」を有効にしても、ライブ配信のチャットコメントが表示されたまま
- 通常の動画コメント (`ytd-comments#comments`) のみが対象で、ライブチャットが未対応

**修正:**
- ライブチャットフレーム (`ytd-live-chat-frame#chat`) をセレクタに追加
- `hideComments` が以下を全て非表示にするように修正:
  - 通常動画のコメントセクション (`ytd-comments#comments`)
  - ライブ配信のチャットフレーム (`ytd-live-chat-frame#chat`)
- 設定説明文（en/ja）を「コメントとライブチャットを非表示」に更新

## テスト

- [ ] 通常動画でコメントが非表示になることを確認
- [ ] ライブ配信でチャットが非表示になることを確認
- [ ] 設定UI で説明文が正しく表示されることを確認

## 関連 Issue

Closes #148