### PR TITLE
test: E2E functional tests (Block/TL/YT/AN/i18n/Data/PR/INT) (#22-D)

### DIFF
--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -1,0 +1,470 @@
+import { test, expect } from './fixtures/extension';
+import { openOptions, openExternalSite } from './helpers/pages';
+import {
+  setStorageData,
+  clearStorage,
+  getStorageData
+} from './helpers/storage';
+import { TEST_DOMAINS } from './helpers/constants';
+
+/**
+ * E2E Tests: アナリティクス機能
+ *
+ * サイト別ブロック回数、Unblock History、Heartbeat、Opt-In/Opt-Outをテスト
+ */
+
+test.describe('Analytics - アナリティクス機能', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('AN-001: サイト別ブロック回数が記録される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロック対象サイトに3回アクセス
+    for (let i = 0; i < 3; i++) {
+      const blockedPage = await openExternalSite(
+        context,
+        `https://${TEST_DOMAINS.example}`
+      );
+      await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+      await blockedPage.close();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+
+    // Analytics データを確認
+    const page2 = await context.newPage();
+    const analytics = (await getStorageData(page2, 'analytics')) as any;
+
+    expect(analytics.siteStats[TEST_DOMAINS.example]).toBeDefined();
+    expect(
+      analytics.siteStats[TEST_DOMAINS.example].blockCount
+    ).toBeGreaterThanOrEqual(3);
+
+    await page2.close();
+  });
+
+  test('AN-002: Unblock History（ブロック解除サイト）が記録される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    await setStorageData(page, 'unblockHistory', {
+      entries: []
+    });
+
+    await page.close();
+
+    // Options ページでブロックを一時解除
+    const optionsPage = await openOptions(context, extensionId, 'blocklist');
+    await optionsPage.waitForLoadState('domcontentloaded');
+
+    // ブロック解除ボタンをクリック（実装に応じてセレクタを調整）
+    const unblockButton = optionsPage
+      .locator('button:has-text("Unblock"), button:has-text("解除")')
+      .first();
+    if (await unblockButton.isVisible()) {
+      await unblockButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+
+    // Unblock History を確認
+    const unblockHistory = (await getStorageData(
+      optionsPage,
+      'unblockHistory'
+    )) as any;
+    expect(unblockHistory.entries.length).toBeGreaterThan(0);
+
+    await optionsPage.close();
+  });
+
+  test('AN-003: 解除サイトの滞在時間が 30 秒間隔の Heartbeat で記録', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    // 解除サイトにアクセス（ブロックリストに含まれていないサイト）
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.reddit}`
+    );
+
+    await externalPage.waitForLoadState('domcontentloaded');
+
+    // 30秒間待機してHeartbeatが送信されるのを待つ（テストでは短縮）
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // トラッキングデータを確認
+    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+
+    // Heartbeatが記録されていることを確認（時間は短いが記録されている）
+    if (analytics.siteStats[TEST_DOMAINS.reddit]) {
+      expect(
+        analytics.siteStats[TEST_DOMAINS.reddit].totalTime
+      ).toBeGreaterThan(0);
+    }
+
+    await externalPage.close();
+  });
+
+  test('AN-004: トラッキング中サイトの滞在時間が記録される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    // 外部サイトにアクセス
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await externalPage.waitForLoadState('domcontentloaded');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Analytics データを確認
+    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+
+    // dailyStats に記録があることを確認
+    const today = new Date().toISOString().slice(0, 10);
+    if (analytics.dailyStats[today]) {
+      expect(analytics.dailyStats[today]).toBeDefined();
+    }
+
+    await externalPage.close();
+  });
+
+  test('AN-005: Analytics Opt-In モーダルで許可/拒否を選択できる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Opt-In が未決定の状態
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: null
+    });
+
+    await page.close();
+
+    // Options ページを開く
+    const optionsPage = await openOptions(context, extensionId, 'analytics');
+
+    // Opt-In モーダルが表示されることを確認
+    const modal = optionsPage.locator('[role="dialog"], .modal');
+    await modal.waitFor({ state: 'visible', timeout: 3000 });
+
+    // 許可ボタンをクリック
+    const allowButton = modal.locator(
+      'button:has-text("Allow"), button:has-text("許可")'
+    );
+    await allowButton.click();
+
+    // 設定が保存されたことを確認
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const settings = (await getStorageData(optionsPage, 'settings')) as any;
+    expect(settings.analyticsOptIn).toBeDefined();
+    expect(settings.analyticsOptIn.enabled).toBe(true);
+
+    await optionsPage.close();
+  });
+
+  test('AN-006: Opt-Out した場合、トラッキングが無効化される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Opt-Out 状態
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
+    });
+
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    // 外部サイトにアクセス
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await externalPage.waitForLoadState('domcontentloaded');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Analytics データが記録されていないことを確認
+    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+    expect(Object.keys(analytics.dailyStats).length).toBe(0);
+
+    await externalPage.close();
+  });
+
+  test('AN-007: Analytics データをリセットできる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    // Analytics データを設定
+    await setStorageData(page, 'analytics', {
+      dailyStats: {
+        '2024-01-01': {
+          date: '2024-01-01',
+          wasteTime: 300,
+          investTime: 0,
+          blockCount: 10,
+          unblockCount: 0
+        }
+      },
+      siteStats: {
+        [TEST_DOMAINS.example]: {
+          domain: TEST_DOMAINS.example,
+          blockCount: 5,
+          unblockCount: 0,
+          totalTime: 200
+        }
+      }
+    });
+
+    await page.close();
+
+    // Options ページを開く
+    const optionsPage = await openOptions(context, extensionId, 'analytics');
+
+    // リセットボタンをクリック
+    const resetButton = optionsPage.locator(
+      'button:has-text("Reset"), button:has-text("リセット")'
+    );
+    if (await resetButton.isVisible()) {
+      await resetButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Analytics データがリセットされたことを確認
+      const analytics = (await getStorageData(optionsPage, 'analytics')) as any;
+      expect(Object.keys(analytics.dailyStats).length).toBe(0);
+      expect(Object.keys(analytics.siteStats).length).toBe(0);
+    }
+
+    await optionsPage.close();
+  });
+
+  test('AN-008: ネットワーク切断時に Heartbeat がローカルキューに保存', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    await page.close();
+
+    // オフラインモードに設定
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+    await context.setOffline(true);
+
+    await externalPage.waitForLoadState('domcontentloaded');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ローカルキューに保存されているか確認（実装に応じて調整）
+    const queueData = await externalPage.evaluate(async () => {
+      const result = await chrome.storage.local.get('heartbeatQueue');
+      return result.heartbeatQueue;
+    });
+
+    // キューが存在する場合は記録されていることを確認
+    if (queueData) {
+      expect(Array.isArray(queueData)).toBeTruthy();
+    }
+
+    await context.setOffline(false);
+    await externalPage.close();
+  });
+
+  test('AN-009: ネットワーク復旧時にキューされた Heartbeat が送信', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    // ダミーのキューデータを設定
+    await setStorageData(page, 'heartbeatQueue', [
+      {
+        domain: TEST_DOMAINS.example,
+        duration: 30,
+        timestamp: new Date().toISOString()
+      }
+    ]);
+
+    await page.close();
+
+    // ネットワークオンラインに復旧
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+    await context.setOffline(false);
+
+    await externalPage.waitForLoadState('domcontentloaded');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // キューが送信されてクリアされたことを確認
+    const queueData = await externalPage.evaluate(async () => {
+      const result = await chrome.storage.local.get('heartbeatQueue');
+      return result.heartbeatQueue;
+    });
+
+    // キューが空になっている、またはundefined
+    expect(queueData?.length || 0).toBe(0);
+
+    await externalPage.close();
+  });
+
+  test('AN-010: Opt-Out 時に Unblock History も無効化される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Opt-Out 状態
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() },
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    await setStorageData(page, 'unblockHistory', {
+      entries: []
+    });
+
+    await page.close();
+
+    // Options ページでブロック解除を試みる
+    const optionsPage = await openOptions(context, extensionId, 'blocklist');
+    await optionsPage.waitForLoadState('domcontentloaded');
+
+    const unblockButton = optionsPage
+      .locator('button:has-text("Unblock"), button:has-text("解除")')
+      .first();
+    if (await unblockButton.isVisible()) {
+      await unblockButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
+
+    // Unblock History に記録されないことを確認
+    const unblockHistory = (await getStorageData(
+      optionsPage,
+      'unblockHistory'
+    )) as any;
+    expect(unblockHistory.entries.length).toBe(0);
+
+    await optionsPage.close();
+  });
+});

--- a/tests/e2e/block.spec.ts
+++ b/tests/e2e/block.spec.ts
@@ -1,0 +1,480 @@
+import { test, expect } from './fixtures/extension';
+import { openNewTab, openOptions, openExternalSite } from './helpers/pages';
+import { setStorageData, clearStorage } from './helpers/storage';
+import { TEST_DOMAINS, SELECTORS } from './helpers/constants';
+
+/**
+ * E2E Tests: サイトブロック機能
+ *
+ * ブロックリストへの追加・削除、Pauseトグル、declarativeNetRequestによるリダイレクトをテスト
+ */
+
+test.describe('Block - ブロック機能', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('BLOCK-001: ブロックリストに追加したサイトが newtab.html にリダイレクト', async ({
+    context,
+    extensionId
+  }) => {
+    // ブロックリストにexample.comを追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    // ブロックルールが適用されるまで待機
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロック対象サイトにアクセス
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    // newtab.html にリダイレクトされることを確認
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    await blockedPage.close();
+  });
+
+  test('BLOCK-002: ワイルドカードで指定したサブドメインがブロックされる', async ({
+    context,
+    extensionId
+  }) => {
+    // ワイルドカードでブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: `*.${TEST_DOMAINS.example}`,
+          isWildcard: true,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サブドメインにアクセス
+    const blockedPage = await openExternalSite(
+      context,
+      `https://sub.${TEST_DOMAINS.example}`
+    );
+
+    // newtab.html にリダイレクトされることを確認
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    await blockedPage.close();
+  });
+
+  test('BLOCK-003: ブロックリストから削除したサイトにアクセスできる', async ({
+    context,
+    extensionId
+  }) => {
+    // 最初はブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロックリストから削除
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: []
+    });
+    await page2.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセスできることを確認
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    // newtab.html にリダイレクトされないことを確認
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+
+    await unblockedPage.close();
+  });
+
+  test('BLOCK-004: Pause トグルで全ブロックが一時停止される', async ({
+    context,
+    extensionId
+  }) => {
+    // ブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Pauseを有効化
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'settings', {
+      language: 'en',
+      paused: true,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page2.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセスできることを確認
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+
+    await unblockedPage.close();
+  });
+
+  test('BLOCK-005: Pause 解除後、通常のブロック動作に戻る', async ({
+    context,
+    extensionId
+  }) => {
+    // Pauseを有効化した状態で開始
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: true,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Pauseを解除
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page2.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロックされることを確認
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    await blockedPage.close();
+  });
+
+  test('BLOCK-006: 無効化したブロックアイテムはブロックされない', async ({
+    context,
+    extensionId
+  }) => {
+    // enabled: false でブロックアイテムを追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: false // 無効化
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセスできることを確認
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+
+    await unblockedPage.close();
+  });
+
+  test('BLOCK-007: 有効化したブロックアイテムがブロックされる', async ({
+    context,
+    extensionId
+  }) => {
+    // 最初は無効化
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: false
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // 有効化
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true // 有効化
+        }
+      ]
+    });
+    await page2.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロックされることを確認
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    await blockedPage.close();
+  });
+
+  test('BLOCK-008: declarativeNetRequest でリダイレクトが実行される', async ({
+    context,
+    extensionId
+  }) => {
+    // ブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // declarativeNetRequest ルールを確認
+    const rulesPage = await context.newPage();
+    const rules = await rulesPage.evaluate(async () => {
+      return chrome.declarativeNetRequest.getDynamicRules();
+    });
+
+    // ルールが存在することを確認
+    expect(rules.length).toBeGreaterThan(0);
+    expect(rules[0].action.type).toBe('redirect');
+    expect(rules[0].action.redirect?.extensionPath).toBe('/newtab.html');
+
+    await rulesPage.close();
+  });
+
+  test('BLOCK-009: ブロック時に lastBlockedDomain がポップアップ用に記録される', async ({
+    context,
+    extensionId
+  }) => {
+    // ブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロック対象サイトにアクセス
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+
+    // lastBlockedDomain が記録されたことを確認
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const lastBlocked = await blockedPage.evaluate(async () => {
+      const result = await chrome.storage.local.get('lastBlockedDomain');
+      return result.lastBlockedDomain;
+    });
+
+    expect(lastBlocked).toBe(TEST_DOMAINS.example);
+
+    await blockedPage.close();
+  });
+
+  test('BLOCK-010: ブロック回数がカウントされる', async ({
+    context,
+    extensionId
+  }) => {
+    // ブロックリストに追加
+    const page = await context.newPage();
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    // Analytics データ初期化
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロック対象サイトに2回アクセス
+    const blockedPage1 = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+    await blockedPage1.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    await blockedPage1.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const blockedPage2 = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+    await blockedPage2.waitForURL(`**newtab.html**`, { timeout: 5000 });
+
+    // ブロック回数を確認
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    const analytics = await blockedPage2.evaluate(async () => {
+      const result = await chrome.storage.local.get('analytics');
+      return result.analytics;
+    });
+
+    const today = new Date().toISOString().slice(0, 10);
+    expect(analytics.dailyStats[today].blockCount).toBeGreaterThanOrEqual(2);
+    expect(
+      analytics.siteStats[TEST_DOMAINS.example].blockCount
+    ).toBeGreaterThanOrEqual(2);
+
+    await blockedPage2.close();
+  });
+});

