### PR TITLE
feat: ブロック中画面に浪費時間も表示

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -41,6 +41,16 @@
       }
     }
   },
+  "wastedTime": {
+    "message": "$TIME$ wasted on this site",
+    "description": "Wasted time display on blocked page",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "2 hr 15 min"
+      }
+    }
+  },
   "topBlockedSites": {
     "message": "Top Blocked Sites",
     "description": "Block count ranking heading"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -41,6 +41,16 @@
       }
     }
   },
+  "wastedTime": {
+    "message": "このサイトで $TIME$ 浪費",
+    "description": "ブロック中画面での浪費時間表示",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "2時間15分"
+      }
+    }
+  },
   "topBlockedSites": {
     "message": "よくブロックしたサイト",
     "description": "ブロック回数ランキング見出し"

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -167,7 +167,10 @@ export async function getSiteWastedTime(domain: string): Promise<number> {
   const siteTime = analytics.siteTime?.[domain];
 
   // 浪費カテゴリまたは未分類のサイトの時間を返す
-  if (siteTime && (siteTime.category === 'waste' || siteTime.category === 'neutral')) {
+  if (
+    siteTime &&
+    (siteTime.category === 'waste' || siteTime.category === 'neutral')
+  ) {
     return siteTime.time;
   }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -161,5 +161,18 @@ export async function clearLastBlockedDomain(): Promise<void> {
   await chrome.storage.session.remove(SESSION_KEYS.lastBlockedDomain);
 }
 
+// Get site wasted time in seconds
+export async function getSiteWastedTime(domain: string): Promise<number> {
+  const analytics = await getAnalytics();
+  const siteTime = analytics.siteTime?.[domain];
+
+  // 浪費カテゴリまたは未分類のサイトの時間を返す
+  if (siteTime && (siteTime.category === 'waste' || siteTime.category === 'neutral')) {
+    return siteTime.time;
+  }
+
+  return 0;
+}
+
 // Export storage instance for direct use with hooks
 export { storage };

--- a/src/newtab.tsx
+++ b/src/newtab.tsx
@@ -20,10 +20,12 @@ import {
   useResolvedPreset
 } from '~/hooks';
 import { getMessage, setCurrentLanguage } from '~/lib/i18n';
+import { formatTimeLocalized } from '~/lib/time';
 import {
   getLastBlockedDomain,
   clearLastBlockedDomain,
-  getSiteBlockCount
+  getSiteBlockCount,
+  getSiteWastedTime
 } from '~/lib/storage';
 import { storage } from '~/lib/storage';
 import type {
@@ -71,6 +73,7 @@ function NewtabApp() {
   const [blockedInfo, setBlockedInfo] = useState<{
     domain: string;
     count: number;
+    wastedTime: number; // 浪費時間（秒）
   } | null>(null);
 
   // Block reason (from URL parameter)
@@ -97,7 +100,8 @@ function NewtabApp() {
       const domain = await getLastBlockedDomain();
       if (domain) {
         const count = await getSiteBlockCount(domain);
-        setBlockedInfo({ domain, count });
+        const wastedTime = await getSiteWastedTime(domain);
+        setBlockedInfo({ domain, count, wastedTime });
         await clearLastBlockedDomain();
       }
     };
@@ -224,9 +228,16 @@ function NewtabApp() {
                   )}
                 </p>
               ) : (
-                <p className="text-danger-300 text-sm">
-                  {getMessage('blockedTimes', blockedInfo.count.toString())}
-                </p>
+                <div className="space-y-1">
+                  <p className="text-danger-300 text-sm">
+                    {getMessage('blockedTimes', blockedInfo.count.toString())}
+                  </p>
+                  {blockedInfo.wastedTime > 0 && (
+                    <p className="text-danger-200 text-sm">
+                      {getMessage('wastedTime', formatTimeLocalized(blockedInfo.wastedTime))}
+                    </p>
+                  )}
+                </div>
               )}
             </div>
           ) : (
@@ -316,20 +327,25 @@ function NewtabApp() {
                     ? getMessage('timeLimitReached')
                     : getMessage('siteBlockedMessage', blockedInfo.domain)}
                 </p>
-                <p
-                  className={`${
-                    blockReason === 'time_limit_exceeded'
-                      ? 'text-warning-200'
-                      : 'text-danger-200'
-                  } text-sm`}
-                >
-                  {blockReason === 'time_limit_exceeded'
-                    ? getMessage(
-                        'timeLimitReachedDescription',
-                        blockedInfo.domain
-                      )
-                    : getMessage('blockedTimes', blockedInfo.count.toString())}
-                </p>
+                {blockReason === 'time_limit_exceeded' ? (
+                  <p className="text-warning-200 text-sm">
+                    {getMessage(
+                      'timeLimitReachedDescription',
+                      blockedInfo.domain
+                    )}
+                  </p>
+                ) : (
+                  <div className="space-y-0.5">
+                    <p className="text-danger-200 text-sm">
+                      {getMessage('blockedTimes', blockedInfo.count.toString())}
+                    </p>
+                    {blockedInfo.wastedTime > 0 && (
+                      <p className="text-danger-100 text-sm">
+                        {getMessage('wastedTime', formatTimeLocalized(blockedInfo.wastedTime))}
+                      </p>
+                    )}
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/newtab.tsx
+++ b/src/newtab.tsx
@@ -234,7 +234,10 @@ function NewtabApp() {
                   </p>
                   {blockedInfo.wastedTime > 0 && (
                     <p className="text-danger-200 text-sm">
-                      {getMessage('wastedTime', formatTimeLocalized(blockedInfo.wastedTime))}
+                      {getMessage(
+                        'wastedTime',
+                        formatTimeLocalized(blockedInfo.wastedTime)
+                      )}
                     </p>
                   )}
                 </div>
@@ -341,7 +344,10 @@ function NewtabApp() {
                     </p>
                     {blockedInfo.wastedTime > 0 && (
                       <p className="text-danger-100 text-sm">
-                        {getMessage('wastedTime', formatTimeLocalized(blockedInfo.wastedTime))}
+                        {getMessage(
+                          'wastedTime',
+                          formatTimeLocalized(blockedInfo.wastedTime)
+                        )}
                       </p>
                     )}
                   </div>


### PR DESCRIPTION
## Summary
- ブロック中画面にそのサイトでの浪費時間を表示
- 既存のブロック回数表示と合わせて見やすくレイアウト
- `getSiteWastedTime()` 関数を追加し、waste/neutral カテゴリの閲覧時間を取得
- `formatTimeLocalized()` を使用してローカライズされた時間表記を実装
- 簡易画面（プリセットなし）とフルダッシュボード両方で対応
- 英語・日本語の翻訳メッセージを追加

## 実装詳細
- `src/lib/storage.ts`: `getSiteWastedTime()` 関数を追加
- `src/newtab.tsx`: blockedInfo の型に wastedTime を追加し、表示ロジックを更新
- `assets/_locales/*/messages.json`: wastedTime メッセージを追加

## Test plan
- [ ] ブロックリストにサイトを追加
- [ ] そのサイトを訪問してブロック中画面を表示
- [ ] ブロック回数と浪費時間が両方表示されることを確認
- [ ] 浪費時間が0の場合は表示されないことを確認
- [ ] 英語・日本語両方で正しくフォーマットされることを確認

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)