### PR TITLE
fix: Extension context invalidated エラーを修正

### DIFF
--- a/src/background/blocker.ts
+++ b/src/background/blocker.ts
@@ -7,6 +7,7 @@ import {
   getActiveBlockedDomains,
   type BlockReason
 } from '~/lib/blockService';
+import { isExtensionContextValid } from '~/lib/chromeApi';
 
 // Re-export types for backwards compatibility
 export type { BlockReason };
@@ -127,6 +128,11 @@ export async function removeBlockedDomain(id: string): Promise<void> {
 
 // Check all open tabs and redirect any that match blocked domains
 export async function blockExistingTabs(): Promise<void> {
+  // Check if extension context is still valid
+  if (!isExtensionContextValid()) {
+    return;
+  }
+
   const tabs = await chrome.tabs.query({});
   const newtabUrl = chrome.runtime.getURL('newtab.html');
 

--- a/src/background/notifications.ts
+++ b/src/background/notifications.ts
@@ -3,6 +3,7 @@ import { findEnabledBlockItemForDomain } from '~/lib/blockService';
 import { getRemainingTime } from '~/lib/timeLimitService';
 import { getYouTubeRemainingTime } from '~/lib/youtubeBlockService';
 import { getMessage } from '~/lib/i18n';
+import { isExtensionContextValid } from '~/lib/chromeApi';
 
 // In-memory state to track which domains have been notified
 // Key: domain, Value: reset key (YYYY-MM-DD for daily, YYYY-MM-DD-HH for hourly)
@@ -61,6 +62,11 @@ async function showTimeLimitNotification(
 ): Promise<void> {
   // Guard: skip if chrome.notifications API is unavailable
   if (!isNotificationsApiAvailable()) {
+    return;
+  }
+
+  // Check if extension context is still valid
+  if (!isExtensionContextValid()) {
     return;
   }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -7,6 +7,7 @@
 
 import { getSettings } from '~/lib/storage';
 import { getCurrentLanguage } from '~/lib/i18n';
+import { isExtensionContextValid } from '~/lib/chromeApi';
 
 const GA_MEASUREMENT_ID = process.env.PLASMO_PUBLIC_GA_MEASUREMENT_ID ?? '';
 const GA_API_SECRET = process.env.PLASMO_PUBLIC_GA_API_SECRET ?? '';
@@ -119,6 +120,11 @@ export async function trackError(type: string): Promise<void> {
 export async function sendDailyActive(): Promise<void> {
   const enabled = await isAnalyticsEnabled();
   if (!enabled) return;
+
+  // Check if extension context is still valid
+  if (!isExtensionContextValid()) {
+    return;
+  }
 
   const settings = await getSettings();
   const version = chrome.runtime.getManifest().version;

--- a/src/lib/chromeApi.ts
+++ b/src/lib/chromeApi.ts
@@ -6,6 +6,18 @@
  * since they use background-specific APIs or run in a different context.
  */
 
+/**
+ * Check if extension context is still valid.
+ * Returns false if the extension has been updated/reloaded and this script is stale.
+ */
+export function isExtensionContextValid(): boolean {
+  try {
+    return !!chrome.runtime?.id;
+  } catch {
+    return false;
+  }
+}
+
 /** Get the currently active tab in the current window */
 export async function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
   const [tab] = await chrome.tabs.query({
@@ -17,6 +29,9 @@ export async function getActiveTab(): Promise<chrome.tabs.Tab | undefined> {
 
 /** Open the extension's options page */
 export function openOptionsPage(): void {
+  if (!isExtensionContextValid()) {
+    return;
+  }
   chrome.runtime.openOptionsPage();
 }
 
@@ -27,6 +42,10 @@ export function createTab(url: string): void {
 
 /** Get the full URL for an extension resource */
 export function getExtensionURL(path: string): string {
+  if (!isExtensionContextValid()) {
+    // Return empty string if context is invalid
+    return '';
+  }
   return chrome.runtime.getURL(path);
 }
 


### PR DESCRIPTION
## Summary

`Extension context invalidated` エラーを修正しました。拡張機能の更新後に古いコンテンツスクリプトやバックグラウンドスクリプトが残っている場合、chrome.runtime API の呼び出しで例外が発生していました。

**変更内容:**
- `chromeApi.ts` に `isExtensionContextValid()` ユーティリティ関数を追加
- `analytics.ts`、`blocker.ts`、`notifications.ts` で chrome.runtime API 呼び出し前にコンテキスト有効性を確認
- コンテキストが無効な場合は処理を graceful にスキップ

**影響範囲:**
- バックグラウンドスクリプト（analytics, blocker, notifications）
- UI ユーティリティ（chromeApi）

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run build` 成功
- [x] `npm run test` 全テスト通過
- [ ] 拡張機能を更新後、古いページでエラーが発生しないことを手動確認
- [ ] 通常の動作（ブロック、通知、アナリティクス）が正常に動作することを確認

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)