--- a/tests/e2e/data.spec.ts
+++ b/tests/e2e/data.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect } from './fixtures/extension';
+import { openPopup, openOptions } from './helpers/pages';
+import {
+  setStorageData,
+  getStorageData,
+  clearStorage
+} from './helpers/storage';
+import { TEST_DOMAINS } from './helpers/constants';
+
+/**
+ * E2E Tests: データ永続化
+ *
+ * chrome.storage.local への保存、ブラウザ再起動後の保持、プリセット・スケジュールの保存をテスト
+ */
+
+test.describe('Data - データ永続化', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('DATA-001: 設定が chrome.storage.local に保存される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 設定を保存
+    await setStorageData(page, 'settings', {
+      language: 'ja',
+      paused: true,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    // 保存された設定を取得
+    const savedSettings = (await getStorageData(page, 'settings')) as any;
+
+    expect(savedSettings.language).toBe('ja');
+    expect(savedSettings.paused).toBe(true);
+    expect(savedSettings.blockList.length).toBe(1);
+    expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.example);
+
+    await page.close();
+  });
+
+  test('DATA-002: ブラウザ再起動後も設定が保持される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 設定を保存
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.reddit,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    await page.close();
+
+    // 新しいページを開いて設定を取得（ブラウザ再起動をシミュレート）
+    const page2 = await context.newPage();
+    const savedSettings = (await getStorageData(page2, 'settings')) as any;
+
+    expect(savedSettings.language).toBe('en');
+    expect(savedSettings.paused).toBe(false);
+    expect(savedSettings.blockList.length).toBe(1);
+    expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.reddit);
+
+    await page2.close();
+  });
+
+  test('DATA-003: 拡張機能を無効化→有効化しても設定が保持される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 設定を保存
+    await setStorageData(page, 'settings', {
+      language: 'ja',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.twitter,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    // 保存された設定を確認
+    const savedSettings = (await getStorageData(page, 'settings')) as any;
+
+    expect(savedSettings.blockList.length).toBe(1);
+    expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.twitter);
+
+    // 実際の無効化/有効化は Playwright では困難なため、
+    // chrome.storage.local が永続的であることを確認
+    await page.close();
+
+    // 新しいページで設定が保持されていることを確認
+    const page2 = await context.newPage();
+    const persistedSettings = (await getStorageData(page2, 'settings')) as any;
+
+    expect(persistedSettings.blockList.length).toBe(1);
+    expect(persistedSettings.blockList[0].domain).toBe(TEST_DOMAINS.twitter);
+
+    await page2.close();
+  });
+
+  test('DATA-004: プリセット（Vision）が正しく保存される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Vision プリセットを保存
+    await setStorageData(page, 'vision', {
+      defaultSettings: {
+        goalText: 'Focus on what matters',
+        subText: 'Stay productive'
+      },
+      presets: [
+        {
+          id: 'default',
+          name: 'Default',
+          goalText: 'Focus on what matters',
+          subText: 'Stay productive',
+          textColor: '#ffffff',
+          backgroundColor: '#1a1a2e',
+          backgroundType: 'color'
+        },
+        {
+          id: 'custom1',
+          name: 'Custom Preset',
+          goalText: 'Custom Goal',
+          subText: 'Custom Sub',
+          textColor: '#000000',
+          backgroundColor: '#ffffff',
+          backgroundType: 'color'
+        }
+      ],
+      activePresetId: 'custom1'
+    });
+
+    // 保存された Vision を取得
+    const savedVision = (await getStorageData(page, 'vision')) as any;
+
+    expect(savedVision.presets.length).toBe(2);
+    expect(savedVision.activePresetId).toBe('custom1');
+    expect(savedVision.presets[1].name).toBe('Custom Preset');
+
+    await page.close();
+  });
+
+  test('DATA-005: スケジュールが正しく保存される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // スケジュール設定を保存
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      schedules: [
+        {
+          id: 'schedule1',
+          name: 'Work Hours',
+          enabled: true,
+          days: [1, 2, 3, 4, 5], // Mon-Fri
+          startTime: '09:00',
+          endTime: '17:00',
+          action: 'enable'
+        },
+        {
+          id: 'schedule2',
+          name: 'Weekend',
+          enabled: true,
+          days: [0, 6], // Sat-Sun
+          startTime: '00:00',
+          endTime: '23:59',
+          action: 'disable'
+        }
+      ]
+    });
+
+    // 保存されたスケジュールを取得
+    const savedSettings = (await getStorageData(page, 'settings')) as any;
+
+    expect(savedSettings.schedules.length).toBe(2);
+    expect(savedSettings.schedules[0].name).toBe('Work Hours');
+    expect(savedSettings.schedules[1].days).toEqual([0, 6]);
+
+    await page.close();
+  });
+
+  test('DATA-006: Analytics データが正しく保存される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    const today = new Date().toISOString().slice(0, 10);
+
+    // Analytics データを保存
+    await setStorageData(page, 'analytics', {
+      dailyStats: {
+        [today]: {
+          date: today,
+          wasteTime: 300,
+          investTime: 120,
+          blockCount: 15,
+          unblockCount: 3
+        }
+      },
+      siteStats: {
+        [TEST_DOMAINS.example]: {
+          domain: TEST_DOMAINS.example,
+          blockCount: 10,
+          unblockCount: 2,
+          totalTime: 200
+        },
+        [TEST_DOMAINS.reddit]: {
+          domain: TEST_DOMAINS.reddit,
+          blockCount: 5,
+          unblockCount: 1,
+          totalTime: 100
+        }
+      }
+    });
+
+    // 保存された Analytics を取得
+    const savedAnalytics = (await getStorageData(page, 'analytics')) as any;
+
+    expect(savedAnalytics.dailyStats[today]).toBeDefined();
+    expect(savedAnalytics.dailyStats[today].blockCount).toBe(15);
+    expect(savedAnalytics.siteStats[TEST_DOMAINS.example].blockCount).toBe(10);
+    expect(Object.keys(savedAnalytics.siteStats).length).toBe(2);
+
+    await page.close();
+  });
+});

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from './fixtures/extension';
+import { openPopup, openNewTab, openOptions } from './helpers/pages';
+import { setStorageData, clearStorage } from './helpers/storage';
+
+/**
+ * E2E Tests: 多言語対応
+ *
+ * ブラウザ言語の自動検出、言語切り替え、全画面での統一をテスト
+ */
+
+test.describe('i18n - 多言語対応', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('I18N-001: ブラウザ言語が英語の場合、英語UIが表示される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 英語に設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Popup を開く
+    const popupPage = await openPopup(context, extensionId);
+
+    // 英語のテキストが表示されることを確認
+    const englishText = await popupPage
+      .locator("text=/Block Websites|Today's Goal/i")
+      .first()
+      .isVisible();
+    expect(englishText).toBeTruthy();
+
+    await popupPage.close();
+  });
+
+  test('I18N-002: ブラウザ言語が日本語の場合、日本語UIが表示される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 日本語に設定
+    await setStorageData(page, 'settings', {
+      language: 'ja',
+      paused: false
+    });
+
+    await page.close();
+
+    // Popup を開く
+    const popupPage = await openPopup(context, extensionId);
+
+    // 日本語のテキストが表示されることを確認
+    const japaneseText = await popupPage
+      .locator('text=/ウェブサイトをブロック|今日の目標/i')
+      .first()
+      .isVisible();
+    expect(japaneseText).toBeTruthy();
+
+    await popupPage.close();
+  });
+
+  test('I18N-003: ポップアップで言語を切り替えできる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 最初は英語
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Popup を開く
+    const popupPage = await openPopup(context, extensionId);
+
+    // 英語のテキストが表示されることを確認
+    let englishText = await popupPage
+      .locator('text=/Block Websites/i')
+      .first()
+      .isVisible();
+    expect(englishText).toBeTruthy();
+
+    // 言語セレクタを探す
+    const languageSelector = popupPage.locator('select');
+    if (await languageSelector.isVisible()) {
+      await languageSelector.selectOption('ja');
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // 日本語に変更されたことを確認
+      const japaneseText = await popupPage
+        .locator('text=/ウェブサイトをブロック/i')
+        .first()
+        .isVisible();
+      expect(japaneseText).toBeTruthy();
+    }
+
+    await popupPage.close();
+  });
+
+  test('I18N-004: 言語設定が全画面で統一されている', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 日本語に設定
+    await setStorageData(page, 'settings', {
+      language: 'ja',
+      paused: false
+    });
+
+    await page.close();
+
+    // Popup を開く
+    const popupPage = await openPopup(context, extensionId);
+    const popupJapanese = await popupPage
+      .locator('text=/ウェブサイトをブロック/i')
+      .first()
+      .isVisible();
+    expect(popupJapanese).toBeTruthy();
+    await popupPage.close();
+
+    // New Tab を開く
+    const newtabPage = await openNewTab(context, extensionId);
+    const newtabJapanese = await newtabPage
+      .locator('text=/今日の目標|集中/i')
+      .first()
+      .isVisible();
+    expect(newtabJapanese).toBeTruthy();
+    await newtabPage.close();
+
+    // Options を開く
+    const optionsPage = await openOptions(context, extensionId);
+    const optionsJapanese = await optionsPage
+      .locator('text=/設定|ブロックリスト/i')
+      .first()
+      .isVisible();
+    expect(optionsJapanese).toBeTruthy();
+    await optionsPage.close();
+  });
+
+  test('I18N-005: 言語変更が即座に反映される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 最初は英語
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options を開く
+    const optionsPage = await openOptions(context, extensionId);
+
+    // 英語のテキストが表示されることを確認
+    let englishText = await optionsPage
+      .locator('text=/Settings|Blocklist/i')
+      .first()
+      .isVisible();
+    expect(englishText).toBeTruthy();
+
+    // 言語を日本語に変更
+    await optionsPage.evaluate(async () => {
+      await chrome.storage.local.set({
+        settings: {
+          language: 'ja',
+          paused: false
+        }
+      });
+    });
+
+    // storage.watch が反応するまで待機
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // ページをリロード
+    await optionsPage.reload();
+
+    // 日本語に変更されたことを確認
+    const japaneseText = await optionsPage
+      .locator('text=/設定|ブロックリスト/i')
+      .first()
+      .isVisible();
+    expect(japaneseText).toBeTruthy();
+
+    await optionsPage.close();
+  });
+});

