### PR TITLE
feat: 分析画面のリデザイン（追跡サイト一覧・節約時間削除・浪費時間追加）

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1183,6 +1183,38 @@
     "message": "Add Tracking Site",
     "description": "Add site to track heading"
   },
+  "trackedSitesList": {
+    "message": "Tracked Sites",
+    "description": "Tracked sites list section title"
+  },
+  "trackedSitesListDescription": {
+    "message": "List of sites currently being tracked.",
+    "description": "Tracked sites list section description"
+  },
+  "noTrackedSites": {
+    "message": "No tracked sites",
+    "description": "No tracked sites title"
+  },
+  "noTrackedSitesDescription": {
+    "message": "Add sites to track their blocking status and usage time.",
+    "description": "No tracked sites description"
+  },
+  "wastedTime": {
+    "message": "Wasted Time",
+    "description": "Wasted time label"
+  },
+  "wastedTimeSite": {
+    "message": "Wasted Time by Site",
+    "description": "Wasted time by site section title"
+  },
+  "totalWastedTime": {
+    "message": "Total Wasted Time",
+    "description": "Total wasted time label"
+  },
+  "wastedTimeDescription": {
+    "message": "Time spent browsing beyond daily limit (or within limit)",
+    "description": "Wasted time description"
+  },
   "trackSitePlaceholder": {
     "message": "example.com",
     "description": "Track site input placeholder"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1183,6 +1183,38 @@
     "message": "追跡サイトを追加",
     "description": "追跡サイト追加見出し"
   },
