### PR TITLE
test: #20 単体テスト カテゴリC (hooks)

### DIFF
--- a/src/hooks/__tests__/useBlocklist.test.ts
+++ b/src/hooks/__tests__/useBlocklist.test.ts
@@ -423,7 +423,7 @@ describe('useBlocklist', () => {
     });
 
     it('通知設定を更新', async () => {
-      vi.mocked(storage.set).mockResolvedValue();
+      vi.mocked(storage.set).mockResolvedValue(undefined);
 
       const { result } = renderHook(() =>
         useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })

--- a/src/hooks/__tests__/useBlocklist.test.ts
+++ b/src/hooks/__tests__/useBlocklist.test.ts
@@ -1,0 +1,470 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useBlocklist } from '~/hooks/useBlocklist';
+import type { AppSettings, BlockItem, TimeLimit } from '~/types/storage';
+import { DEFAULT_SETTINGS } from '~/types/storage';
+
+// Mock dependencies
+vi.mock('@plasmohq/messaging', () => ({
+  sendToBackground: vi.fn()
+}));
+
+vi.mock('~/lib/analytics', () => ({
+  trackFeatureUse: vi.fn()
+}));
+
+vi.mock('~/lib/domain', () => ({
+  parseDomainInput: vi.fn()
+}));
+
+vi.mock('~/lib/license', () => ({
+  canAddToBlocklist: vi.fn()
+}));
+
+vi.mock('~/lib/storage', () => ({
+  storage: {
+    get: vi.fn(),
+    set: vi.fn()
+  }
+}));
+
+import { sendToBackground } from '@plasmohq/messaging';
+import { trackFeatureUse } from '~/lib/analytics';
+import { parseDomainInput } from '~/lib/domain';
+import { canAddToBlocklist } from '~/lib/license';
+import { storage } from '~/lib/storage';
+
+describe('useBlocklist', () => {
+  const mockSetSettings = vi.fn();
+
+  const mockBlockItem: BlockItem = {
+    id: 'test-id',
+    domain: 'youtube.com',
+    isWildcard: false,
+    createdAt: '2024-01-01T00:00:00Z',
+    enabled: true
+  };
+
+  const mockSettings: AppSettings = {
+    ...DEFAULT_SETTINGS,
+    blockList: [mockBlockItem]
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('初期状態でnewDomainが空文字', () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+      expect(result.current.newDomain).toBe('');
+    });
+
+    it('初期状態でblockErrorが空文字', () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+      expect(result.current.blockError).toBe('');
+    });
+  });
+
+  describe('setNewDomain', () => {
+    it('newDomainを更新できる', () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('twitter.com');
+      });
+
+      expect(result.current.newDomain).toBe('twitter.com');
+    });
+  });
+
+  describe('handleAddDomain', () => {
+    it('settingsがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: undefined, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(canAddToBlocklist).not.toHaveBeenCalled();
+    });
+
+    it('newDomainが空の場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(canAddToBlocklist).not.toHaveBeenCalled();
+    });
+
+    it('ライセンス制限に達した場合、エラーメッセージを設定', async () => {
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: false,
+        limit: 5,
+        reason: 'Limit reached: 5 sites'
+      });
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('twitter.com');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(result.current.blockError).toBe('Limit reached: 5 sites');
+    });
+
+    it('無効なドメイン形式の場合、エラーメッセージを設定', async () => {
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: true,
+        limit: 10
+      });
+      vi.mocked(parseDomainInput).mockReturnValue(null);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('invalid');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(result.current.blockError).toBe('Invalid domain format');
+    });
+
+    it('既にブロックリストに存在するドメインの場合、エラーメッセージを設定', async () => {
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: true,
+        limit: 10
+      });
+      vi.mocked(parseDomainInput).mockReturnValue({
+        domain: 'youtube.com',
+        isWildcard: false
+      });
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('youtube.com');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(result.current.blockError).toBe('Domain already in block list');
+    });
+
+    it('成功時、背景スクリプトを呼び出し、設定を更新', async () => {
+      const updatedSettings: AppSettings = {
+        ...mockSettings,
+        blockList: [
+          mockBlockItem,
+          {
+            id: 'test-id-2',
+            domain: 'twitter.com',
+            isWildcard: false,
+            createdAt: '2024-01-02T00:00:00Z',
+            enabled: true
+          }
+        ]
+      };
+
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: true,
+        limit: 10
+      });
+      vi.mocked(parseDomainInput).mockReturnValue({
+        domain: 'twitter.com',
+        isWildcard: false
+      });
+      vi.mocked(sendToBackground).mockResolvedValue({ success: true });
+      vi.mocked(storage.get).mockResolvedValue(updatedSettings);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('twitter.com');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(sendToBackground).toHaveBeenCalledWith({
+        name: 'add-block',
+        body: { domain: 'twitter.com' }
+      });
+      expect(trackFeatureUse).toHaveBeenCalledWith('block_add');
+      expect(result.current.newDomain).toBe('');
+      expect(result.current.blockError).toBe('');
+      expect(mockSetSettings).toHaveBeenCalledWith(updatedSettings);
+    });
+
+    it('背景スクリプトがエラーを返した場合、エラーメッセージを設定', async () => {
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: true,
+        limit: 10
+      });
+      vi.mocked(parseDomainInput).mockReturnValue({
+        domain: 'twitter.com',
+        isWildcard: false
+      });
+      vi.mocked(sendToBackground).mockResolvedValue({
+        success: false,
+        error: 'Backend error'
+      });
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('twitter.com');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(result.current.blockError).toBe('Backend error');
+    });
+
+    it('背景スクリプトが例外を投げた場合、エラーメッセージを設定', async () => {
+      vi.mocked(canAddToBlocklist).mockResolvedValue({
+        allowed: true,
+        limit: 10
+      });
+      vi.mocked(parseDomainInput).mockReturnValue({
+        domain: 'twitter.com',
+        isWildcard: false
+      });
+      vi.mocked(sendToBackground).mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setNewDomain('twitter.com');
+      });
+
+      await act(async () => {
+        await result.current.handleAddDomain();
+      });
+
+      expect(result.current.blockError).toBe('Failed to add domain');
+    });
+  });
+
+  describe('handleRemoveDomain', () => {
+    it('背景スクリプトを呼び出し、設定を更新', async () => {
+      const updatedSettings: AppSettings = {
+        ...mockSettings,
+        blockList: []
+      };
+
+      vi.mocked(sendToBackground).mockResolvedValue({ success: true });
+      vi.mocked(storage.get).mockResolvedValue(updatedSettings);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleRemoveDomain('test-id');
+      });
+
+      expect(sendToBackground).toHaveBeenCalledWith({
+        name: 'remove-block',
+        body: { id: 'test-id' }
+      });
+      expect(trackFeatureUse).toHaveBeenCalledWith('block_remove');
+      expect(mockSetSettings).toHaveBeenCalledWith(updatedSettings);
+    });
+
+    it('例外が発生してもエラーをスローしない', async () => {
+      vi.mocked(sendToBackground).mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleRemoveDomain('test-id');
+      });
+
+      // エラーがスローされないことを確認
+      expect(mockSetSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleToggleDomain', () => {
+    it('背景スクリプトを呼び出し、設定を更新', async () => {
+      const updatedSettings: AppSettings = {
+        ...mockSettings,
+        blockList: [{ ...mockBlockItem, enabled: false }]
+      };
+
+      vi.mocked(sendToBackground).mockResolvedValue({ success: true });
+      vi.mocked(storage.get).mockResolvedValue(updatedSettings);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleToggleDomain('test-id', false);
+      });
+
+      expect(sendToBackground).toHaveBeenCalledWith({
+        name: 'toggle-block',
+        body: { id: 'test-id', enabled: false }
+      });
+      expect(mockSetSettings).toHaveBeenCalledWith(updatedSettings);
+    });
+  });
+
+  describe('handleUpdateTimeLimit', () => {
+    it('背景スクリプトを呼び出し、設定を更新', async () => {
+      const timeLimit: TimeLimit = {
+        type: 'daily',
+        limitSeconds: 3600
+      };
+
+      const updatedSettings: AppSettings = {
+        ...mockSettings,
+        blockList: [{ ...mockBlockItem, timeLimit }]
+      };
+
+      vi.mocked(sendToBackground).mockResolvedValue({ success: true });
+      vi.mocked(storage.get).mockResolvedValue(updatedSettings);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateTimeLimit('test-id', timeLimit);
+      });
+
+      expect(sendToBackground).toHaveBeenCalledWith({
+        name: 'update-time-limit',
+        body: { id: 'test-id', timeLimit }
+      });
+      expect(mockSetSettings).toHaveBeenCalledWith(updatedSettings);
+    });
+
+    it('タイムリミットをnullに設定できる', async () => {
+      const updatedSettings: AppSettings = {
+        ...mockSettings,
+        blockList: [{ ...mockBlockItem, timeLimit: null }]
+      };
+
+      vi.mocked(sendToBackground).mockResolvedValue({ success: true });
+      vi.mocked(storage.get).mockResolvedValue(updatedSettings);
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateTimeLimit('test-id', null);
+      });
+
+      expect(sendToBackground).toHaveBeenCalledWith({
+        name: 'update-time-limit',
+        body: { id: 'test-id', timeLimit: null }
+      });
+      expect(mockSetSettings).toHaveBeenCalledWith(updatedSettings);
+    });
+  });
+
+  describe('handleUpdateNotifications', () => {
+    it('settingsがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: undefined, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNotifications({
+          timeLimitEnabled: true,
+          timeLimitMinutes: 10
+        });
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('通知設定を更新', async () => {
+      vi.mocked(storage.set).mockResolvedValue();
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      const newNotifications = {
+        timeLimitEnabled: false,
+        timeLimitMinutes: 10 as const
+      };
+
+      await act(async () => {
+        await result.current.handleUpdateNotifications(newNotifications);
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        notifications: newNotifications
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+    });
+
+    it('例外が発生してもエラーをスローしない', async () => {
+      vi.mocked(storage.set).mockRejectedValue(new Error('Storage error'));
+
+      const { result } = renderHook(() =>
+        useBlocklist({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleUpdateNotifications({
+          timeLimitEnabled: true,
+          timeLimitMinutes: 5
+        });
+      });
+
+      // エラーがスローされないことを確認
+      await waitFor(() => {
+        expect(mockSetSettings).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/hooks/__tests__/usePresets.test.ts
+++ b/src/hooks/__tests__/usePresets.test.ts
@@ -2,14 +2,8 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { usePresets } from '~/hooks/usePresets';
-import type {
-  VisionSettings,
-  DashboardPreset
-} from '~/types/storage';
-import {
-  DEFAULT_VISION,
-  DEFAULT_DISPLAY_SETTINGS
-} from '~/types/storage';
+import type { VisionSettings, DashboardPreset } from '~/types/storage';
+import { DEFAULT_VISION, DEFAULT_DISPLAY_SETTINGS } from '~/types/storage';
 import { DEFAULT_FONT_SETTINGS } from '~/types/font';
 
 // Mock dependencies
@@ -368,7 +362,8 @@ describe('usePresets', () => {
         await result.current.handleSaveSelectedPreset();
       });
 
-      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      const savedVision = vi.mocked(storage.set).mock
+        .calls[0][1] as VisionSettings;
       expect(savedVision.presets[0].name).toBe('Updated Name');
       expect(savedVision.presets[0].goalText).toBe('Updated Goal');
       expect(mockSetVision).toHaveBeenCalledWith(savedVision);
@@ -496,7 +491,8 @@ describe('usePresets', () => {
         await result.current.handleApplyPreset();
       });
 
-      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      const savedVision = vi.mocked(storage.set).mock
+        .calls[0][1] as VisionSettings;
       expect(savedVision.activePresetId).toBe('preset-1');
       expect(mockSetVision).toHaveBeenCalledWith(savedVision);
       expect(trackFeatureUse).toHaveBeenCalledWith('preset_switch');
@@ -573,7 +569,8 @@ describe('usePresets', () => {
         await result.current.handleCreatePreset();
       });
 
-      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      const savedVision = vi.mocked(storage.set).mock
+        .calls[0][1] as VisionSettings;
       expect(savedVision.presets).toHaveLength(2);
       expect(savedVision.presets[1].id).toBe('new-preset-id');
       expect(savedVision.presets[1].name).toBe('New Preset');
@@ -625,7 +622,8 @@ describe('usePresets', () => {
         await result.current.handleDeletePreset('preset-1');
       });
 
-      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      const savedVision = vi.mocked(storage.set).mock
+        .calls[0][1] as VisionSettings;
       expect(savedVision.presets).toHaveLength(0);
       expect(mockSetVision).toHaveBeenCalledWith(savedVision);
       expect(result.current.selectedPresetId).toBeNull();
@@ -693,7 +691,8 @@ describe('usePresets', () => {
         await result.current.handleDeletePreset('preset-1');
       });
 
-      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      const savedVision = vi.mocked(storage.set).mock
+        .calls[0][1] as VisionSettings;
       expect(savedVision.activePresetId).toBeNull();
     });
   });

--- a/src/hooks/__tests__/usePresets.test.ts
+++ b/src/hooks/__tests__/usePresets.test.ts
@@ -1,0 +1,745 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { usePresets } from '~/hooks/usePresets';
+import type {
+  VisionSettings,
+  DashboardPreset,
+  DashboardDisplaySettings
+} from '~/types/storage';
+import {
+  DEFAULT_VISION,
+  DEFAULT_DISPLAY_SETTINGS
+} from '~/types/storage';
+import { DEFAULT_FONT_SETTINGS } from '~/types/font';
+
+// Mock dependencies
+vi.mock('~/lib/analytics', () => ({
+  trackFeatureUse: vi.fn()
+}));
+
+vi.mock('~/lib/storage', () => ({
+  storage: {
+    get: vi.fn(),
+    set: vi.fn()
+  }
+}));
+
+vi.mock('~/lib/presetUtils', () => ({
+  presetToDisplaySettings: vi.fn((preset: DashboardPreset) => ({
+    goalText: preset.goalText,
+    goalSubText: preset.goalSubText,
+    textColor: preset.textColor,
+    backgroundType: preset.backgroundType,
+    backgroundImage: preset.backgroundImage,
+    backgroundColor: preset.backgroundColor,
+    customBackgroundData: preset.customBackgroundData,
+    fontSettings: preset.fontSettings
+  }))
+}));
+
+vi.mock('~/constants/fonts', () => ({
+  loadGoogleFont: vi.fn()
+}));
+
+vi.mock('~/constants/intervals', () => ({
+  STATUS_RESET_DELAY_MS: 1000
+}));
+
+import { trackFeatureUse } from '~/lib/analytics';
+import { storage } from '~/lib/storage';
+
+describe('usePresets', () => {
+  const mockSetVision = vi.fn();
+
+  const mockPreset: DashboardPreset = {
+    id: 'preset-1',
+    name: 'Focus Mode',
+    goalText: 'Stay Focused',
+    goalSubText: 'Deep Work',
+    textColor: '#ffffff',
+    backgroundType: 'image',
+    backgroundImage: 'default-1',
+    backgroundColor: '#1a1a2e',
+    customBackgroundData: null,
+    fontSettings: DEFAULT_FONT_SETTINGS,
+    createdAt: '2024-01-01T00:00:00Z'
+  };
+
+  const mockVision: VisionSettings = {
+    ...DEFAULT_VISION,
+    presets: [mockPreset],
+    activePresetId: 'preset-1'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(storage.get).mockResolvedValue(mockVision);
+    vi.mocked(storage.set).mockResolvedValue();
+    // crypto.randomUUID のモック
+    vi.stubGlobal('crypto', {
+      ...global.crypto,
+      randomUUID: vi.fn(() => 'new-preset-id')
+    });
+  });
+
+  describe('初期化', () => {
+    it('プリセットがある場合、activePresetIdを選択', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+        expect(result.current.editingPresetName).toBe('Focus Mode');
+        expect(result.current.draftDisplaySettings.goalText).toBe(
+          'Stay Focused'
+        );
+      });
+    });
+
+    it('activePresetIdがnullの場合、最初のプリセットを選択', async () => {
+      const visionWithoutActive: VisionSettings = {
+        ...mockVision,
+        activePresetId: null
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithoutActive);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithoutActive,
+          setVision: mockSetVision
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+    });
+
+    it('プリセットがない場合、デフォルト設定を使用', async () => {
+      const visionWithoutPresets: VisionSettings = {
+        ...DEFAULT_VISION,
+        presets: []
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithoutPresets);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithoutPresets,
+          setVision: mockSetVision
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBeNull();
+        expect(result.current.editingPresetName).toBe('');
+        expect(result.current.draftDisplaySettings).toEqual(
+          DEFAULT_DISPLAY_SETTINGS
+        );
+      });
+    });
+
+    it('storageからvisionが取得できない場合、DEFAULT_VISIONを使用', async () => {
+      vi.mocked(storage.get).mockResolvedValue(undefined);
+
+      const { result } = renderHook(() =>
+        usePresets({ vision: undefined, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBeNull();
+      });
+    });
+  });
+
+  describe('表示設定の更新', () => {
+    it('handleGoalTextChange でゴールテキストを更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleGoalTextChange('New Goal');
+      });
+
+      expect(result.current.draftDisplaySettings.goalText).toBe('New Goal');
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleGoalSubTextChange でサブテキストを更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleGoalSubTextChange('New Subtext');
+      });
+
+      expect(result.current.draftDisplaySettings.goalSubText).toBe(
+        'New Subtext'
+      );
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleTextColorChange でテキスト色を更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleTextColorChange('#ff0000');
+      });
+
+      expect(result.current.draftDisplaySettings.textColor).toBe('#ff0000');
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleBackgroundTypeChange で背景タイプを更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleBackgroundTypeChange('color');
+      });
+
+      expect(result.current.draftDisplaySettings.backgroundType).toBe('color');
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleBackgroundChange で背景画像を更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleBackgroundChange('default-2');
+      });
+
+      expect(result.current.draftDisplaySettings.backgroundImage).toBe(
+        'default-2'
+      );
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleBackgroundColorChange で背景色を更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleBackgroundColorChange('#00ff00');
+      });
+
+      expect(result.current.draftDisplaySettings.backgroundColor).toBe(
+        '#00ff00'
+      );
+      expect(result.current.isDirty).toBe(true);
+    });
+
+    it('handleFontSettingsChange でフォント設定を更新', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      const newFontSettings = {
+        ...DEFAULT_FONT_SETTINGS,
+        family: 'Inter' as const
+      };
+
+      act(() => {
+        result.current.handleFontSettingsChange(newFontSettings);
+      });
+
+      expect(result.current.draftDisplaySettings.fontSettings).toEqual(
+        newFontSettings
+      );
+      expect(result.current.isDirty).toBe(true);
+    });
+  });
+
+  describe('handleSelectPreset', () => {
+    it('プリセットを選択すると、表示設定を切り替え', async () => {
+      const anotherPreset: DashboardPreset = {
+        id: 'preset-2',
+        name: 'Relax Mode',
+        goalText: 'Take a Break',
+        goalSubText: 'Rest',
+        textColor: '#000000',
+        backgroundType: 'color',
+        backgroundImage: 'default-2',
+        backgroundColor: '#f0f0f0',
+        customBackgroundData: null,
+        fontSettings: DEFAULT_FONT_SETTINGS,
+        createdAt: '2024-01-02T00:00:00Z'
+      };
+
+      const visionWithMultiplePresets: VisionSettings = {
+        ...mockVision,
+        presets: [mockPreset, anotherPreset]
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithMultiplePresets);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithMultiplePresets,
+          setVision: mockSetVision
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleSelectPreset('preset-2');
+      });
+
+      expect(result.current.selectedPresetId).toBe('preset-2');
+      expect(result.current.editingPresetName).toBe('Relax Mode');
+      expect(result.current.draftDisplaySettings.goalText).toBe('Take a Break');
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('存在しないプリセットIDの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleSelectPreset('non-existent-id');
+      });
+
+      expect(result.current.selectedPresetId).toBe('preset-1');
+    });
+  });
+
+  describe('handleSaveSelectedPreset', () => {
+    it('選択中のプリセットを保存', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleGoalTextChange('Updated Goal');
+        result.current.handlePresetNameChange('Updated Name');
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSelectedPreset();
+      });
+
+      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      expect(savedVision.presets[0].name).toBe('Updated Name');
+      expect(savedVision.presets[0].goalText).toBe('Updated Goal');
+      expect(mockSetVision).toHaveBeenCalledWith(savedVision);
+      expect(result.current.isDirty).toBe(false);
+    });
+
+    it('selectedPresetIdがnullの場合、何もしない', async () => {
+      const visionWithoutPresets: VisionSettings = {
+        ...DEFAULT_VISION,
+        presets: []
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithoutPresets);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithoutPresets,
+          setVision: mockSetVision
+        })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBeNull();
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSelectedPreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('goalTextが空の場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handleGoalTextChange('   ');
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSelectedPreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('editingPresetNameが空の場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      await waitFor(() => {
+        expect(result.current.selectedPresetId).toBe('preset-1');
+      });
+
+      act(() => {
+        result.current.handlePresetNameChange('   ');
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSelectedPreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('保存後、visionSavedフラグが一時的にtrueになる', async () => {
+      vi.useFakeTimers();
+
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      act(() => {
+        result.current.handleGoalTextChange('Updated Goal');
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSelectedPreset();
+      });
+
+      expect(result.current.visionSaved).toBe(true);
+
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      await vi.waitFor(() => {
+        if (result.current.visionSaved !== false) {
+          throw new Error('Not updated');
+        }
+      });
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('handleApplyPreset', () => {
+    it('選択中のプリセットをアクティブに設定', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleApplyPreset();
+      });
+
+      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      expect(savedVision.activePresetId).toBe('preset-1');
+      expect(mockSetVision).toHaveBeenCalledWith(savedVision);
+      expect(trackFeatureUse).toHaveBeenCalledWith('preset_switch');
+    });
+
+    it('selectedPresetIdがnullの場合、何もしない', async () => {
+      const visionWithoutPresets: VisionSettings = {
+        ...DEFAULT_VISION,
+        presets: []
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithoutPresets);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithoutPresets,
+          setVision: mockSetVision
+        })
+      );
+
+      // 初期化が完了するまで待つ（非同期初期化がある）
+      await vi.waitFor(() => {
+        if (result.current.draftPresets.length !== 0) {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleApplyPreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('visionがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: undefined, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.draftPresets.length !== 0) {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleApplyPreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCreatePreset', () => {
+    it('新しいプリセットを作成', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      act(() => {
+        result.current.setShowSavePresetModal(true);
+        result.current.setPresetName('New Preset');
+      });
+
+      await act(async () => {
+        await result.current.handleCreatePreset();
+      });
+
+      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      expect(savedVision.presets).toHaveLength(2);
+      expect(savedVision.presets[1].id).toBe('new-preset-id');
+      expect(savedVision.presets[1].name).toBe('New Preset');
+      expect(mockSetVision).toHaveBeenCalledWith(savedVision);
+      expect(trackFeatureUse).toHaveBeenCalledWith('preset_create');
+      expect(result.current.showSavePresetModal).toBe(false);
+      expect(result.current.presetName).toBe('');
+      expect(result.current.selectedPresetId).toBe('new-preset-id');
+    });
+
+    it('プリセット名が空の場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      act(() => {
+        result.current.setPresetName('   ');
+      });
+
+      await act(async () => {
+        await result.current.handleCreatePreset();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleDeletePreset', () => {
+    it('プリセットを削除', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleDeletePreset('preset-1');
+      });
+
+      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      expect(savedVision.presets).toHaveLength(0);
+      expect(mockSetVision).toHaveBeenCalledWith(savedVision);
+      expect(result.current.selectedPresetId).toBeNull();
+      expect(result.current.draftDisplaySettings).toEqual(
+        DEFAULT_DISPLAY_SETTINGS
+      );
+    });
+
+    it('選択していないプリセットを削除しても、選択は変わらない', async () => {
+      const anotherPreset: DashboardPreset = {
+        id: 'preset-2',
+        name: 'Relax Mode',
+        goalText: 'Take a Break',
+        goalSubText: 'Rest',
+        textColor: '#000000',
+        backgroundType: 'color',
+        backgroundImage: 'default-2',
+        backgroundColor: '#f0f0f0',
+        customBackgroundData: null,
+        fontSettings: DEFAULT_FONT_SETTINGS,
+        createdAt: '2024-01-02T00:00:00Z'
+      };
+
+      const visionWithMultiplePresets: VisionSettings = {
+        ...mockVision,
+        presets: [mockPreset, anotherPreset]
+      };
+
+      vi.mocked(storage.get).mockResolvedValue(visionWithMultiplePresets);
+
+      const { result } = renderHook(() =>
+        usePresets({
+          vision: visionWithMultiplePresets,
+          setVision: mockSetVision
+        })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleDeletePreset('preset-2');
+      });
+
+      expect(result.current.selectedPresetId).toBe('preset-1');
+    });
+
+    it('activePresetIdを削除した場合、nullにリセット', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      await act(async () => {
+        await result.current.handleDeletePreset('preset-1');
+      });
+
+      const savedVision = vi.mocked(storage.set).mock.calls[0][1] as VisionSettings;
+      expect(savedVision.activePresetId).toBeNull();
+    });
+  });
+
+  describe('モーダル管理', () => {
+    it('setShowSavePresetModal でモーダルの表示状態を切り替え', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      expect(result.current.showSavePresetModal).toBe(false);
+
+      act(() => {
+        result.current.setShowSavePresetModal(true);
+      });
+
+      expect(result.current.showSavePresetModal).toBe(true);
+    });
+
+    it('setPresetName でプリセット名を設定', async () => {
+      const { result } = renderHook(() =>
+        usePresets({ vision: mockVision, setVision: mockSetVision })
+      );
+
+      // 初期化が完了するまで待つ
+      await vi.waitFor(() => {
+        if (result.current.selectedPresetId !== 'preset-1') {
+          throw new Error('Not ready');
+        }
+      });
+
+      expect(result.current.presetName).toBe('');
+
+      act(() => {
+        result.current.setPresetName('Test Name');
+      });
+
+      expect(result.current.presetName).toBe('Test Name');
+    });
+  });
+});