--- a/tests/e2e/interaction.spec.ts
+++ b/tests/e2e/interaction.spec.ts
@@ -1,0 +1,393 @@
+import { test, expect } from './fixtures/extension';
+import { openExternalSite, openPopup } from './helpers/pages';
+import { setStorageData, clearStorage } from './helpers/storage';
+import { TEST_DOMAINS } from './helpers/constants';
+
+/**
+ * E2E Tests: 機能間相互作用
+ *
+ * Pause、Time Limit、Schedule、Analytics、パスワード保護の組み合わせ動作をテスト
+ */
+
+test.describe('Interaction - 機能間相互作用', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('INT-001: Pause + Time Limit 同時有効時、Pause が優先される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Pause 有効 + Time Limit 超過
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: true, // Pause 有効
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 1,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 10, // 超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（Pause が優先されてアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('INT-002: Pause + Schedule 同時有効時、Pause が優先される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    const now = new Date();
+    const currentHour = now.getHours();
+    const currentDay = now.getDay();
+
+    // Pause 有効 + Schedule でブロック有効化時間帯
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: true, // Pause 有効
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ],
+      schedules: [
+        {
+          id: 'schedule1',
+          name: 'Block Now',
+          enabled: true,
+          days: [currentDay],
+          startTime: `${String(currentHour).padStart(2, '0')}:00`,
+          endTime: `${String(currentHour + 1).padStart(2, '0')}:00`,
+          action: 'enable'
+        }
+      ]
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（Pause が優先されてアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('INT-003: Time Limit + Schedule 同時有効時の動作確認', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    const now = new Date();
+    const currentHour = now.getHours();
+    const currentDay = now.getDay();
+
+    // Time Limit 未超過 + Schedule でブロック有効化時間帯
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60,
+            hourly: null
+          }
+        }
+      ],
+      schedules: [
+        {
+          id: 'schedule1',
+          name: 'Block Now',
+          enabled: true,
+          days: [currentDay],
+          startTime: `${String(currentHour).padStart(2, '0')}:00`,
+          endTime: `${String(currentHour + 1).padStart(2, '0')}:00`,
+          action: 'enable'
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 30, // 未超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（Schedule により有効化 + Time Limit 未超過でもブロック）
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    await blockedPage.close();
+  });
+
+  test('INT-004: Pause + Time Limit + Schedule 同時有効時の優先順位', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    const now = new Date();
+    const currentHour = now.getHours();
+    const currentDay = now.getDay();
+
+    // Pause 有効 + Time Limit 超過 + Schedule 有効
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: true, // Pause が最優先
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 1,
+            hourly: null
+          }
+        }
+      ],
+      schedules: [
+        {
+          id: 'schedule1',
+          name: 'Block Now',
+          enabled: true,
+          days: [currentDay],
+          startTime: `${String(currentHour).padStart(2, '0')}:00`,
+          endTime: `${String(currentHour + 1).padStart(2, '0')}:00`,
+          action: 'enable'
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 10, // 超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（Pause が最優先でアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('INT-005: Analytics Opt-Out 時に Unblock History も無効化', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Opt-Out 状態
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
+    });
+
+    await setStorageData(page, 'unblockHistory', {
+      entries: []
+    });
+
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {}
+    });
+
+    await page.close();
+
+    // 外部サイトにアクセス
+    const externalPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await externalPage.waitForLoadState('domcontentloaded');
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Unblock History が記録されないことを確認
+    const unblockHistory = await externalPage.evaluate(async () => {
+      const result = await chrome.storage.local.get('unblockHistory');
+      return result.unblockHistory;
+    });
+
+    expect(unblockHistory.entries.length).toBe(0);
+
+    await externalPage.close();
+  });
+
+  test('INT-006: パスワード保護 + Pause トグル の認証フロー', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // パスワード保護を有効化
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      password: {
+        enabled: true,
+        passwordHash:
+          '1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014' // SHA-256("test1234")
+      }
+    });
+
+    await page.close();
+
+    // Popup を開く
+    const popupPage = await openPopup(context, extensionId);
+
+    // Pause トグルをクリック
+    const pauseToggle = popupPage.locator('[role="switch"]');
+    await pauseToggle.click();
+
+    // パスワードモーダルが表示されることを確認
+    const passwordModal = popupPage.locator('[role="dialog"], .modal');
+    await passwordModal.waitFor({ state: 'visible', timeout: 3000 });
+
+    // パスワード入力フィールドが表示されることを確認
+    const passwordInput = passwordModal.locator('input[type="password"]');
+    expect(await passwordInput.isVisible()).toBeTruthy();
+
+    await popupPage.close();
+  });
+
+  test('INT-007: パスワード保護 + ブロック解除 の認証フロー', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // パスワード保護を有効化
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      password: {
+        enabled: true,
+        passwordHash:
+          '1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014'
+      },
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true
+        }
+      ]
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // ブロックされたサイトにアクセス
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+
+    // newtab.html でブロック解除ボタンをクリック
+    const unblockButton = blockedPage.locator(
+      'button:has-text("Unblock"), button:has-text("解除")'
+    );
+    if (await unblockButton.isVisible()) {
+      await unblockButton.click();
+
+      // パスワードモーダルが表示されることを確認
+      const passwordModal = blockedPage.locator('[role="dialog"], .modal');
+      await passwordModal.waitFor({ state: 'visible', timeout: 3000 });
+
+      const passwordInput = passwordModal.locator('input[type="password"]');
+      expect(await passwordInput.isVisible()).toBeTruthy();
+    }
+
+    await blockedPage.close();
+  });
+});

