### PR TITLE
feat: 月次・週次レポートに途中経過バッジを追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -601,6 +601,10 @@
     "message": "Monthly Report",
     "description": "Monthly report title"
   },
+  "inProgress": {
+    "message": "In Progress",
+    "description": "In progress badge label"
+  },
   "noReportData": {
     "message": "Not enough data for report",
     "description": "No report data message"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -601,6 +601,10 @@
     "message": "月次レポート",
     "description": "月次レポートタイトル"
   },
+  "inProgress": {
+    "message": "途中経過",
+    "description": "途中経過バッジラベル"
+  },
   "noReportData": {
     "message": "レポート用のデータが不足しています",
     "description": "レポートデータなしメッセージ"

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -32,6 +32,7 @@ interface WeeklyReportCardProps {
   onPrevious: () => void;
   onNext: () => void;
   canGoNext: boolean;
+  isCurrentWeek?: boolean; // 当週の途中経過かどうか
 }
 
 interface MonthlyReportCardProps {
@@ -39,6 +40,7 @@ interface MonthlyReportCardProps {
   onPrevious: () => void;
   onNext: () => void;
   canGoNext: boolean;
+  isCurrentMonth?: boolean; // 当月の途中経過かどうか
 }
 
 // Trend icon component
@@ -405,7 +407,8 @@ export function WeeklyReportCard({
   report,
   onPrevious,
   onNext,
-  canGoNext
+  canGoNext,
+  isCurrentWeek = false
 }: WeeklyReportCardProps) {
   return (
     <Card>
@@ -416,6 +419,11 @@ export function WeeklyReportCard({
           <h3 className="text-lg font-semibold text-gray-900">
             {getMessage('weeklyReport')}
           </h3>
+          {isCurrentWeek && (
+            <span className="px-2 py-1 text-xs font-medium text-primary-700 bg-primary-100 rounded-md">
+              {getMessage('inProgress')}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" onClick={onPrevious}>
@@ -491,7 +499,8 @@ export function MonthlyReportCard({
   report,
   onPrevious,
   onNext,
-  canGoNext
+  canGoNext,
+  isCurrentMonth = false
 }: MonthlyReportCardProps) {
   return (
     <Card>
@@ -502,6 +511,11 @@ export function MonthlyReportCard({
           <h3 className="text-lg font-semibold text-gray-900">
             {getMessage('monthlyReport')}
           </h3>
+          {isCurrentMonth && (
+            <span className="px-2 py-1 text-xs font-medium text-primary-700 bg-primary-100 rounded-md">
+              {getMessage('inProgress')}
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" onClick={onPrevious}>

--- a/src/components/options/analytics/AnalyticsDateFilter.tsx
+++ b/src/components/options/analytics/AnalyticsDateFilter.tsx
@@ -59,12 +59,14 @@ export function AnalyticsDateFilter({
             onPrevious={handlePreviousWeek}
             onNext={handleNextWeek}
             canGoNext={weeklyOffset < 0}
+            isCurrentWeek={weeklyOffset === 0}
           />
           <MonthlyReportCard
             report={monthlyReport}
             onPrevious={handlePreviousMonth}
             onNext={handleNextMonth}
             canGoNext={monthlyOffset < 0}
+            isCurrentMonth={monthlyOffset === 0}
           />
         </div>
       </Card>


### PR DESCRIPTION
## 概要
Issue #165 に対応し、月次・週次レポートで当月・当週の途中経過を明示的に表示するように改善しました。

Closes #165

## 変更内容
- 当月・当週のレポート表示時に「途中経過」バッジをヘッダーに表示
- i18n メッセージに `inProgress` を追加
  - 日本語: 途中経過
  - 英語: In Progress
- `WeeklyReportCard` と `MonthlyReportCard` に `isCurrentWeek` / `isCurrentMonth` プロパティを追加
- `AnalyticsDateFilter` から offset が 0（当週/当月）の場合に途中経過フラグを渡すように修正

## UI の変更
- 当月・当週のレポートヘッダーに青色のバッジで「途中経過」を表示
- 過去の週・月を表示している場合はバッジを表示しない（確定データとして扱う）

## テスト
- ビルドが成功することを確認
- 既存のテストがパスすることを確認

## スクリーンショット
（後で追加予定）

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>