--- a/src/hooks/__tests__/usePresets.test.ts
+++ b/src/hooks/__tests__/usePresets.test.ts
@@ -68,7 +68,7 @@ describe('usePresets', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(storage.get).mockResolvedValue(mockVision);
-    vi.mocked(storage.set).mockResolvedValue();
+    vi.mocked(storage.set).mockResolvedValue(undefined);
     // crypto.randomUUID のモック
     vi.stubGlobal('crypto', {
       ...global.crypto,
@@ -268,7 +268,7 @@ describe('usePresets', () => {
 
       const newFontSettings = {
         ...DEFAULT_FONT_SETTINGS,
-        family: 'Inter' as const
+        family: 'inter' as const
       };
 
       act(() => {

--- a/src/hooks/__tests__/usePresets.test.ts
+++ b/src/hooks/__tests__/usePresets.test.ts
@@ -4,8 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { usePresets } from '~/hooks/usePresets';
 import type {
   VisionSettings,
-  DashboardPreset,
-  DashboardDisplaySettings
+  DashboardPreset
 } from '~/types/storage';
 import {
   DEFAULT_VISION,

--- a/src/hooks/__tests__/useSchedules.test.ts
+++ b/src/hooks/__tests__/useSchedules.test.ts
@@ -17,9 +17,7 @@ vi.mock('~/lib/storage', () => ({
 }));
 
 vi.mock('~/lib/time', () => ({
-  normalizeEndTime: vi.fn((time: string) =>
-    time === '00:00' ? '24:00' : time
-  )
+  normalizeEndTime: vi.fn((time: string) => (time === '00:00' ? '24:00' : time))
 }));
 
 import { trackFeatureUse } from '~/lib/analytics';
@@ -281,7 +279,8 @@ describe('useSchedules', () => {
         await result.current.handleSaveSchedule();
       });
 
-      const savedSchedule = vi.mocked(storage.set).mock.calls[0][1] as AppSettings;
+      const savedSchedule = vi.mocked(storage.set).mock
+        .calls[0][1] as AppSettings;
       expect(savedSchedule.schedules[1].presetId).toBeUndefined();
     });
 
@@ -347,7 +346,8 @@ describe('useSchedules', () => {
         await result.current.handleSaveSchedule();
       });
 
-      const savedSchedule = vi.mocked(storage.set).mock.calls[0][1] as AppSettings;
+      const savedSchedule = vi.mocked(storage.set).mock
+        .calls[0][1] as AppSettings;
       expect(savedSchedule.schedules[1].endTime).toBe('24:00');
     });
   });

--- a/src/hooks/__tests__/useSchedules.test.ts
+++ b/src/hooks/__tests__/useSchedules.test.ts
@@ -1,0 +1,493 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useSchedules, type ScheduleFormData } from '~/hooks/useSchedules';
+import type { AppSettings, Schedule } from '~/types/storage';
+import { DEFAULT_SETTINGS } from '~/types/storage';
+
+// Mock dependencies
+vi.mock('~/lib/analytics', () => ({
+  trackFeatureUse: vi.fn()
+}));
+
+vi.mock('~/lib/storage', () => ({
+  storage: {
+    set: vi.fn()
+  }
+}));
+
+vi.mock('~/lib/time', () => ({
+  normalizeEndTime: vi.fn((time: string) =>
+    time === '00:00' ? '24:00' : time
+  )
+}));
+
+import { trackFeatureUse } from '~/lib/analytics';
+import { storage } from '~/lib/storage';
+
+describe('useSchedules', () => {
+  const mockSetSettings = vi.fn();
+
+  const mockSchedule: Schedule = {
+    id: 'schedule-1',
+    name: 'Work Hours',
+    startTime: '09:00',
+    endTime: '17:00',
+    days: [1, 2, 3, 4, 5],
+    enabled: true,
+    presetId: 'preset-1'
+  };
+
+  const mockSettings: AppSettings = {
+    ...DEFAULT_SETTINGS,
+    schedules: [mockSchedule]
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('初期状態', () => {
+    it('初期状態でモーダルが非表示', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+      expect(result.current.showScheduleModal).toBe(false);
+    });
+
+    it('初期状態で編集中のスケジュールがnull', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+      expect(result.current.editingSchedule).toBeNull();
+    });
+
+    it('初期状態でフォームがデフォルト値', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      expect(result.current.scheduleForm).toEqual({
+        name: '',
+        startTime: '09:00',
+        endTime: '17:00',
+        days: [1, 2, 3, 4, 5],
+        presetId: ''
+      });
+    });
+  });
+
+  describe('setShowScheduleModal', () => {
+    it('モーダルの表示状態を更新できる', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setShowScheduleModal(true);
+      });
+
+      expect(result.current.showScheduleModal).toBe(true);
+    });
+  });
+
+  describe('setScheduleForm', () => {
+    it('フォームを更新できる', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      const newForm: ScheduleFormData = {
+        name: 'Evening',
+        startTime: '18:00',
+        endTime: '22:00',
+        days: [0, 6],
+        presetId: 'preset-2'
+      };
+
+      act(() => {
+        result.current.setScheduleForm(newForm);
+      });
+
+      expect(result.current.scheduleForm).toEqual(newForm);
+    });
+  });
+
+  describe('openAddSchedule', () => {
+    it('新規作成モードでモーダルを開く', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openAddSchedule();
+      });
+
+      expect(result.current.showScheduleModal).toBe(true);
+      expect(result.current.editingSchedule).toBeNull();
+      expect(result.current.scheduleForm).toEqual({
+        name: '',
+        startTime: '09:00',
+        endTime: '17:00',
+        days: [1, 2, 3, 4, 5],
+        presetId: ''
+      });
+    });
+  });
+
+  describe('openEditSchedule', () => {
+    it('編集モードでモーダルを開く', () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openEditSchedule(mockSchedule);
+      });
+
+      expect(result.current.showScheduleModal).toBe(true);
+      expect(result.current.editingSchedule).toEqual(mockSchedule);
+      expect(result.current.scheduleForm).toEqual({
+        name: 'Work Hours',
+        startTime: '09:00',
+        endTime: '17:00',
+        days: [1, 2, 3, 4, 5],
+        presetId: 'preset-1'
+      });
+    });
+
+    it('presetIdがundefinedの場合、空文字に変換', () => {
+      const scheduleWithoutPreset: Schedule = {
+        ...mockSchedule,
+        presetId: undefined
+      };
+
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openEditSchedule(scheduleWithoutPreset);
+      });
+
+      expect(result.current.scheduleForm.presetId).toBe('');
+    });
+  });
+
+  describe('handleSaveSchedule', () => {
+    beforeEach(() => {
+      vi.mocked(storage.set).mockResolvedValue();
+      // crypto.randomUUID のモック
+      vi.stubGlobal('crypto', {
+        ...global.crypto,
+        randomUUID: vi.fn(() => 'new-schedule-id')
+      });
+    });
+
+    it('settingsがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: undefined, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('名前が空の場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.setScheduleForm({
+          name: '   ',
+          startTime: '09:00',
+          endTime: '17:00',
+          days: [1, 2, 3, 4, 5],
+          presetId: ''
+        });
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('新規作成時、スケジュールを追加', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openAddSchedule();
+        result.current.setScheduleForm({
+          name: 'Evening',
+          startTime: '18:00',
+          endTime: '22:00',
+          days: [0, 6],
+          presetId: 'preset-2'
+        });
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        schedules: [
+          mockSchedule,
+          {
+            id: 'new-schedule-id',
+            name: 'Evening',
+            startTime: '18:00',
+            endTime: '22:00',
+            days: [0, 6],
+            enabled: true,
+            presetId: 'preset-2'
+          }
+        ]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+      expect(trackFeatureUse).toHaveBeenCalledWith('schedule_create');
+      expect(result.current.showScheduleModal).toBe(false);
+      expect(result.current.editingSchedule).toBeNull();
+    });
+
+    it('新規作成時、presetIdが空の場合はundefinedに変換', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openAddSchedule();
+        result.current.setScheduleForm({
+          name: 'Evening',
+          startTime: '18:00',
+          endTime: '22:00',
+          days: [0, 6],
+          presetId: ''
+        });
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      const savedSchedule = vi.mocked(storage.set).mock.calls[0][1] as AppSettings;
+      expect(savedSchedule.schedules[1].presetId).toBeUndefined();
+    });
+
+    it('編集時、既存のスケジュールを更新', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openEditSchedule(mockSchedule);
+        result.current.setScheduleForm({
+          name: 'Updated Work Hours',
+          startTime: '08:00',
+          endTime: '18:00',
+          days: [1, 2, 3, 4, 5],
+          presetId: 'preset-1'
+        });
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        schedules: [
+          {
+            id: 'schedule-1',
+            name: 'Updated Work Hours',
+            startTime: '08:00',
+            endTime: '18:00', // normalizeEndTime は '18:00' をそのまま返す
+            days: [1, 2, 3, 4, 5],
+            enabled: true,
+            presetId: 'preset-1'
+          }
+        ]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+      expect(trackFeatureUse).not.toHaveBeenCalled(); // 編集時は呼ばれない
+      expect(result.current.showScheduleModal).toBe(false);
+      expect(result.current.editingSchedule).toBeNull();
+    });
+
+    it('endTimeが00:00の場合、24:00に正規化される', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      act(() => {
+        result.current.openAddSchedule();
+        result.current.setScheduleForm({
+          name: 'All Day',
+          startTime: '00:00',
+          endTime: '00:00',
+          days: [0, 1, 2, 3, 4, 5, 6],
+          presetId: ''
+        });
+      });
+
+      await act(async () => {
+        await result.current.handleSaveSchedule();
+      });
+
+      const savedSchedule = vi.mocked(storage.set).mock.calls[0][1] as AppSettings;
+      expect(savedSchedule.schedules[1].endTime).toBe('24:00');
+    });
+  });
+
+  describe('handleDeleteSchedule', () => {
+    beforeEach(() => {
+      vi.mocked(storage.set).mockResolvedValue();
+    });
+
+    it('settingsがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: undefined, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleDeleteSchedule('schedule-1');
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('指定したIDのスケジュールを削除', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleDeleteSchedule('schedule-1');
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        schedules: []
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+    });
+
+    it('存在しないIDの場合、何も削除しない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleDeleteSchedule('non-existent-id');
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        schedules: [mockSchedule]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+    });
+  });
+
+  describe('handleToggleSchedule', () => {
+    beforeEach(() => {
+      vi.mocked(storage.set).mockResolvedValue();
+    });
+
+    it('settingsがundefinedの場合、何もしない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: undefined, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleToggleSchedule('schedule-1', false);
+      });
+
+      expect(storage.set).not.toHaveBeenCalled();
+    });
+
+    it('スケジュールのenabledを切り替え', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleToggleSchedule('schedule-1', false);
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        paused: false, // enabled=false の場合は paused に影響しない
+        schedules: [{ ...mockSchedule, enabled: false }]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+      expect(trackFeatureUse).toHaveBeenCalledWith('schedule_toggle');
+    });
+
+    it('スケジュールを有効化すると、pausedもfalseになる', async () => {
+      const pausedSettings: AppSettings = {
+        ...mockSettings,
+        paused: true,
+        schedules: [{ ...mockSchedule, enabled: false }]
+      };
+
+      const { result } = renderHook(() =>
+        useSchedules({
+          settings: pausedSettings,
+          setSettings: mockSetSettings
+        })
+      );
+
+      await act(async () => {
+        await result.current.handleToggleSchedule('schedule-1', true);
+      });
+
+      const expectedSettings = {
+        ...pausedSettings,
+        paused: false, // enabled=true の場合は paused が false になる
+        schedules: [{ ...mockSchedule, enabled: true }]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+    });
+
+    it('存在しないIDの場合、何も変更しない', async () => {
+      const { result } = renderHook(() =>
+        useSchedules({ settings: mockSettings, setSettings: mockSetSettings })
+      );
+
+      await act(async () => {
+        await result.current.handleToggleSchedule('non-existent-id', false);
+      });
+
+      const expectedSettings = {
+        ...mockSettings,
+        paused: false,
+        schedules: [mockSchedule]
+      };
+
+      expect(storage.set).toHaveBeenCalledWith('settings', expectedSettings);
+      expect(mockSetSettings).toHaveBeenCalledWith(expectedSettings);
+    });
+  });
+});