--- a/tests/e2e/premium.spec.ts
+++ b/tests/e2e/premium.spec.ts
@@ -1,0 +1,601 @@
+import { test, expect } from './fixtures/extension';
+import { openOptions } from './helpers/pages';
+import {
+  setStorageData,
+  getStorageData,
+  clearStorage
+} from './helpers/storage';
+
+/**
+ * E2E Tests: Premium 機能
+ *
+ * ライセンスキー入力、Premium 機能の解放、Free ダウングレード、開発者モードをテスト
+ */
+
+test.describe('Premium - Premium 機能', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('PR-001: ライセンスキー入力で Premium が有効化される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Premium タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'premium');
+
+    // ライセンスキー入力フィールドを探す
+    const licenseInput = optionsPage.locator('input[type="text"]').first();
+    if (await licenseInput.isVisible()) {
+      await licenseInput.fill('TEST-LICENSE-KEY-123');
+
+      const activateButton = optionsPage.locator(
+        'button:has-text("Activate"), button:has-text("有効化")'
+      );
+      await activateButton.click();
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Premium が有効化されたことを確認
+      const premium = (await getStorageData(optionsPage, 'premium')) as any;
+      if (premium) {
+        expect(premium.isPremium).toBe(true);
+      }
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-002: Premium 機能（Google Fonts など）が解放される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Styles タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'styles');
+
+    // Google Fonts セレクタが表示されることを確認
+    const googleFontsSelector = optionsPage.locator(
+      'text=/Google Fonts|フォント/i'
+    );
+    const isVisible = await googleFontsSelector.isVisible();
+    expect(isVisible).toBeTruthy();
+
+    await optionsPage.close();
+  });
+
+  test('PR-003: カスタム背景画像アップロードが使える', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Styles タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'styles');
+
+    // カスタム背景画像アップロードボタンが表示されることを確認
+    const uploadButton = optionsPage.locator(
+      'input[type="file"], button:has-text("Upload")'
+    );
+    const isVisible = await uploadButton.first().isVisible();
+    expect(isVisible).toBeTruthy();
+
+    await optionsPage.close();
+  });
+
+  test('PR-004: 壁紙ダウンロード機能が使える', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Styles タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'styles');
+
+    // 壁紙ダウンロードボタンが表示されることを確認
+    const downloadButton = optionsPage.locator(
+      'button:has-text("Download"), button:has-text("ダウンロード")'
+    );
+    if (await downloadButton.isVisible()) {
+      expect(await downloadButton.isVisible()).toBeTruthy();
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-005: プリセット上限が5件になる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    // 5件のプリセットを設定
+    await setStorageData(page, 'vision', {
+      defaultSettings: {
+        goalText: 'Focus',
+        subText: 'Stay productive'
+      },
+      presets: [
+        {
+          id: '1',
+          name: 'Preset 1',
+          goalText: 'Goal 1',
+          subText: 'Sub 1',
+          textColor: '#fff',
+          backgroundColor: '#000',
+          backgroundType: 'color'
+        },
+        {
+          id: '2',
+          name: 'Preset 2',
+          goalText: 'Goal 2',
+          subText: 'Sub 2',
+          textColor: '#fff',
+          backgroundColor: '#111',
+          backgroundType: 'color'
+        },
+        {
+          id: '3',
+          name: 'Preset 3',
+          goalText: 'Goal 3',
+          subText: 'Sub 3',
+          textColor: '#fff',
+          backgroundColor: '#222',
+          backgroundType: 'color'
+        },
+        {
+          id: '4',
+          name: 'Preset 4',
+          goalText: 'Goal 4',
+          subText: 'Sub 4',
+          textColor: '#fff',
+          backgroundColor: '#333',
+          backgroundType: 'color'
+        },
+        {
+          id: '5',
+          name: 'Preset 5',
+          goalText: 'Goal 5',
+          subText: 'Sub 5',
+          textColor: '#fff',
+          backgroundColor: '#444',
+          backgroundType: 'color'
+        }
+      ],
+      activePresetId: '1'
+    });
+
+    await page.close();
+
+    // Options の Styles タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'styles');
+
+    // 5件のプリセットが表示されることを確認
+    const vision = (await getStorageData(optionsPage, 'vision')) as any;
+    expect(vision.presets.length).toBe(5);
+
+    await optionsPage.close();
+  });
+
+  test('PR-006: Analytics 全期間表示が使える', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    await page.close();
+
+    // Options の Analytics タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'analytics');
+
+    // 全期間フィルタが表示されることを確認
+    const allTimeFilter = optionsPage.locator('text=/All Time|全期間/i');
+    const isVisible = await allTimeFilter.isVisible();
+    expect(isVisible).toBeTruthy();
+
+    await optionsPage.close();
+  });
+
+  test('PR-007: Unblock History CSV エクスポートが使える', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    await page.close();
+
+    // Options の Analytics タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'analytics');
+
+    // CSV エクスポートボタンが表示されることを確認
+    const exportButton = optionsPage.locator(
+      'button:has-text("Export CSV"), button:has-text("CSV出力")'
+    );
+    if (await exportButton.isVisible()) {
+      expect(await exportButton.isVisible()).toBeTruthy();
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-008: 開発者モードで24時間 Premium 体験ができる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Premium タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'premium');
+
+    // 開発者モードボタンを探す
+    const devModeButton = optionsPage.locator(
+      'button:has-text("Developer Mode"), button:has-text("開発者モード")'
+    );
+    if (await devModeButton.isVisible()) {
+      await devModeButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Premium が有効化されたことを確認
+      const premium = (await getStorageData(optionsPage, 'premium')) as any;
+      if (premium) {
+        expect(premium.isPremium).toBe(true);
+        expect(premium.devMode).toBe(true);
+      }
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-009: ライセンス解除で Free にダウングレードされる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false
+    });
+
+    await page.close();
+
+    // Options の Premium タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'premium');
+
+    // ライセンス解除ボタンを探す
+    const deactivateButton = optionsPage.locator(
+      'button:has-text("Deactivate"), button:has-text("解除")'
+    );
+    if (await deactivateButton.isVisible()) {
+      await deactivateButton.click();
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Premium が無効化されたことを確認
+      const premium = (await getStorageData(optionsPage, 'premium')) as any;
+      if (premium) {
+        expect(premium.isPremium).toBe(false);
+      }
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-010: Free ダウングレード時、2件目以降のプリセットがロック', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 最初は Premium
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    // 3件のプリセットを設定
+    await setStorageData(page, 'vision', {
+      defaultSettings: {
+        goalText: 'Focus',
+        subText: 'Stay productive'
+      },
+      presets: [
+        {
+          id: '1',
+          name: 'Preset 1',
+          goalText: 'Goal 1',
+          subText: 'Sub 1',
+          textColor: '#fff',
+          backgroundColor: '#000',
+          backgroundType: 'color'
+        },
+        {
+          id: '2',
+          name: 'Preset 2',
+          goalText: 'Goal 2',
+          subText: 'Sub 2',
+          textColor: '#fff',
+          backgroundColor: '#111',
+          backgroundType: 'color'
+        },
+        {
+          id: '3',
+          name: 'Preset 3',
+          goalText: 'Goal 3',
+          subText: 'Sub 3',
+          textColor: '#fff',
+          backgroundColor: '#222',
+          backgroundType: 'color'
+        }
+      ],
+      activePresetId: '1'
+    });
+
+    await page.close();
+
+    // Premium を解除
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'premium', {
+      isPremium: false,
+      activatedAt: null
+    });
+
+    await page2.close();
+
+    // Options の Styles タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'styles');
+
+    // 2件目以降のプリセットがロックされていることを確認
+    const lockedPreset = optionsPage.locator('text=/Locked|ロック/i');
+    if (await lockedPreset.isVisible()) {
+      expect(await lockedPreset.isVisible()).toBeTruthy();
+    }
+
+    await optionsPage.close();
+  });
+
+  test('PR-011: ダウングレード時、カスタム背景が削除される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    // カスタム背景を設定
+    await setStorageData(page, 'vision', {
+      defaultSettings: {
+        goalText: 'Focus',
+        subText: 'Stay productive'
+      },
+      presets: [
+        {
+          id: '1',
+          name: 'Custom Background',
+          goalText: 'Goal',
+          subText: 'Sub',
+          textColor: '#fff',
+          backgroundColor: 'data:image/png;base64,CUSTOM_IMAGE',
+          backgroundType: 'image'
+        }
+      ],
+      activePresetId: '1'
+    });
+
+    await page.close();
+
+    // Premium を解除
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'premium', {
+      isPremium: false,
+      activatedAt: null
+    });
+
+    // ダウングレード処理が実行されるのを待つ
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // カスタム背景が削除されたことを確認
+    const vision = (await getStorageData(page2, 'vision')) as any;
+    if (vision.presets[0].backgroundType === 'image') {
+      // Free プランではカスタム背景は使用できないため、color にリセット
+      expect(vision.presets[0].backgroundType).toBe('color');
+    }
+
+    await page2.close();
+  });
+
+  test('PR-012: ダウングレード時、3件目以降のプリセットが無効化', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Premium を有効化
+    await setStorageData(page, 'premium', {
+      isPremium: true,
+      activatedAt: new Date().toISOString()
+    });
+
+    // 5件のプリセットを設定
+    await setStorageData(page, 'vision', {
+      defaultSettings: {
+        goalText: 'Focus',
+        subText: 'Stay productive'
+      },
+      presets: [
+        {
+          id: '1',
+          name: 'Preset 1',
+          goalText: 'Goal 1',
+          subText: 'Sub 1',
+          textColor: '#fff',
+          backgroundColor: '#000',
+          backgroundType: 'color'
+        },
+        {
+          id: '2',
+          name: 'Preset 2',
+          goalText: 'Goal 2',
+          subText: 'Sub 2',
+          textColor: '#fff',
+          backgroundColor: '#111',
+          backgroundType: 'color'
+        },
+        {
+          id: '3',
+          name: 'Preset 3',
+          goalText: 'Goal 3',
+          subText: 'Sub 3',
+          textColor: '#fff',
+          backgroundColor: '#222',
+          backgroundType: 'color'
+        },
+        {
+          id: '4',
+          name: 'Preset 4',
+          goalText: 'Goal 4',
+          subText: 'Sub 4',
+          textColor: '#fff',
+          backgroundColor: '#333',
+          backgroundType: 'color'
+        },
+        {
+          id: '5',
+          name: 'Preset 5',
+          goalText: 'Goal 5',
+          subText: 'Sub 5',
+          textColor: '#fff',
+          backgroundColor: '#444',
+          backgroundType: 'color'
+        }
+      ],
+      activePresetId: '3'
+    });
+
+    await page.close();
+
+    // Premium を解除
+    const page2 = await context.newPage();
+    await setStorageData(page2, 'premium', {
+      isPremium: false,
+      activatedAt: null
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // 3件目以降のプリセットがアクセスできないことを確認
+    const vision = (await getStorageData(page2, 'vision')) as any;
+    // Free プランでは最大2件まで
+    expect(
+      vision.presets.filter((p) => p.id === '1' || p.id === '2').length
+    ).toBe(2);
+
+    // activePresetId が 3 以降の場合、デフォルトに戻される
+    if (
+      vision.activePresetId === '3' ||
+      vision.activePresetId === '4' ||
+      vision.activePresetId === '5'
+    ) {
+      expect(vision.activePresetId).toBe('1');
+    }
+
+    await page2.close();
+  });
+});

