### PR TITLE
fix: 1日の制限が残っているのにブロックされてしまう問題を修正

### DIFF
--- a/src/lib/__tests__/timeLimitService.test.ts
+++ b/src/lib/__tests__/timeLimitService.test.ts
@@ -151,7 +151,7 @@ describe('checkTimeLimitExceeded', () => {
       timeLimitUsage: {
         'youtube.com': {
           domain: 'youtube.com',
-          dailyUsedSeconds: 3600,
+          dailyUsedSeconds: 3601, // 制限時間を超えている
           hourlyUsedSeconds: 0,
           lastDailyReset: '2024-06-12',
           lastHourlyReset: '2024-06-12-12'
@@ -183,6 +183,25 @@ describe('checkTimeLimitExceeded', () => {
     );
   });
 
+  it('日次リミットちょうどの場合falseを返す（制限時間内として扱う）', () => {
+    const analytics: AnalyticsData = {
+      ...DEFAULT_ANALYTICS,
+      timeLimitUsage: {
+        'youtube.com': {
+          domain: 'youtube.com',
+          dailyUsedSeconds: 3600, // 制限時間ちょうど
+          hourlyUsedSeconds: 0,
+          lastDailyReset: '2024-06-12',
+          lastHourlyReset: '2024-06-12-12'
+        }
+      }
+    };
+    const timeLimit: TimeLimit = { type: 'daily', limitSeconds: 3600 };
+    expect(checkTimeLimitExceeded('youtube.com', timeLimit, analytics)).toBe(
+      false
+    );
+  });
+
   it('時間リミット超過の場合trueを返す', () => {
     const analytics: AnalyticsData = {
       ...DEFAULT_ANALYTICS,
@@ -190,7 +209,7 @@ describe('checkTimeLimitExceeded', () => {
         'youtube.com': {
           domain: 'youtube.com',
           dailyUsedSeconds: 0,
-          hourlyUsedSeconds: 1800,
+          hourlyUsedSeconds: 1801, // 制限時間を超えている
           lastDailyReset: '2024-06-12',
           lastHourlyReset: '2024-06-12-12'
         }
@@ -199,6 +218,25 @@ describe('checkTimeLimitExceeded', () => {
     const timeLimit: TimeLimit = { type: 'hourly', limitSeconds: 1800 };
     expect(checkTimeLimitExceeded('youtube.com', timeLimit, analytics)).toBe(
       true
+    );
+  });
+
+  it('時間リミットちょうどの場合falseを返す（制限時間内として扱う）', () => {
+    const analytics: AnalyticsData = {
+      ...DEFAULT_ANALYTICS,
+      timeLimitUsage: {
+        'youtube.com': {
+          domain: 'youtube.com',
+          dailyUsedSeconds: 0,
+          hourlyUsedSeconds: 1800, // 制限時間ちょうど
+          lastDailyReset: '2024-06-12',
+          lastHourlyReset: '2024-06-12-12'
+        }
+      }
+    };
+    const timeLimit: TimeLimit = { type: 'hourly', limitSeconds: 1800 };
+    expect(checkTimeLimitExceeded('youtube.com', timeLimit, analytics)).toBe(
+      false
     );
   });
 

--- a/src/lib/timeLimitService.ts
+++ b/src/lib/timeLimitService.ts
@@ -98,7 +98,8 @@ export function checkTimeLimitExceeded(
   const usedSeconds =
     type === 'daily' ? effective.dailyUsedSeconds : effective.hourlyUsedSeconds;
 
-  return usedSeconds >= limitSeconds;
+  // 制限時間を超えた場合のみブロック（制限時間ちょうどはブロックしない）
+  return usedSeconds > limitSeconds;
 }
 
 /**


### PR DESCRIPTION
## Summary
- 制限時間の判定ロジックで「以上 (>=)」を使用していたため、制限時間ちょうど（例: 30分の制限に対して30分使用）の時点でブロックされてしまっていた
- 本来は「制限を超えた」場合のみブロックすべきなので、判定を「より大きい (>)」に変更
- テストケースを追加・修正: 制限時間ちょうどの場合は未超過として扱う

## Test plan
- [x] 既存のテスト全て（591テスト）がパス
- [x] checkTimeLimitExceeded のロジック修正
- [x] テストケースに「制限時間ちょうど」のケースを追加

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)