### PR TITLE
fix: 追跡しているサイトが分からない問題を改善

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2008,5 +2008,19 @@
   "scheduleBlockingNotice": {
     "message": "Blocking is only active during scheduled times. Outside of schedules, sites will not be blocked.",
     "description": "Notice shown when schedules are configured"
+  },
+  "trackedSites": {
+    "message": "Tracked Sites",
+    "description": "Tracked sites section title in blocklist tab"
+  },
+  "trackedSitesCount": {
+    "message": "$COUNT$ tracked",
+    "description": "Number of tracked sites",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -2008,5 +2008,19 @@
   "scheduleBlockingNotice": {
     "message": "スケジュール設定中は、設定された時間帯のみブロックが有効になります。スケジュール対象外の時間帯はブロックされません。",
     "description": "スケジュール設定時に表示される注意書き"
+  },
+  "trackedSites": {
+    "message": "追跡中のサイト",
+    "description": "ブロックリストタブの追跡サイトセクションタイトル"
+  },
+  "trackedSitesCount": {
+    "message": "$COUNT$ サイト追跡中",
+    "description": "追跡中のサイト数",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "5"
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "2.1.9",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.39.2",
         "eslint-config-prettier": "^10.1.8",
@@ -381,6 +382,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@chromatic-com/storybook": {
       "version": "3.2.7",
@@ -1911,6 +1919,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -8069,6 +8087,39 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
@@ -9409,82 +9460,6 @@
         "utrie": "^1.0.2"
       }
     },
-    "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-select/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/css-select/node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -9529,42 +9504,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/csso": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "css-tree": "~2.2.0"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/css-tree": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mdn-data": "2.0.28",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/csso/node_modules/mdn-data": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
-      "license": "CC0-1.0",
-      "optional": true
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -11458,6 +11397,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -12343,6 +12289,89 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -13066,6 +13095,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/make-dir": {
@@ -15948,6 +15989,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -17626,6 +17708,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/components/options/BlocklistTab.stories.tsx
+++ b/src/components/options/BlocklistTab.stories.tsx
@@ -9,6 +9,7 @@ import type {
   NotificationSettings,
   YouTubeSettings
 } from '~/types/storage';
+import { DEFAULT_UNBLOCK_HISTORY } from '~/types/storage';
 
 const mockBlockList: BlockItem[] = [
   {
@@ -134,6 +135,7 @@ const BlocklistTabWrapper = () => {
       timeLimitUsage={{}}
       youtube={settings.youtube}
       onYouTubeChange={handleYouTubeChange}
+      unblockHistory={DEFAULT_UNBLOCK_HISTORY}
     />
   );
 };
@@ -165,7 +167,8 @@ const meta = {
     siteBlockCounts: {},
     timeLimitUsage: {},
     youtube: mockSettings.youtube,
-    onYouTubeChange: () => {}
+    onYouTubeChange: () => {},
+    unblockHistory: DEFAULT_UNBLOCK_HISTORY
   }
 } satisfies Meta<typeof BlocklistTab>;
 