--- a/tests/e2e/time-limit.spec.ts
+++ b/tests/e2e/time-limit.spec.ts
@@ -135,7 +135,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     expect(blockedPage.url()).toContain('newtab.html');
 
     // reason パラメータが含まれることを確認
-    expect(blockedPage.url()).toContain('reason=time-limit');
+    expect(blockedPage.url()).toContain('reason=time_limit_exceeded');
 
     await blockedPage.close();
   });

--- a/tests/e2e/time-limit.spec.ts
+++ b/tests/e2e/time-limit.spec.ts
@@ -1,0 +1,608 @@
+import { test, expect } from './fixtures/extension';
+import { openExternalSite, openPopup, openOptions } from './helpers/pages';
+import {
+  setStorageData,
+  clearStorage,
+  getStorageData
+} from './helpers/storage';
+import { TEST_DOMAINS } from './helpers/constants';
+
+/**
+ * E2E Tests: Time Limit 機能
+ *
+ * Daily/Hourly Time Limit、リセット、超過時のリダイレクトをテスト
+ */
+
+test.describe('TimeLimit - Time Limit 機能', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('TL-001: Daily Time Limit を設定できる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Daily Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60, // 60秒
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    // 設定が保存されたことを確認
+    const settings = (await getStorageData(page, 'settings')) as any;
+    expect(settings.blockList[0].timeLimit.daily).toBe(60);
+
+    await page.close();
+  });
+
+  test('TL-002: Hourly Time Limit を設定できる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Hourly Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: null,
+            hourly: 30 // 30秒
+          }
+        }
+      ]
+    });
+
+    // 設定が保存されたことを確認
+    const settings = (await getStorageData(page, 'settings')) as any;
+    expect(settings.blockList[0].timeLimit.hourly).toBe(30);
+
+    await page.close();
+  });
+
+  test('TL-003: Time Limit 超過時に newtab.html へリダイレクト（reason付き）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Time Limit を1秒に設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 1, // 1秒
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    // 既に使用済みとして記録
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 2, // 1秒を超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    // newtab.html にリダイレクトされることを確認
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+
+    // reason パラメータが含まれることを確認
+    expect(blockedPage.url()).toContain('reason=time-limit');
+
+    await blockedPage.close();
+  });
+
+  test('TL-004: Time Limit 超過後、Daily は日付変更でリセット（00:00）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 昨日の使用データを設定（resetAt が過去）
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 70, // 超過していた
+          resetAt: yesterday.toISOString() // 過去のリセット時刻
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（リセットされているのでアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    // ブロックされないことを確認
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('TL-005: Time Limit 超過後、Hourly は時間変更でリセット（毎時00分）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 1時間前の使用データを設定
+    const oneHourAgo = new Date();
+    oneHourAgo.setHours(oneHourAgo.getHours() - 1);
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: null,
+            hourly: 30
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: null,
+        hourly: {
+          used: 40, // 超過していた
+          resetAt: oneHourAgo.toISOString() // 過去のリセット時刻
+        }
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（リセットされているのでアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('TL-006: 残り時間がポップアップで表示される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    // 30秒使用済み
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 30,
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    // ポップアップを開く
+    const popupPage = await openPopup(context, extensionId);
+
+    // 残り時間バッジが表示されることを確認
+    const remainingTimeText = await popupPage
+      .locator('text=/remaining|残り/i')
+      .first()
+      .isVisible();
+    expect(remainingTimeText).toBeTruthy();
+
+    await popupPage.close();
+  });
+
+  test('TL-007: Time Limit 使用状況が Analytics タブで確認できる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
+    });
+
+    // Analytics データにTime Limit使用状況を記録
+    await setStorageData(page, 'analytics', {
+      dailyStats: {
+        [new Date().toISOString().slice(0, 10)]: {
+          date: new Date().toISOString().slice(0, 10),
+          wasteTime: 120,
+          investTime: 0,
+          blockCount: 5,
+          unblockCount: 0
+        }
+      },
+      siteStats: {}
+    });
+
+    await page.close();
+
+    // Options の Analytics タブを開く
+    const optionsPage = await openOptions(context, extensionId, 'analytics');
+
+    // Analytics データが表示されることを確認
+    await optionsPage.waitForSelector('text=/analytics|分析/i');
+    const statsVisible = await optionsPage
+      .locator('text=/120|waste time/i')
+      .isVisible();
+    expect(statsVisible).toBeTruthy();
+
+    await optionsPage.close();
+  });
+
+  test('TL-008: Pause 有効中に Time Limit 超過した場合もリダイレクトされない', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // Pause 有効 + Time Limit 超過状態
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: true, // Pause 有効
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 1,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 10, // 超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // サイトにアクセス（Pauseが優先されてアクセス可能）
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.example);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+
+    await unblockedPage.close();
+  });
+
+  test('TL-009: Daily リセット境界値テスト（23:59→00:00）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 23:59の resetAt を設定（現在時刻より1分後）
+    const resetTime = new Date();
+    resetTime.setHours(23, 59, 0, 0);
+    if (resetTime <= new Date()) {
+      resetTime.setDate(resetTime.getDate() + 1);
+    }
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 50,
+          resetAt: resetTime.toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    // Date をモックして00:00を再現
+    await page.evaluate(() => {
+      const midnight = new Date();
+      midnight.setHours(0, 0, 0, 0);
+      const realDate = Date;
+      // @ts-ignore
+      Date = class extends realDate {
+        constructor() {
+          super();
+          return midnight;
+        }
+        static now() {
+          return midnight.getTime();
+        }
+      };
+    });
+
+    // リセットされているか確認
+    // リセットされているか確認
+    const usage = (await getStorageData(page, 'timeLimitUsage')) as any;
+    // resetAt が過去になっているため、次回アクセス時にリセットされる
+    expect(
+      new Date(usage[TEST_DOMAINS.example].daily.resetAt).getTime()
+    ).toBeLessThan(new Date().getTime());
+
+    await page.close();
+  });
+
+  test('TL-010: Hourly リセット境界値テスト（09:59→10:00）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 09:59の resetAt を設定
+    const resetTime = new Date();
+    resetTime.setMinutes(59, 0, 0);
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: null,
+            hourly: 30
+          }
+        }
+      ]
+    });
+
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: null,
+        hourly: {
+          used: 25,
+          resetAt: resetTime.toISOString()
+        }
+      }
+    });
+
+    // Date をモックして10:00を再現
+    await page.evaluate(() => {
+      const nextHour = new Date();
+      nextHour.setMinutes(0, 0, 0);
+      nextHour.setHours(nextHour.getHours() + 1);
+      const realDate = Date;
+      // @ts-ignore
+      Date = class extends realDate {
+        constructor() {
+          super();
+          return nextHour;
+        }
+        static now() {
+          return nextHour.getTime();
+        }
+      };
+    });
+
+    const usageHourly = (await getStorageData(page, 'timeLimitUsage')) as any;
+    expect(
+      new Date(usageHourly[TEST_DOMAINS.example].hourly.resetAt).getTime()
+    ).toBeLessThan(new Date().getTime());
+
+    await page.close();
+  });
+
+  test('TL-011: 複数サイトで異なる Time Limit が同時に動作する', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 2つのサイトに異なる Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      blockList: [
+        {
+          id: '1',
+          domain: TEST_DOMAINS.example,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 60,
+            hourly: null
+          }
+        },
+        {
+          id: '2',
+          domain: TEST_DOMAINS.reddit,
+          isWildcard: false,
+          createdAt: new Date().toISOString(),
+          enabled: true,
+          timeLimit: {
+            daily: 30,
+            hourly: null
+          }
+        }
+      ]
+    });
+
+    // example.com は超過、reddit.com は未超過
+    await setStorageData(page, 'timeLimitUsage', {
+      [TEST_DOMAINS.example]: {
+        daily: {
+          used: 70, // 超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      },
+      [TEST_DOMAINS.reddit]: {
+        daily: {
+          used: 10, // 未超過
+          resetAt: new Date(Date.now() + 86400000).toISOString()
+        },
+        hourly: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // example.com はブロック
+    const blockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.example}`
+    );
+    await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(blockedPage.url()).toContain('newtab.html');
+    await blockedPage.close();
+
+    // reddit.com はアクセス可能
+    const unblockedPage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.reddit}`
+    );
+    await unblockedPage.waitForLoadState('domcontentloaded');
+    expect(unblockedPage.url()).toContain(TEST_DOMAINS.reddit);
+    expect(unblockedPage.url()).not.toContain('newtab.html');
+    await unblockedPage.close();
+  });
+});

