### PR TITLE
refactor: ブロックリストタブから追跡中サイト一覧を削除

### DIFF
--- a/src/components/options/BlocklistTab.stories.tsx
+++ b/src/components/options/BlocklistTab.stories.tsx
@@ -9,7 +9,6 @@ import type {
   NotificationSettings,
   YouTubeSettings
 } from '~/types/storage';
-import { DEFAULT_UNBLOCK_HISTORY } from '~/types/storage';
 
 const mockBlockList: BlockItem[] = [
   {
@@ -135,7 +134,6 @@ const BlocklistTabWrapper = () => {
       timeLimitUsage={{}}
       youtube={settings.youtube}
       onYouTubeChange={handleYouTubeChange}
-      unblockHistory={DEFAULT_UNBLOCK_HISTORY}
     />
   );
 };
@@ -167,8 +165,7 @@ const meta = {
     siteBlockCounts: {},
     timeLimitUsage: {},
     youtube: mockSettings.youtube,
-    onYouTubeChange: () => {},
-    unblockHistory: DEFAULT_UNBLOCK_HISTORY
+    onYouTubeChange: () => {}
   }
 } satisfies Meta<typeof BlocklistTab>;
 
@@ -177,38 +174,4 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => <BlocklistTabWrapper />
-};
-
-// ストーリー: 追跡サイトがある場合
-export const WithTrackedSites: Story = {
-  args: {
-    unblockHistory: {
-      sites: {
-        'twitter.com': {
-          domain: 'twitter.com',
-          status: 'blocked',
-          blockedAt: '2026-02-10T10:00:00Z',
-          unblockedAt: null,
-          timeAfterUnblock: 0,
-          lastActivity: null
-        },
-        'facebook.com': {
-          domain: 'facebook.com',
-          status: 'unblocked',
-          blockedAt: '2026-02-05T08:00:00Z',
-          unblockedAt: '2026-02-12T16:30:00Z',
-          timeAfterUnblock: 3600,
-          lastActivity: '2026-02-14T12:00:00Z'
-        },
-        'reddit.com': {
-          domain: 'reddit.com',
-          status: 'blocked',
-          blockedAt: '2026-02-08T14:00:00Z',
-          unblockedAt: null,
-          timeAfterUnblock: 0,
-          lastActivity: null
-        }
-      }
-    }
-  }
 };

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -10,8 +10,7 @@ import { getMessage } from '~/lib/i18n';
 import {
   NotificationSettingsSection,
   YouTubeSection,
-  DomainListItem,
-  TrackedSitesSection
+  DomainListItem
 } from '~/components/options/blocklist';
 import type {
   AppSettings,
@@ -20,8 +19,7 @@ import type {
   TimeLimit,
   TimeLimitUsage,
   NotificationSettings,
-  YouTubeSettings,
-  UnblockHistory
+  YouTubeSettings
 } from '~/types/storage';
 
 interface BlocklistTabProps {
@@ -38,7 +36,6 @@ interface BlocklistTabProps {
   timeLimitUsage?: Record<string, TimeLimitUsage>;
   youtube: YouTubeSettings;
   onYouTubeChange: (youtube: YouTubeSettings) => void;
-  unblockHistory: UnblockHistory;
 }
 
 export function BlocklistTab({
@@ -54,8 +51,7 @@ export function BlocklistTab({
   siteBlockCounts = {},
   timeLimitUsage = {},
   youtube,
-  onYouTubeChange,
-  unblockHistory
+  onYouTubeChange
 }: BlocklistTabProps) {
   // Password protection state
   const [showPasswordModal, setShowPasswordModal] = useState(false);
@@ -167,9 +163,6 @@ export function BlocklistTab({
 
   return (
     <div className="space-y-6">
-      {/* Tracked Sites Section - 追跡中のサイト一覧 */}
-      <TrackedSitesSection unblockHistory={unblockHistory} />
-
       {/* Notification Settings - only show if time limit sites exist */}
       <NotificationSettingsSection
         notifications={settings?.notifications}

--- a/src/options.stories.tsx
+++ b/src/options.stories.tsx
@@ -11,7 +11,7 @@ import {
   HelpTab
 } from '~/components/options';
 import type { AppSettings } from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_UNBLOCK_HISTORY } from '~/types/storage';
+import { DEFAULT_SETTINGS } from '~/types/storage';
 
 import './styles/globals.css';
 
@@ -44,7 +44,6 @@ function OptionsDemo() {
             onUpdateNotifications={() => {}}
             youtube={settings.youtube}
             onYouTubeChange={() => {}}
-            unblockHistory={DEFAULT_UNBLOCK_HISTORY}
           />
         );
       case 'schedules':

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -235,7 +235,6 @@ function OptionsApp() {
             timeLimitUsage={analytics.analyticsData.timeLimitUsage}
             youtube={settings?.youtube ?? DEFAULT_YOUTUBE_SETTINGS}
             onYouTubeChange={handleYouTubeChange}
-            unblockHistory={analytics.unblockHistory}
           />
         )}
 


### PR DESCRIPTION
## 概要

ブロックリストタブに表示されていた「追跡中のサイト」セクションを削除しました。追跡中のサイトは分析タブでのみ表示されるようになります。

Closes #228

## 変更内容

### 削除
- `BlocklistTab` コンポーネントから `TrackedSitesSection` の使用を削除
- `unblockHistory` プロパティを削除（このプロパティは分析タブでのみ必要）

### 更新
- `BlocklistTab.tsx`: インポートとコンポーネント呼び出しを削除
- `BlocklistTab.stories.tsx`: 不要なプロパティとストーリーを削除
- `options.tsx`: `BlocklistTab` への `unblockHistory` プロパティ渡しを削除

### 保持
- `TrackedSitesSection` コンポーネント自体は保持（分析タブの `AnalyticsSummary` で使用中）

## 理由

追跡中のサイト一覧はブロックリスト管理とは別の関心事であり、分析機能の一部です。分析タブに既に追跡中サイトの情報が表示されているため、ブロックリストタブでは冗長でした。

## テスト

- [ ] ブロックリストタブに追跡中サイトセクションが表示されないことを確認
- [ ] 分析タブで追跡中サイト一覧が正常に表示されることを確認
- [ ] ブロックリストタブの他の機能（ドメイン追加・削除・有効/無効切替）が正常に動作することを確認

## スクリーンショット

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)