@@ -174,4 +177,38 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => <BlocklistTabWrapper />
+};
+
+// ストーリー: 追跡サイトがある場合
+export const WithTrackedSites: Story = {
+  args: {
+    unblockHistory: {
+      sites: {
+        'twitter.com': {
+          domain: 'twitter.com',
+          status: 'blocked',
+          blockedAt: '2026-02-10T10:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        },
+        'facebook.com': {
+          domain: 'facebook.com',
+          status: 'unblocked',
+          blockedAt: '2026-02-05T08:00:00Z',
+          unblockedAt: '2026-02-12T16:30:00Z',
+          timeAfterUnblock: 3600,
+          lastActivity: '2026-02-14T12:00:00Z'
+        },
+        'reddit.com': {
+          domain: 'reddit.com',
+          status: 'blocked',
+          blockedAt: '2026-02-08T14:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        }
+      }
+    }
+  }
 };

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -10,7 +10,8 @@ import { getMessage } from '~/lib/i18n';
 import {
   NotificationSettingsSection,
   YouTubeSection,
-  DomainListItem
+  DomainListItem,
+  TrackedSitesSection
 } from '~/components/options/blocklist';
 import type {
   AppSettings,
@@ -19,7 +20,8 @@ import type {
   TimeLimit,
   TimeLimitUsage,
   NotificationSettings,
-  YouTubeSettings
+  YouTubeSettings,
+  UnblockHistory
 } from '~/types/storage';
 
 interface BlocklistTabProps {
@@ -36,6 +38,7 @@ interface BlocklistTabProps {
   timeLimitUsage?: Record<string, TimeLimitUsage>;
   youtube: YouTubeSettings;
   onYouTubeChange: (youtube: YouTubeSettings) => void;
+  unblockHistory: UnblockHistory;
 }
 
 export function BlocklistTab({
@@ -51,7 +54,8 @@ export function BlocklistTab({
   siteBlockCounts = {},
   timeLimitUsage = {},
   youtube,
-  onYouTubeChange
+  onYouTubeChange,
+  unblockHistory
 }: BlocklistTabProps) {
   // Password protection state
   const [showPasswordModal, setShowPasswordModal] = useState(false);
@@ -163,6 +167,9 @@ export function BlocklistTab({
 
   return (
     <div className="space-y-6">
+      {/* Tracked Sites Section - 追跡中のサイト一覧 */}
+      <TrackedSitesSection unblockHistory={unblockHistory} />
+
       {/* Notification Settings - only show if time limit sites exist */}
       <NotificationSettingsSection
         notifications={settings?.notifications}

--- a/src/components/options/blocklist/TrackedSitesSection.stories.tsx
+++ b/src/components/options/blocklist/TrackedSitesSection.stories.tsx
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { TrackedSitesSection } from './TrackedSitesSection';
+
+const meta = {
+  title: 'Options/Blocklist/TrackedSitesSection',
+  component: TrackedSitesSection,
+  parameters: {
+    layout: 'padded'
+  },
+  tags: ['autodocs']
+} satisfies Meta<typeof TrackedSitesSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 追跡サイトが複数ある場合
+export const WithMultipleSites: Story = {
+  args: {
+    unblockHistory: {
+      sites: {
+        'twitter.com': {
+          domain: 'twitter.com',
+          status: 'blocked',
+          blockedAt: '2026-02-10T10:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        },
+        'facebook.com': {
+          domain: 'facebook.com',
+          status: 'unblocked',
+          blockedAt: '2026-02-05T08:00:00Z',
+          unblockedAt: '2026-02-12T16:30:00Z',
+          timeAfterUnblock: 3600,
+          lastActivity: '2026-02-14T12:00:00Z'
+        },
+        'reddit.com': {
+          domain: 'reddit.com',
+          status: 'blocked',
+          blockedAt: '2026-02-08T14:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        },
+        'youtube.com': {
+          domain: 'youtube.com',
+          status: 'unblocked',
+          blockedAt: '2026-01-15T09:00:00Z',
+          unblockedAt: '2026-02-01T18:00:00Z',
+          timeAfterUnblock: 7200,
+          lastActivity: '2026-02-15T10:30:00Z'
+        }
+      }
+    }
+  }
+};
+
+// すべてブロック中の場合
+export const AllBlocked: Story = {
+  args: {
+    unblockHistory: {
+      sites: {
+        'twitter.com': {
+          domain: 'twitter.com',
+          status: 'blocked',
+          blockedAt: '2026-02-10T10:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        },
+        'facebook.com': {
+          domain: 'facebook.com',
+          status: 'blocked',
+          blockedAt: '2026-02-12T15:00:00Z',
+          unblockedAt: null,
+          timeAfterUnblock: 0,
+          lastActivity: null
+        }
+      }
+    }
+  }
+};
+
+// すべてブロック解除済みの場合
+export const AllUnblocked: Story = {
+  args: {
+    unblockHistory: {
+      sites: {
+        'twitter.com': {
+          domain: 'twitter.com',
+          status: 'unblocked',
+          blockedAt: '2026-01-10T10:00:00Z',
+          unblockedAt: '2026-02-10T15:00:00Z',
+          timeAfterUnblock: 5400,
+          lastActivity: '2026-02-15T12:00:00Z'
+        },
+        'facebook.com': {
+          domain: 'facebook.com',
+          status: 'unblocked',
+          blockedAt: '2026-01-05T08:00:00Z',
+          unblockedAt: '2026-02-01T09:00:00Z',
+          timeAfterUnblock: 10800,
+          lastActivity: '2026-02-14T14:30:00Z'
+        }
+      }
+    }
+  }
+};
+
+// 追跡サイトがない場合（null の場合はレンダリングしない）
+export const NoTrackedSites: Story = {
+  args: {
+    unblockHistory: {
+      sites: {}
+    }
+  }
+};

--- a/src/components/options/blocklist/TrackedSitesSection.tsx
+++ b/src/components/options/blocklist/TrackedSitesSection.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Eye, Lock, Unlock } from 'lucide-react';
+
+import { Card } from '~/components/ui';
+import { getMessage } from '~/lib/i18n';
+import type { UnblockHistory } from '~/types/storage';
+
+interface TrackedSitesSectionProps {
+  unblockHistory: UnblockHistory;
+}
+
+/**
+ * 追跡中のサイト一覧を表示するセクション
+ * ブロック状態（blocked/unblocked）を分かりやすく表示する
+ */
+export function TrackedSitesSection({
+  unblockHistory
+}: TrackedSitesSectionProps) {
+  const trackedSites = Object.values(unblockHistory.sites);
+
+  // ブロック状態でソート（blocked → unblocked の順）
+  const sortedSites = trackedSites.sort((a, b) => {
+    if (a.status === b.status) {
+      // 同じ状態の場合は最新の活動順
+      const aTime = a.lastActivity || a.blockedAt;
+      const bTime = b.lastActivity || b.blockedAt;
+      return new Date(bTime).getTime() - new Date(aTime).getTime();
+    }
+    return a.status === 'blocked' ? -1 : 1;
+  });
+
+  const blockedCount = trackedSites.filter((s) => s.status === 'blocked').length;
+  const unblockedCount = trackedSites.filter(
+    (s) => s.status === 'unblocked'
+  ).length;
+
+  if (trackedSites.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+          <Eye className="w-5 h-5" />
+          {getMessage('trackedSites')}
+        </h2>
+        <div className="text-sm text-gray-500">
+          {getMessage('trackedSitesCount', String(trackedSites.length))}
+        </div>
+      </div>
+
+      <p className="text-sm text-gray-600 mb-4">
+        {getMessage('trackedSitesDescription')}
+      </p>
+
+      {/* サマリー */}
+      <div className="flex gap-4 mb-4 p-3 bg-gray-50 rounded-lg">
+        <div className="flex items-center gap-2">
+          <Lock className="w-4 h-4 text-success-600" />
+          <span className="text-sm font-medium text-gray-700">
+            {getMessage('statusBlocked')}: {blockedCount}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Unlock className="w-4 h-4 text-block-500" />
+          <span className="text-sm font-medium text-gray-700">
+            {getMessage('statusUnblocked')}: {unblockedCount}
+          </span>
+        </div>
+      </div>
+
+      {/* 追跡サイトリスト */}
+      <div className="space-y-2">
+        {sortedSites.map((site) => (
+          <div
+            key={site.domain}
+            className={`p-3 rounded-lg border ${
+              site.status === 'blocked'
+                ? 'bg-success-50 border-success-200'
+                : 'bg-block-50 border-block-200'
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                {site.status === 'blocked' ? (
+                  <Lock className="w-4 h-4 text-success-600 flex-shrink-0" />
+                ) : (
+                  <Unlock className="w-4 h-4 text-block-500 flex-shrink-0" />
+                )}
+                <span className="font-medium text-gray-900 truncate">
+                  {site.domain}
+                </span>
+              </div>
+              <span
+                className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium flex-shrink-0 ${
+                  site.status === 'blocked'
+                    ? 'bg-success-100 text-success-700'
+                    : 'bg-block-100 text-block-700'
+                }`}
+              >
+                {site.status === 'blocked'
+                  ? getMessage('statusBlocked')
+                  : getMessage('statusUnblocked')}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/options/blocklist/TrackedSitesSection.tsx
+++ b/src/components/options/blocklist/TrackedSitesSection.tsx
@@ -29,7 +29,9 @@ export function TrackedSitesSection({
     return a.status === 'blocked' ? -1 : 1;
   });
 
-  const blockedCount = trackedSites.filter((s) => s.status === 'blocked').length;
+  const blockedCount = trackedSites.filter(
+    (s) => s.status === 'blocked'
+  ).length;
   const unblockedCount = trackedSites.filter(
     (s) => s.status === 'unblocked'
   ).length;

--- a/src/components/options/blocklist/index.ts
+++ b/src/components/options/blocklist/index.ts
@@ -3,3 +3,4 @@ export { NotificationSettingsSection } from './NotificationSettingsSection';
 export { YouTubeFeatureToggle } from './YouTubeFeatureToggle';
 export { YouTubeSection } from './YouTubeSection';
 export { DomainListItem } from './DomainListItem';
+export { TrackedSitesSection } from './TrackedSitesSection';

--- a/src/options.stories.tsx
+++ b/src/options.stories.tsx
@@ -11,7 +11,7 @@ import {
   HelpTab
 } from '~/components/options';
 import type { AppSettings } from '~/types/storage';
-import { DEFAULT_SETTINGS } from '~/types/storage';
+import { DEFAULT_SETTINGS, DEFAULT_UNBLOCK_HISTORY } from '~/types/storage';
 
 import './styles/globals.css';
 
@@ -44,6 +44,7 @@ function OptionsDemo() {
             onUpdateNotifications={() => {}}
             youtube={settings.youtube}
             onYouTubeChange={() => {}}
+            unblockHistory={DEFAULT_UNBLOCK_HISTORY}
           />
         );
       case 'schedules':

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -235,6 +235,7 @@ function OptionsApp() {
             timeLimitUsage={analytics.analyticsData.timeLimitUsage}
             youtube={settings?.youtube ?? DEFAULT_YOUTUBE_SETTINGS}
             onYouTubeChange={handleYouTubeChange}
+            unblockHistory={analytics.unblockHistory}
           />
         )}
 


### PR DESCRIPTION
## Summary
- BlockList タブに追跡中のサイト一覧セクションを追加
- 各サイトのブロック状態（blocked/unblocked）を明確に表示
- サマリーでブロック中・解除済みサイト数を表示

## 実装内容
- 追跡サイト一覧コンポーネント `TrackedSitesSection` を実装
- i18n メッセージ追加（`trackedSites`, `trackedSitesCount`）
- `BlocklistTab` に `unblockHistory` プロパティを追加
- Storybook ストーリー追加（`WithTrackedSites`, 各種状態のストーリー）

## Test plan
- [x] TypeScript 型チェック通過
- [x] ESLint チェック通過（警告のみ）
- [x] テスト実行（589 tests passed）
- [x] ビルド成功
- [ ] 手動テスト: BlockList タブで追跡サイト一覧が表示される
- [ ] 手動テスト: ブロック中/解除済みのサイトが正しく表示される
- [ ] 手動テスト: サマリーのカウントが正しい

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)