--- a/tests/e2e/youtube.spec.ts
+++ b/tests/e2e/youtube.spec.ts
@@ -51,7 +51,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Shorts が非表示になる CSS が適用されているか確認
     const shortsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('[title*="Shorts"]');
     });
 
@@ -89,7 +89,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Recommendations が非表示になる CSS が適用されているか確認
     const recsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes(
         'ytd-watch-next-secondary-results-renderer'
       );
@@ -129,7 +129,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Comments が非表示になる CSS が適用されているか確認
     const commentsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('ytd-comments');
     });
 
@@ -225,13 +225,23 @@ test.describe('YouTube - YouTube ブロック機能', () => {
       }
     });
 
-    // 既に超過
-    await setStorageData(page, 'youtubeTimeLimitUsage', {
-      daily: {
-        used: 10, // 超過
-        resetAt: new Date(Date.now() + 86400000).toISOString()
-      },
-      hourly: null
+    // 既に超過（analytics.timeLimitUsage に youtube.com の使用データを設定）
+    const todayKey = new Date().toISOString().split('T')[0];
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteTime: {},
+      siteCategories: {},
+      siteBlockCounts: {},
+      siteUnblockCounts: {},
+      timeLimitUsage: {
+        'youtube.com': {
+          domain: 'youtube.com',
+          dailyUsedSeconds: 10, // 超過（limitSeconds: 1）
+          hourlyUsedSeconds: 0,
+          lastDailyReset: todayKey,
+          lastHourlyReset: ''
+        }
+      }
     });
 
     await page.close();
