### PR TITLE
feat: ダッシュボード（Options）に言語切り替え機能を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -2068,5 +2068,21 @@
         "example": "5"
       }
     }
+  },
+  "languageSettingsTitle": {
+    "message": "Language Settings",
+    "description": "Language settings section title"
+  },
+  "languageSettingsDescription": {
+    "message": "Change dashboard display language",
+    "description": "Language settings section description"
+  },
+  "languageLabel": {
+    "message": "Display Language",
+    "description": "Language selection label"
+  },
+  "languageSelectDescription": {
+    "message": "Select the language for the dashboard",
+    "description": "Language selection description"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -2068,5 +2068,21 @@
         "example": "5"
       }
     }
+  },
+  "languageSettingsTitle": {
+    "message": "言語設定",
+    "description": "言語設定セクションのタイトル"
+  },
+  "languageSettingsDescription": {
+    "message": "ダッシュボードの表示言語を変更",
+    "description": "言語設定セクションの説明"
+  },
+  "languageLabel": {
+    "message": "表示言語",
+    "description": "言語選択のラベル"
+  },
+  "languageSelectDescription": {
+    "message": "ダッシュボードの表示言語を選択してください",
+    "description": "言語選択の説明"
   }
 }

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -15,7 +15,8 @@ import {
   Shield,
   Clock,
   Calendar,
-  BarChart2
+  BarChart2,
+  Globe
 } from 'lucide-react';
 
 import { Button, Card, Toggle } from '~/components/ui';
@@ -24,7 +25,7 @@ import {
   EXPORT_STATUS_DELAY_MS,
   SHARE_MESSAGE_DELAY_MS
 } from '~/constants/intervals';
-import { getMessage } from '~/lib/i18n';
+import { getMessage, getSupportedLanguages } from '~/lib/i18n';
 import {
   exportSettings,
   downloadSettings,
@@ -36,7 +37,8 @@ import { getSettings, getVision, setSettings, setVision } from '~/lib/storage';
 import type {
   PasswordSettings,
   AppSettings,
-  AnalyticsOptIn
+  AnalyticsOptIn,
+  SupportedLanguage
 } from '~/types/storage';
 import { DEFAULT_PASSWORD_SETTINGS } from '~/types/storage';
 
@@ -47,13 +49,15 @@ interface HelpTabProps {
   settings?: AppSettings;
   onPasswordUpdate?: (settings: PasswordSettings) => Promise<void>;
   onAnalyticsOptInChange?: (optIn: AnalyticsOptIn) => Promise<void>;
+  onLanguageChange?: (language: SupportedLanguage | null) => Promise<void>;
 }
 
 export function HelpTab({
   onSettingsChange,
   settings,
   onPasswordUpdate,
-  onAnalyticsOptInChange
+  onAnalyticsOptInChange,
+  onLanguageChange
 }: HelpTabProps) {
   const [exportStatus, setExportStatus] = useState<
     'idle' | 'loading' | 'success' | 'error'
@@ -354,6 +358,54 @@ export function HelpTab({
           ))}
         </div>
       </Card>
+
+      {/* Language Settings */}
+      {onLanguageChange && (
+        <Card>
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-10 h-10 bg-info-100 rounded-lg flex items-center justify-center">
+              <Globe className="w-5 h-5 text-info-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">
+                {getMessage('languageSettingsTitle')}
+              </h2>
+              <p className="text-sm text-gray-500">
+                {getMessage('languageSettingsDescription')}
+              </p>
+            </div>
+          </div>
+
+          <div className="p-4 bg-gray-50 rounded-lg">
+            <div className="space-y-3">
+              <label className="block">
+                <span className="text-sm font-medium text-gray-700 mb-2 block">
+                  {getMessage('languageLabel')}
+                </span>
+                <select
+                  value={settings?.language ?? ''}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    onLanguageChange(
+                      value === '' ? null : (value as SupportedLanguage)
+                    );
+                  }}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                >
+                  <option value="">
+                    {getMessage('languageSelectDescription')}
+                  </option>
+                  {getSupportedLanguages().map((lang) => (
+                    <option key={lang.code} value={lang.code}>
+                      {lang.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </div>
+        </Card>
+      )}
 
       {/* Password Protection */}
       {onPasswordUpdate && (

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -156,6 +156,14 @@ function OptionsApp() {
     setSettings(updated);
   };
 
+  // Language change handler
+  const handleLanguageChange = async (language: 'en' | 'ja' | null) => {
+    if (!settings) return;
+    const updated = { ...settings, language };
+    await storage.set('settings', updated);
+    setSettings(updated);
+  };
+
   // Tabs configuration (using TABS constant for type safety)
   const tabs: Array<{ id: TabName; label: string; icon: React.ReactNode }> = [
     {
@@ -297,6 +305,7 @@ function OptionsApp() {
               await analytics.reloadAnalyticsData();
             }}
             onPasswordUpdate={handlePasswordUpdate}
+            onLanguageChange={handleLanguageChange}
           />
         )}
       </main>


### PR DESCRIPTION
## 概要

ダッシュボード（Options → Help タブ）に言語切り替え機能を追加しました。

## 変更内容

- HelpTab に言語設定セクションを追加（Globe アイコン）
- 日本語 / English の切り替えをサポート
- 設定は `storage.settings.language` に保存され、次回起動時も維持
- 言語切り替え後は即座に反映（`options.tsx` の `useEffect` で i18n に同期）
- `messages.json` に言語設定関連のメッセージキーを追加:
  - `languageSettingsTitle`
  - `languageSettingsDescription`
  - `languageLabel`
  - `languageSelectDescription`

## テスト方法

1. Options ページを開く
2. Help タブに移動
3. 言語設定セクションで言語を切り替え
4. ダッシュボードの表示が即座に切り替わることを確認
5. 拡張機能を再起動して、言語設定が維持されることを確認

## スクリーンショット

<!-- TODO: 実装後にスクリーンショットを追加 -->

## 関連 Issue

Closes #235