### PR TITLE
feat: ポップアップに「只今の目標」として newtab の目標を表示

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -292,7 +292,7 @@
     "description": "Goal input placeholder"
   },
   "todaysGoal": {
-    "message": "Today's Goal",
+    "message": "Current Goal",
     "description": "Goal card label"
   },
   "saved": {

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -292,7 +292,7 @@
     "description": "目標入力プレースホルダー"
   },
   "todaysGoal": {
-    "message": "今日の目標",
+    "message": "只今の目標",
     "description": "目標カードラベル"
   },
   "saved": {


### PR DESCRIPTION
## 概要

ポップアップの目標表示を「只今の目標」に変更し、newtab のビジョンステートメントと連動させました。

Closes #233

## 変更内容

### i18n メッセージの更新

- **日本語**: "今日の目標" → "只今の目標"
- **英語**: "Today's Goal" → "Current Goal"

### 実装の詳細

ポップアップは既に `vision.defaultSettings.goalText` を使用して目標を表示していたため、データソースの変更は不要でした。今回の変更は i18n メッセージのラベル更新のみです。

```tsx
// popup.tsx (既存のコード - 変更なし)
<GoalCard
  goalText={
    vision?.defaultSettings?.goalText ||
    DEFAULT_VISION.defaultSettings.goalText
  }
  onClick={handleGoalClick}
/>
```

## テスト結果

- ✅ ユニットテスト: 28 files, 593 tests passed
- ✅ ビルド: 成功

## スクリーンショット

変更前: 「今日の目標」
変更後: 「只今の目標」

## チェックリスト

- [x] i18n 対応（日本語・英語）
- [x] ユニットテストが通過
- [x] ビルドが成功
- [x] newtab のビジョンステートメントがポップアップに表示される

🤖 Generated with Claude Code