### PR TITLE
fix: ブロック解除後に追跡サイトのステータスがリアルタイム更新されない

### DIFF
--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -61,6 +61,32 @@ export function useAnalytics({
     reloadAnalyticsData();
   }, [reloadAnalyticsData]);
 
+  // Listen for storage changes to unblockHistory and analytics
+  // This ensures UI updates when background scripts modify the data
+  useEffect(() => {
+    // Check if chrome.storage is available (not in test environment)
+    if (typeof chrome === 'undefined' || !chrome?.storage?.local) {
+      return;
+    }
+
+    const handleStorageChange = (
+      changes: Record<string, chrome.storage.StorageChange>
+    ) => {
+      // Check if unblockHistory or analytics changed
+      if (changes.unblockHistory || changes.analytics) {
+        reloadAnalyticsData();
+      }
+    };
+
+    // Add listener for local storage changes
+    chrome.storage.local.onChanged.addListener(handleStorageChange);
+
+    // Cleanup listener on unmount
+    return () => {
+      chrome.storage.local.onChanged.removeListener(handleStorageChange);
+    };
+  }, [reloadAnalyticsData]);
+
   // Re-block handler
   const handleReblock = useCallback(
     async (domain: string) => {


### PR DESCRIPTION
## Summary

- ブロック解除操作後に追跡サイトのステータスがリアルタイムで更新されるよう修正
- Chrome Storage の変更リスナーを useAnalytics フックに追加
- バックグラウンドスクリプトが unblockHistory を更新した際に、AnalyticsTab が自動的に最新データを再読み込みする

## Changes

- `src/hooks/useAnalytics.ts`
  - `chrome.storage.local.onChanged` リスナーを追加
  - `unblockHistory` または `analytics` の変更を検知して `reloadAnalyticsData()` を実行
  - テスト環境で `chrome` オブジェクトが未定義の場合の対応を追加

## Test plan

- [x] ユニットテスト実行 (`npm test`) - 全テスト通過
- [x] ビルド確認 (`npm run build`) - 成功
- [x] Lint 実行 (`npm run lint`) - エラーなし
- [ ] 手動テスト: ブロックリストタブでサイトのブロックを解除後、分析タブでステータスが即座に更新されることを確認

## Related Issue

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)