### PR TITLE
feat: ダッシュボードヘッダーにロゴとテキストを表示

### DIFF
--- a/src/options.tsx
+++ b/src/options.tsx
@@ -195,9 +195,16 @@ function OptionsApp() {
       {/* Header */}
       <header className="bg-white border-b border-gray-200">
         <div className="max-w-6xl mx-auto px-6 py-4">
-          <h1 className="text-2xl font-bold text-gray-900">
-            {getMessage('settingsTitle')}
-          </h1>
+          <div className="flex items-center gap-3">
+            <img
+              src="/assets/images/logo.png"
+              alt="VisionFocus Logo"
+              className="h-8 w-8 object-contain"
+            />
+            <h1 className="text-2xl font-bold text-gray-900">
+              {getMessage('settingsTitle')}
+            </h1>
+          </div>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary

ダッシュボード（Options ページ）のヘッダーにVisionFocusロゴを追加し、「VisionFocus Dashboard」テキストと並べて表示することで、ブランド認知を向上させました。

### 変更内容

- ヘッダーに `/assets/images/logo.png` を表示（8x8サイズ、object-contain）
- ロゴとテキストを横並びに配置（flex, items-center, gap-3）
- レスポンシブ対応を維持
- 既存のTailwind CSSスタイルに準拠

## Test plan

- [ ] Options ページを開く（chrome://extensions → VisionFocus → Options）
- [ ] ヘッダーにロゴ画像が表示されることを確認
- [ ] ロゴの横に「VisionFocus Dashboard」テキストが表示されることを確認
- [ ] ロゴとテキストが適切に配置されていることを確認
- [ ] レスポンシブデザインが機能することを確認

## CI Status

- ✅ Lint: 通過（pre-existing warningsのみ）
- ✅ Build: 通過
- ✅ Tests: 全593テスト通過

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)