--- a/src/hooks/__tests__/useSchedules.test.ts
+++ b/src/hooks/__tests__/useSchedules.test.ts
@@ -174,7 +174,7 @@ describe('useSchedules', () => {
 
   describe('handleSaveSchedule', () => {
     beforeEach(() => {
-      vi.mocked(storage.set).mockResolvedValue();
+      vi.mocked(storage.set).mockResolvedValue(undefined);
       // crypto.randomUUID のモック
       vi.stubGlobal('crypto', {
         ...global.crypto,
@@ -354,7 +354,7 @@ describe('useSchedules', () => {
 
   describe('handleDeleteSchedule', () => {
     beforeEach(() => {
-      vi.mocked(storage.set).mockResolvedValue();
+      vi.mocked(storage.set).mockResolvedValue(undefined);
     });
 
     it('settingsがundefinedの場合、何もしない', async () => {
@@ -408,7 +408,7 @@ describe('useSchedules', () => {
 
   describe('handleToggleSchedule', () => {
     beforeEach(() => {
-      vi.mocked(storage.set).mockResolvedValue();
+      vi.mocked(storage.set).mockResolvedValue(undefined);
     });
 
     it('settingsがundefinedの場合、何もしない', async () => {


### PR DESCRIPTION
## Summary
- Issue #20 の Part 3/3 — カスタムフックの単体テスト作成
- 対象モジュール: `useBlocklist`, `useSchedules`, `usePresets`
- 合計 68 テスト、全て pass

## 作成したテスト

### useBlocklist.test.ts (19 tests)
- 初期状態の検証
- ドメイン追加処理（ライセンス制限、バリデーション、重複チェック、背景スクリプト連携）
- ドメイン削除・トグル処理
- タイムリミット更新
- 通知設定更新

### useSchedules.test.ts (21 tests)
- 初期状態の検証
- スケジュール作成・編集（新規作成、既存更新、時刻正規化）
- スケジュール削除
- スケジュールトグル（paused 連動）
- モーダル管理（開閉、フォーム管理）

### usePresets.test.ts (28 tests)
- 初期化（プリセット選択、デフォルト設定フォールバック）
- 表示設定更新（ゴールテキスト、色、背景、フォント）
- プリセット選択・保存・適用
- プリセット作成・削除
- モーダル管理
- 状態フィードバック（visionSaved フラグ）

## テスト戦略
- Chrome API（`chrome.storage`、`sendToBackground`）のモック
- 外部ライブラリ（`@plasmohq/storage`、`@plasmohq/messaging`）のモック
- ヘルパー関数（`analytics`, `license`, `domain`, `time`, `presetUtils`）のモック
- React Hooks テストには `renderHook`, `act`, `waitFor` を使用
- 非同期初期化の待機処理（`vi.waitFor`）

## 技術的ポイント
- `crypto.randomUUID` のモックは `vi.stubGlobal` を使用（`global.crypto` への直接代入は不可）
- `usePresets` の useEffect による非同期初期化に対応
- `normalizeEndTime` のモック実装で時刻変換をシミュレート

## 完了条件
- ✅ 全テスト pass
- ✅ カバレッジ 70% 以上達成

Part of #20