@@ -245,9 +255,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // 全コンテンツが非表示になる CSS が適用されているか確認
     const contentHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector(
-        'style[data-visionfocus-youtube-limit]'
-      );
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('display: none !important');
     });
 
@@ -286,7 +294,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Shorts が表示されていることを確認
     let shortsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('[title*="Shorts"]');
     });
     expect(shortsHidden).toBeFalsy();
@@ -313,7 +321,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Shorts が非表示になることを確認
     shortsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('[title*="Shorts"]');
     });
     expect(shortsHidden).toBeTruthy();
@@ -389,13 +397,23 @@ test.describe('YouTube - YouTube ブロック機能', () => {
       }
     });
 
-    // Time Limit は未超過
-    await setStorageData(page, 'youtubeTimeLimitUsage', {
-      daily: {
-        used: 30,
-        resetAt: new Date(Date.now() + 86400000).toISOString()
-      },
-      hourly: null
+    // Time Limit は未超過（analytics.timeLimitUsage に youtube.com の使用データを設定）
+    const todayKey = new Date().toISOString().split('T')[0];
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteTime: {},
+      siteCategories: {},
+      siteBlockCounts: {},
+      siteUnblockCounts: {},
+      timeLimitUsage: {
+        'youtube.com': {
+          domain: 'youtube.com',
+          dailyUsedSeconds: 30, // 未超過（limitSeconds: 60）
+          hourlyUsedSeconds: 0,
+          lastDailyReset: todayKey,
+          lastHourlyReset: ''
+        }
+      }
     });
 
     await page.close();
@@ -409,16 +427,14 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     // Shorts 非表示の CSS が適用されていることを確認
     const shortsHidden = await youtubePage.evaluate(() => {
-      const style = document.querySelector('style[data-visionfocus-youtube]');
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style?.textContent?.includes('[title*="Shorts"]');
     });
     expect(shortsHidden).toBeTruthy();
 
     // Time Limit 超過の CSS は適用されていないことを確認
     const limitExceeded = await youtubePage.evaluate(() => {
-      const style = document.querySelector(
-        'style[data-visionfocus-youtube-limit]'
-      );
+      const style = document.getElementById('vision-focus-youtube-blocker');
       return style !== null;
     });
     expect(limitExceeded).toBeFalsy();
@@ -448,13 +464,23 @@ test.describe('YouTube - YouTube ブロック機能', () => {
       }
     });
 
-    // Time Limit は未超過
-    await setStorageData(page, 'youtubeTimeLimitUsage', {
-      daily: {
-        used: 30,
-        resetAt: new Date(Date.now() + 86400000).toISOString()
-      },
-      hourly: null
+    // Time Limit は未超過（analytics.timeLimitUsage に youtube.com の使用データを設定）
+    const todayKey = new Date().toISOString().split('T')[0];
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteTime: {},
+      siteCategories: {},
+      siteBlockCounts: {},
+      siteUnblockCounts: {},
+      timeLimitUsage: {
+        'youtube.com': {
+          domain: 'youtube.com',
+          dailyUsedSeconds: 30, // 未超過（limitSeconds: 60）
+          hourlyUsedSeconds: 0,
+          lastDailyReset: todayKey,
+          lastHourlyReset: ''
+        }
+      }
     });
 
     await page.close();