+  "trackedSitesList": {
+    "message": "追跡中のサイト",
+    "description": "追跡中サイト一覧セクションタイトル"
+  },
+  "trackedSitesListDescription": {
+    "message": "現在追跡しているサイトの一覧です。",
+    "description": "追跡中サイト一覧セクション説明"
+  },
+  "noTrackedSites": {
+    "message": "追跡中のサイトはありません",
+    "description": "追跡中サイトなしタイトル"
+  },
+  "noTrackedSitesDescription": {
+    "message": "サイトを追加して、ブロック状況や利用時間を追跡しましょう。",
+    "description": "追跡中サイトなし説明"
+  },
+  "wastedTime": {
+    "message": "浪費時間",
+    "description": "浪費時間ラベル"
+  },
+  "wastedTimeSite": {
+    "message": "サイト別浪費時間",
+    "description": "サイト別浪費時間セクションタイトル"
+  },
+  "totalWastedTime": {
+    "message": "合計浪費時間",
+    "description": "合計浪費時間ラベル"
+  },
+  "wastedTimeDescription": {
+    "message": "1日の制限を超えて閲覧した時間（または制限内での閲覧時間）",
+    "description": "浪費時間の説明"
+  },
   "trackSitePlaceholder": {
     "message": "example.com",
     "description": "追跡サイト入力プレースホルダー"

--- a/src/components/options/AnalyticsTab.stories.tsx
+++ b/src/components/options/AnalyticsTab.stories.tsx
@@ -8,6 +8,14 @@ import { DEFAULT_SETTINGS } from '~/types/storage';
 
 const mockUnblockHistory: UnblockHistory = {
   sites: {
+    'reddit.com': {
+      domain: 'reddit.com',
+      status: 'blocked',
+      blockedAt: '2026-02-12T09:00:00Z',
+      unblockedAt: null,
+      timeAfterUnblock: 0,
+      lastActivity: null
+    },
     'twitter.com': {
       domain: 'twitter.com',
       status: 'unblocked',
@@ -23,6 +31,14 @@ const mockUnblockHistory: UnblockHistory = {
       unblockedAt: '2026-02-11T14:30:00Z',
       timeAfterUnblock: 2400,
       lastActivity: '2026-02-15T12:00:00Z'
+    },
+    'facebook.com': {
+      domain: 'facebook.com',
+      status: 'blocked',
+      blockedAt: '2026-02-14T15:00:00Z',
+      unblockedAt: null,
+      timeAfterUnblock: 0,
+      lastActivity: null
     }
   }
 };

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo } from 'react';
-import {
-  Clock,
-  Lock,
-  RefreshCw,
-  EyeOff,
-  List
-} from 'lucide-react';
+import { Clock, Lock, RefreshCw, EyeOff, List } from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
 import { UpgradePrompt } from '~/components/features';

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -2,10 +2,10 @@ import React, { useMemo } from 'react';
 import {
   AlertTriangle,
   Clock,
-  Info,
   Lock,
   RefreshCw,
-  EyeOff
+  EyeOff,
+  List
 } from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
@@ -49,23 +49,27 @@ export function AnalyticsSummary({
   onReblock,
   onStopTracking
 }: AnalyticsSummaryProps) {
-  const { blockedSites, unblockedSites } = useMemo(() => {
+  // 全追跡サイト（ブロック中・解除済み両方）
+  const allTrackedSites = useMemo(() => {
     const allSites = Object.values(unblockHistory.sites);
-    const blocked = allSites
-      .filter((s) => s.status === 'blocked')
-      .sort(
-        (a, b) =>
-          new Date(b.blockedAt).getTime() - new Date(a.blockedAt).getTime()
-      );
-    const unblocked = allSites
-      .filter((s) => s.status === 'unblocked')
-      .sort((a, b) => b.timeAfterUnblock - a.timeAfterUnblock);
-    return { blockedSites: blocked, unblockedSites: unblocked };
+    return allSites.sort((a, b) => {
+      // ブロック中を先に、その後解除済み
+      if (a.status === 'blocked' && b.status !== 'blocked') return -1;
+      if (a.status !== 'blocked' && b.status === 'blocked') return 1;
+      // 同じステータス内では最近のものを先に
+      return new Date(b.blockedAt).getTime() - new Date(a.blockedAt).getTime();
+    });
   }, [unblockHistory.sites]);
 
-  const hasTrackedSites = blockedSites.length > 0 || unblockedSites.length > 0;
+  // 解除済みサイトのリスト（浪費時間表示用）
+  const unblockedSites = useMemo(() => {
+    return allTrackedSites.filter((s) => s.status === 'unblocked');
+  }, [allTrackedSites]);
 
-  const totalTimeSpent = useMemo(() => {
+  const hasTrackedSites = allTrackedSites.length > 0;
+
+  // 合計浪費時間（解除済みサイトの閲覧時間の合計）
+  const totalWastedTime = useMemo(() => {
     return unblockedSites.reduce((sum, site) => sum + site.timeAfterUnblock, 0);
   }, [unblockedSites]);
 
@@ -75,44 +79,32 @@ export function AnalyticsSummary({
       {!hasTrackedSites && (
         <Card>
           <div className="text-center py-12">
-            <div className="w-16 h-16 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-3xl">&#10003;</span>
+            <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+              <List className="w-8 h-8 text-gray-400" />
             </div>
             <h3 className="text-lg font-medium text-gray-900 mb-2">
-              {getMessage('noUnblockedSites')}
+              {getMessage('noTrackedSites')}
             </h3>
             <p className="text-sm text-gray-500">
-              {getMessage('noUnblockedSitesDescription')}
+              {getMessage('noTrackedSitesDescription')}
             </p>
           </div>
         </Card>
       )}
 
-      {/* Blocked Sites List */}
-      {blockedSites.length > 0 && (
+      {/* 追跡中のサイト一覧 */}
+      {hasTrackedSites && (
         <Card>
           <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <Lock className="w-4 h-4 text-success-600" />
-            {getMessage('statusBlocked')} ({blockedSites.length})
+            <List className="w-4 h-4 text-gray-600" />
+            {getMessage('trackedSitesList')} ({allTrackedSites.length})
           </h3>
+          <p className="text-xs text-gray-500 mb-4">
+            {getMessage('trackedSitesListDescription')}
+          </p>
           <div className="space-y-3">
-            {blockedSites.map((site) => (
-              <BlockedSiteItem key={site.domain} site={site} />
-            ))}
-          </div>
-        </Card>
-      )}
-
-      {/* Unblocked Sites List */}
-      {unblockedSites.length > 0 && (
-        <Card>
-          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-block-500" />
-            {getMessage('statusUnblocked')} ({unblockedSites.length})
-          </h3>
-          <div className="space-y-3">
-            {unblockedSites.map((site) => (
-              <UnblockedSiteItem
+            {allTrackedSites.map((site) => (
+              <TrackedSiteItem
                 key={site.domain}
                 site={site}
                 isPremium={isPremium}
@@ -120,16 +112,38 @@ export function AnalyticsSummary({
                 onStopTracking={onStopTracking}
               />
             ))}
+          </div>
+        </Card>
+      )}
 
-            {/* Total time (Premium only) */}
+      {/* 浪費時間セクション */}
+      {unblockedSites.length > 0 && (
+        <Card>
+          <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+            <Clock className="w-4 h-4 text-block-500" />
+            {getMessage('wastedTimeSite')}
+          </h3>
+          <p className="text-xs text-gray-500 mb-4">
+            {getMessage('wastedTimeDescription')}
+          </p>
+          <div className="space-y-3">
+            {unblockedSites.map((site) => (
+              <WastedTimeItem
+                key={site.domain}
+                site={site}
+                isPremium={isPremium}
+              />
+            ))}
+
+            {/* 合計浪費時間 (Premium only) */}
             {isPremium && unblockedSites.length > 1 && (
               <div className="pt-4 border-t border-block-200">
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-gray-700">
-                    {getMessage('totalTimeOnUnblockedSites')}
+                    {getMessage('totalWastedTime')}
                   </span>
                   <span className="text-lg font-bold text-block-600">
-                    {formatTime(totalTimeSpent)}
+                    {formatTime(totalWastedTime)}
                   </span>
                 </div>
               </div>
@@ -155,116 +169,108 @@ export function AnalyticsSummary({
   );
 }
 
-function BlockedSiteItem({ site }: { site: TrackedSite }) {
-  return (
-    <div className="p-3 bg-success-50 rounded-lg border border-success-100">
-      <div className="flex items-center justify-between">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-success-500 rounded-full" />
-            <span className="font-medium text-gray-900 truncate">
-              {site.domain}
-            </span>
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success-100 text-success-700">
-              {getMessage('statusBlocked')}
-            </span>
-          </div>
-          <p className="text-sm text-gray-500 mt-1">
-            {getMessage('blockedSince')}: {formatRelativeTime(site.blockedAt)}
-          </p>
-        </div>
-        <div className="text-right">
-          <span className="text-lg font-bold text-success-600">
-            0{getMessage('time') === 'Time' ? 'm' : '\u5206'}
-          </span>
-          <p className="text-xs text-gray-500 inline-flex items-center gap-1">
-            {getMessage('timeSaved')}
-            <button
-              type="button"
-              className="inline-flex text-gray-400 hover:text-gray-600"
-              title={getMessage('timeSavedTooltip')}
-              aria-label={getMessage('timeSavedTooltip')}
-            >
-              <Info className="w-3 h-3" />
-            </button>
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface UnblockedSiteItemProps {
+// 追跡中サイトのアイテム表示（ステータス表示のみ）
+interface TrackedSiteItemProps {
   site: TrackedSite;
   isPremium: boolean;
   onReblock: (domain: string) => void;
   onStopTracking: (domain: string) => void;
 }
 
-function UnblockedSiteItem({
+function TrackedSiteItem({
   site,
   isPremium,
   onReblock,
   onStopTracking
-}: UnblockedSiteItemProps) {
+}: TrackedSiteItemProps) {
+  const isBlocked = site.status === 'blocked';
+  const bgColor = isBlocked ? 'bg-success-50' : 'bg-gray-50';
+  const borderColor = isBlocked ? 'border-success-100' : 'border-gray-200';
+  const dotColor = isBlocked ? 'bg-success-500' : 'bg-gray-400';
+  const statusBgColor = isBlocked ? 'bg-success-100' : 'bg-gray-100';
+  const statusTextColor = isBlocked ? 'text-success-700' : 'text-gray-700';
+
   return (
-    <div className="p-4 bg-block-50 rounded-lg border border-block-100">
+    <div className={`p-3 ${bgColor} rounded-lg border ${borderColor}`}>
       <div className="flex items-start justify-between">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 bg-block-500 rounded-full" />
+            <div className={`w-2 h-2 ${dotColor} rounded-full`} />
             <span className="font-medium text-gray-900 truncate">
               {site.domain}
             </span>
-            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-block-100 text-block-700">
-              {getMessage('statusUnblocked')}
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${statusBgColor} ${statusTextColor}`}
+            >
+              {getMessage(isBlocked ? 'statusBlocked' : 'statusUnblocked')}
             </span>
           </div>
-
           <p className="text-sm text-gray-500 mt-1">
-            {getMessage('unblockedOn')}:{' '}
-            {site.unblockedAt ? formatRelativeTime(site.unblockedAt) : '-'}
+            {getMessage('blockedSince')}: {formatRelativeTime(site.blockedAt)}
           </p>
-
-          <div className="flex items-center gap-2 mt-2">
-            <Clock className="w-4 h-4 text-gray-400" />
-            {isPremium ? (
-              <span className="text-sm font-medium text-block-600">
-                {getMessage('timeSpentSinceUnblock')}:{' '}
-                {formatTime(site.timeAfterUnblock)}
-              </span>
-            ) : (
-              <span className="text-sm text-gray-400 flex items-center gap-1">
-                {getMessage('timeSpentSinceUnblock')}:{' '}
-                <span className="tracking-widest">******</span>
-                <Lock className="w-3 h-3" />
-              </span>
-            )}
-          </div>
+          {!isBlocked && site.unblockedAt && (
+            <p className="text-sm text-gray-500">
+              {getMessage('unblockedOn')}:{' '}
+              {formatRelativeTime(site.unblockedAt)}
+            </p>
+          )}
         </div>
 
-        {/* Action buttons */}
-        <div className="flex items-center gap-2">
-          {isPremium && (
+        {/* アクションボタン（解除済みサイトのみ） */}
+        {!isBlocked && (
+          <div className="flex items-center gap-2">
+            {isPremium && (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => onReblock(site.domain)}
+                className="flex items-center gap-1.5"
+              >
+                <RefreshCw className="w-4 h-4" />
+                {getMessage('reblock')}
+              </Button>
+            )}
             <Button
-              variant="secondary"
+              variant="ghost"
               size="sm"
-              onClick={() => onReblock(site.domain)}
-              className="flex items-center gap-1.5"
+              onClick={() => onStopTracking(site.domain)}
+              className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700"
             >
-              <RefreshCw className="w-4 h-4" />
-              {getMessage('reblock')}
+              <EyeOff className="w-4 h-4" />
+              {getMessage('stopTracking')}
             </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// 浪費時間表示アイテム（解除済みサイトのみ）
+interface WastedTimeItemProps {
+  site: TrackedSite;
+  isPremium: boolean;
+}
+
+function WastedTimeItem({ site, isPremium }: WastedTimeItemProps) {
+  return (
+    <div className="p-3 bg-block-50 rounded-lg border border-block-100">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-2 h-2 bg-block-500 rounded-full" />
+          <span className="font-medium text-gray-900">{site.domain}</span>
+        </div>
+        <div className="text-right">
+          {isPremium ? (
+            <span className="text-lg font-bold text-block-600">
+              {formatTime(site.timeAfterUnblock)}
+            </span>
+          ) : (
+            <span className="text-sm text-gray-400 flex items-center gap-1">
+              <span className="tracking-widest">******</span>
+              <Lock className="w-3 h-3" />
+            </span>
           )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => onStopTracking(site.domain)}
-            className="flex items-center gap-1.5 text-gray-500 hover:text-gray-700"
-          >
-            <EyeOff className="w-4 h-4" />
-            {getMessage('stopTracking')}
-          </Button>
         </div>
       </div>
     </div>

--- a/src/components/options/analytics/AnalyticsSummary.tsx
+++ b/src/components/options/analytics/AnalyticsSummary.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import {
-  AlertTriangle,
   Clock,
   Lock,
   RefreshCw,

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -155,16 +155,19 @@ export const SELECTORS = {
   // Options - Analytics Tab
   analytics: {
     siteRankingList:
-      'h3:has-text("Site Ranking"), h3:has-text("サイトランキング")',
+      'h3:has-text("よくブロックしたサイト"), h3:has-text("Top Blocked Sites")',
+    trackedSitesList:
+      'h3:has-text("追跡中のサイト"), h3:has-text("Tracked Sites")',
     unblockHistory: 'h3:has-text("Unblock History"), h3:has-text("解除履歴")',
+    wastedTimeSection:
+      'h3:has-text("サイト別浪費時間"), h3:has-text("Wasted Time by Site")',
     exportButton: 'button:has-text("CSV"), button:has-text("Export")',
     refreshButton: 'button:has-text("更新"), button:has-text("Refresh")',
     resetButton: 'button:has-text("リセット"), button:has-text("Reset")',
     reblockButton: 'button:has-text("再ブロック"), button:has-text("Re-block")',
     stopTrackingButton:
-      'button:has-text("停止"), button:has-text("Stop Tracking")',
-    addSiteInput:
-      'input[placeholder*="ドメイン"], input[placeholder*="domain"]',
+      'button:has-text("追跡を停止"), button:has-text("Stop tracking")',
+    addSiteInput: 'input[placeholder*="example.com"]',
     addSiteButton: 'button:has-text("追加"), button:has-text("Add")'
   },
 

--- a/tests/e2e/options-analytics.spec.ts
+++ b/tests/e2e/options-analytics.spec.ts
@@ -68,7 +68,7 @@ test.describe('Options - Analytics Tab', () => {
     await page.close();
   });
 
-  test('OPT-A03: Unblock History（ブロック解除サイト）が表示される', async ({
+  test('OPT-A03: 追跡中のサイト一覧が表示される', async ({
     context,
     extensionId
   }) => {
@@ -90,9 +90,9 @@ test.describe('Options - Analytics Tab', () => {
 
     const page = await openOptions(context, extensionId, 'analytics');
 
-    // Unblock Historyセクションが表示される
+    // 追跡中のサイト一覧セクションが表示される
     await expect(
-      page.locator(SELECTORS.analytics.unblockHistory)
+      page.locator(SELECTORS.analytics.trackedSitesList)
     ).toBeVisible();
 
     // youtube.com が表示される
@@ -101,7 +101,7 @@ test.describe('Options - Analytics Tab', () => {
     await page.close();
   });
 
-  test('OPT-A04: ブロック解除サイトの滞在時間が表示される', async ({
+  test('OPT-A04: 浪費時間セクションにサイト別の時間が表示される', async ({
     context,
     extensionId
   }) => {
@@ -123,9 +123,9 @@ test.describe('Options - Analytics Tab', () => {
 
     const page = await openOptions(context, extensionId, 'analytics');
 
-    // Unblock Historyセクションが表示される
+    // 追跡中のサイト一覧セクションが表示される
     await expect(
-      page.locator(SELECTORS.analytics.unblockHistory)
+      page.locator(SELECTORS.analytics.trackedSitesList)
     ).toBeVisible();
 
     // reddit.com が表示される


### PR DESCRIPTION
## Summary
- 「ブロック中」セクションを削除し、「追跡中のサイト一覧」セクションを追加
  - ブロック中・解除済み両方のサイトを一覧で表示
  - ステータスバッジで状態を識別
- 「節約した時間」の表示・計算ロジックを完全に削除
- 「浪費時間」セクションを追加
  - 解除済みサイトの閲覧時間をサイト別に表示
  - 合計浪費時間の表示（Premium ユーザーのみ）

## 変更内容

### UI/UX
- `AnalyticsSummary.tsx` の全面リデザイン
  - `BlockedSiteItem` コンポーネントを削除
  - `TrackedSiteItem` コンポーネントを追加（ステータス表示）
  - `WastedTimeItem` コンポーネントを追加（浪費時間表示）
- 追跡サイト一覧でブロック中・解除済みを区別して表示
- 解除済みサイトのアクションボタン（再ブロック・追跡停止）を維持

### i18n
- 日本語・英語メッセージファイルに新規キー追加
  - `trackedSitesList`: 追跡中のサイト
  - `wastedTimeSite`: サイト別浪費時間
  - `totalWastedTime`: 合計浪費時間
  - `wastedTimeDescription`: 浪費時間の説明

### テスト
- E2E テストのセレクタ更新（`constants.ts`）
  - `trackedSitesList` セレクタを追加
  - `wastedTimeSection` セレクタを追加
- テストケース名を更新（`options-analytics.spec.ts`）

## Test plan
- [ ] Storybook で AnalyticsTab の各ストーリーを確認
  - [ ] FreeTier: 浪費時間がマスクされる
  - [ ] Premium: 浪費時間が表示される
  - [ ] Empty: 空の状態メッセージが表示される
- [ ] ブラウザで実際の分析画面を確認
  - [ ] 追跡中のサイト一覧が表示される
  - [ ] ブロック中のサイトにステータスバッジが表示される
  - [ ] 浪費時間セクションが表示される
  - [ ] 「節約した時間」が表示されない
- [ ] E2E テストが通る
  - [ ] `npm run test:e2e tests/e2e/options-analytics.spec.ts`

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)