### PR TITLE
feat: ブロック解除回数を週次・月次レポートに表示

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -573,6 +573,10 @@
     "message": "Blocked",
     "description": "Blocked count label"
   },
+  "unblockedCount": {
+    "message": "Unblocked",
+    "description": "Unblocked count label"
+  },
   "noData": {
     "message": "No data available",
     "description": "No data message"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -573,6 +573,10 @@
     "message": "ブロック",
     "description": "ブロック数ラベル"
   },
+  "unblockedCount": {
+    "message": "ブロック解除",
+    "description": "ブロック解除数ラベル"
+  },
   "noData": {
     "message": "データがありません",
     "description": "データなしメッセージ"

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -8,7 +8,8 @@ import {
   ChevronLeft,
   ChevronRight,
   Calendar,
-  BarChart3
+  BarChart3,
+  Unlock
 } from 'lucide-react';
 import {
   Bar,
@@ -80,10 +81,12 @@ function formatChangePercent(value: number | null): string {
 function StatsGrid({
   wasteTime,
   blockCount,
+  unblockCount,
   wasteTimeChangePercent
 }: {
   wasteTime: number;
   blockCount: number;
+  unblockCount: number;
   wasteTimeChangePercent: number | null;
 }) {
   // Determine color for change percent: negative (less waste) = green, positive (more waste) = red
@@ -112,7 +115,7 @@ function StatsGrid({
   const changeColors = getChangeColor(wasteTimeChangePercent);
 
   return (
-    <div className="grid grid-cols-3 gap-4">
+    <div className="grid grid-cols-4 gap-4">
       <div className="text-center p-3 bg-danger-50 rounded-lg">
         <div className="flex items-center justify-center gap-1 text-danger-600 mb-1">
           <Clock className="w-4 h-4" />
@@ -147,6 +150,13 @@ function StatsGrid({
         </div>
         <p className="text-lg font-bold text-info-700">{blockCount}</p>
         <p className="text-xs text-info-600">{getMessage('blockedCount')}</p>
+      </div>
+      <div className="text-center p-3 bg-warning-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-warning-600 mb-1">
+          <Unlock className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-warning-700">{unblockCount}</p>
+        <p className="text-xs text-warning-600">{getMessage('unblockedCount')}</p>
       </div>
     </div>
   );
@@ -448,6 +458,7 @@ export function WeeklyReportCard({
           <StatsGrid
             wasteTime={report.totalWasteTime}
             blockCount={report.totalBlockCount}
+            unblockCount={report.totalUnblockCount}
             wasteTimeChangePercent={report.wasteTimeChangePercent}
           />
 
@@ -534,6 +545,7 @@ export function MonthlyReportCard({
           <StatsGrid
             wasteTime={report.totalWasteTime}
             blockCount={report.totalBlockCount}
+            unblockCount={report.totalUnblockCount}
             wasteTimeChangePercent={report.wasteTimeChangePercent}
           />
 

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -156,7 +156,9 @@ function StatsGrid({
           <Unlock className="w-4 h-4" />
         </div>
         <p className="text-lg font-bold text-warning-700">{unblockCount}</p>
-        <p className="text-xs text-warning-600">{getMessage('unblockedCount')}</p>
+        <p className="text-xs text-warning-600">
+          {getMessage('unblockedCount')}
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

ブロック解除回数を週次・月次レポートの統計グリッドに表示する機能を追加しました。

- ブロック解除回数は既に `toggle-block.ts` で記録されており、`report.ts` でも集計済みでしたが、レポートカードでの表示がありませんでした
- 週次・月次レポートの統計グリッドに4つ目の項目としてブロック解除回数を追加
- ユーザーがどれだけブロックを解除しているかを可視化

## Changes

- `ReportCard.tsx` の `StatsGrid` を 3列から4列に変更
- ブロック解除回数の表示を追加（警告色の背景、Unlock アイコン使用）
- i18n キー `unblockedCount` を英語・日本語で追加

## Test plan

- [x] TypeScript 型チェック通過
- [x] ESLint 通過（警告のみ、エラーなし）
- [x] 全テスト（593件）通過

## Screenshots

統計グリッドが4列になり、右端にブロック解除回数が表示されます:
- 浪費時間（赤）
- 前期比較（緑/赤/灰）
- ブロック回数（青）
- ブロック解除回数（黄） ← 新規追加

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)