--- a/tests/e2e/youtube.spec.ts
+++ b/tests/e2e/youtube.spec.ts
@@ -1,0 +1,476 @@
+import { test, expect } from './fixtures/extension';
+import { openExternalSite } from './helpers/pages';
+import {
+  setStorageData,
+  clearStorage,
+  getStorageData
+} from './helpers/storage';
+import { TEST_DOMAINS } from './helpers/constants';
+
+/**
+ * E2E Tests: YouTube ブロック機能
+ *
+ * YouTube Shorts、Recommendations、Comments の非表示、完全ブロック、Time Limitをテスト
+ */
+
+test.describe('YouTube - YouTube ブロック機能', () => {
+  test.beforeEach(async ({ context }) => {
+    const page = await context.newPage();
+    await clearStorage(page);
+    await page.close();
+  });
+
+  test('YT-001: YouTube Shorts を非表示にできる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // YouTube Shorts を非表示に設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: true,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: null
+      }
+    });
+
+    await page.close();
+
+    // YouTube にアクセス
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // Shorts が非表示になる CSS が適用されているか確認
+    const shortsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes('[title*="Shorts"]');
+    });
+
+    expect(shortsHidden).toBeTruthy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-002: YouTube Recommendations（関連動画）を非表示にできる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: true,
+        hideComments: false,
+        timeLimit: null
+      }
+    });
+
+    await page.close();
+
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // Recommendations が非表示になる CSS が適用されているか確認
+    const recsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes(
+        'ytd-watch-next-secondary-results-renderer'
+      );
+    });
+
+    expect(recsHidden).toBeTruthy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-003: YouTube Comments を非表示にできる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: true,
+        timeLimit: null
+      }
+    });
+
+    await page.close();
+
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // Comments が非表示になる CSS が適用されているか確認
+    const commentsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes('ytd-comments');
+    });
+
+    expect(commentsHidden).toBeTruthy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-004: YouTube 完全ブロック（blockAccess）が動作する', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // YouTube を完全ブロック
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: true,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: null
+      }
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // YouTube にアクセス
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    // newtab.html にリダイレクトされることを確認
+    await youtubePage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(youtubePage.url()).toContain('newtab.html');
+
+    await youtubePage.close();
+  });
+
+  test('YT-005: YouTube Time Limit を設定できる', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // YouTube Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: {
+          daily: 120,
+          hourly: null
+        }
+      }
+    });
+
+    // 設定が保存されたことを確認
+    const settings = (await getStorageData(page, 'settings')) as any;
+    expect(settings.youtube.timeLimit.daily).toBe(120);
+
+    await page.close();
+  });
+
+  test('YT-006: YouTube Time Limit 超過時に CSS で全コンテンツ非表示', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // YouTube Time Limit を設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: {
+          daily: 1, // 1秒
+          hourly: null
+        }
+      }
+    });
+
+    // 既に超過
+    await setStorageData(page, 'youtubeTimeLimitUsage', {
+      daily: {
+        used: 10, // 超過
+        resetAt: new Date(Date.now() + 86400000).toISOString()
+      },
+      hourly: null
+    });
+
+    await page.close();
+
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // 全コンテンツが非表示になる CSS が適用されているか確認
+    const contentHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector(
+        'style[data-visionfocus-youtube-limit]'
+      );
+      return style?.textContent?.includes('display: none !important');
+    });
+
+    expect(contentHidden).toBeTruthy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-007: YouTube 設定変更が即座に反映される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // 最初は Shorts 非表示なし
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: null
+      }
+    });
+
+    await page.close();
+
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // Shorts が表示されていることを確認
+    let shortsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes('[title*="Shorts"]');
+    });
+    expect(shortsHidden).toBeFalsy();
+
+    // 設定を変更
+    await youtubePage.evaluate(async () => {
+      await chrome.storage.local.set({
+        settings: {
+          language: 'en',
+          paused: false,
+          youtube: {
+            blockAccess: false,
+            hideShorts: true, // 有効化
+            hideRecommendations: false,
+            hideComments: false,
+            timeLimit: null
+          }
+        }
+      });
+    });
+
+    // storage.watch が反応するまで待機
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // Shorts が非表示になることを確認
+    shortsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes('[title*="Shorts"]');
+    });
+    expect(shortsHidden).toBeTruthy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-008: YouTube 有効化/無効化がトラッキング履歴に記録される', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
+      youtube: {
+        blockAccess: false,
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: {
+          daily: 60,
+          hourly: null
+        }
+      }
+    });
+
+    // YouTube を訪問
+    await setStorageData(page, 'analytics', {
+      dailyStats: {},
+      siteStats: {
+        [TEST_DOMAINS.youtube]: {
+          domain: TEST_DOMAINS.youtube,
+          blockCount: 0,
+          unblockCount: 0,
+          totalTime: 120 // 2分間の使用
+        }
+      }
+    });
+
+    await page.close();
+
+    const page2 = await context.newPage();
+    const analytics = (await getStorageData(page2, 'analytics')) as any;
+
+    // YouTube のトラッキングデータが記録されていることを確認
+    expect(analytics.siteStats[TEST_DOMAINS.youtube]).toBeDefined();
+    expect(analytics.siteStats[TEST_DOMAINS.youtube].totalTime).toBe(120);
+
+    await page2.close();
+  });
+
+  test('YT-009: Hide Shorts + Time Limit 同時設定時に両方が機能する', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: true, // Shorts 非表示
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: {
+          daily: 60,
+          hourly: null
+        }
+      }
+    });
+
+    // Time Limit は未超過
+    await setStorageData(page, 'youtubeTimeLimitUsage', {
+      daily: {
+        used: 30,
+        resetAt: new Date(Date.now() + 86400000).toISOString()
+      },
+      hourly: null
+    });
+
+    await page.close();
+
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    await youtubePage.waitForLoadState('domcontentloaded');
+
+    // Shorts 非表示の CSS が適用されていることを確認
+    const shortsHidden = await youtubePage.evaluate(() => {
+      const style = document.querySelector('style[data-visionfocus-youtube]');
+      return style?.textContent?.includes('[title*="Shorts"]');
+    });
+    expect(shortsHidden).toBeTruthy();
+
+    // Time Limit 超過の CSS は適用されていないことを確認
+    const limitExceeded = await youtubePage.evaluate(() => {
+      const style = document.querySelector(
+        'style[data-visionfocus-youtube-limit]'
+      );
+      return style !== null;
+    });
+    expect(limitExceeded).toBeFalsy();
+
+    await youtubePage.close();
+  });
+
+  test('YT-010: blockAccess と Time Limit の優先順位（blockAccess 優先）', async ({
+    context,
+    extensionId
+  }) => {
+    const page = await context.newPage();
+
+    // blockAccess と Time Limit を両方設定
+    await setStorageData(page, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: true, // 完全ブロック
+        hideShorts: false,
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: {
+          daily: 60,
+          hourly: null
+        }
+      }
+    });
+
+    // Time Limit は未超過
+    await setStorageData(page, 'youtubeTimeLimitUsage', {
+      daily: {
+        used: 30,
+        resetAt: new Date(Date.now() + 86400000).toISOString()
+      },
+      hourly: null
+    });
+
+    await page.close();
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // YouTube にアクセス
+    const youtubePage = await openExternalSite(
+      context,
+      `https://${TEST_DOMAINS.youtube}`
+    );
+
+    // blockAccess が優先され、newtab.html にリダイレクト
+    await youtubePage.waitForURL(`**newtab.html**`, { timeout: 5000 });
+    expect(youtubePage.url()).toContain('newtab.html');
+
+    await youtubePage.close();
+  });
+});


### PR DESCRIPTION
## Summary

E2E機能テストを実装 (Part D of #22)

### 実装内容

**block.spec.ts (10 tests)**: ブロック機能
- ブロックリスト追加・削除
- ワイルドカード対応
- Pauseトグル
- 有効化/無効化
- declarativeNetRequest
- ブロック回数カウント

**time-limit.spec.ts (11 tests)**: Time Limit機能
- Daily/Hourly Time Limit設定
- 超過時リダイレクト (reason付き)
- Daily/Hourly リセット境界値テスト
- Pause優先順位
- 複数サイト同時動作

**youtube.spec.ts (10 tests)**: YouTube特化機能
- Shorts/Recommendations/Comments非表示
- 完全ブロック (blockAccess)
- YouTube Time Limit
- 設定即時反映
- blockAccess優先順位

**analytics.spec.ts (10 tests)**: アナリティクス
- サイト別ブロック回数
- Unblock History記録
- 30秒Heartbeat
- Opt-In/Opt-Out
- データリセット
- ネットワーク切断時キューイング

**i18n.spec.ts (5 tests)**: 多言語対応
- 英語/日本語UI自動表示
- 言語切り替え
- 全画面統一

**data.spec.ts (6 tests)**: データ永続化
- chrome.storage.local保存
- ブラウザ再起動後保持
- プリセット・スケジュール・Analytics保存

**premium.spec.ts (12 tests)**: Premium機能
- ライセンスキー有効化
- Google Fonts/カスタム背景/壁紙DL
- プリセット5件上限
- CSV エクスポート
- 開発者モード
- ダウングレード処理

**interaction.spec.ts (7 tests)**: 機能間相互作用
- Pause/Time Limit/Schedule優先順位
- Analytics Opt-Out時の動作
- パスワード保護認証フロー

### テスト統計
- **Total**: 71 tests
- **Coverage**: Block, Time Limit, YouTube, Analytics, i18n, Data, Premium, Interaction

### Test Infrastructure
- PR #205の既存インフラを使用
- `playwright.config.ts`: Chrome拡張用設定
- `tests/e2e/fixtures/extension.ts`: フィクスチャ
- `tests/e2e/helpers/`: セレクタ/ストレージ/ページヘルパー

Part of #22

## Test plan
- [x] `pnpm format:check` — Prettier
- [x] `pnpm lint` — ESLint
- [x] `pnpm type-check` — TypeScript

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>