### PR TITLE
feat: ポップアップの今日のサマリーに浪費時間とブロック解除回数を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1483,6 +1483,14 @@
     "message": "None yet",
     "description": "No blocked sites yet message"
   },
+  "todayWastedTime": {
+    "message": "Wasted Time",
+    "description": "Today's wasted time label"
+  },
+  "todayUnblocks": {
+    "message": "Unblock Count",
+    "description": "Today's unblock count label"
+  },
   "settingsBackup": {
     "message": "Settings Backup",
     "description": "Settings backup section title"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1483,6 +1483,14 @@
     "message": "まだなし",
     "description": "ブロックサイトがまだない場合のメッセージ"
   },
+  "todayWastedTime": {
+    "message": "浪費時間",
+    "description": "今日の浪費時間ラベル"
+  },
+  "todayUnblocks": {
+    "message": "ブロック解除",
+    "description": "今日のブロック解除回数ラベル"
+  },
   "settingsBackup": {
     "message": "設定のバックアップ",
     "description": "設定バックアップセクションタイトル"

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 
 import { useStorage } from '@plasmohq/storage/hook';
-import { Ban, Shield, TrendingUp, Clock } from 'lucide-react';
+import { Ban, Shield, TrendingUp, Clock, Timer, Unlock } from 'lucide-react';
 
 import {
   GoalCard,
@@ -23,6 +23,7 @@ import {
 } from '~/hooks';
 import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
+import { formatTimeLocalized } from '~/lib/time';
 import type {
   AnalyticsOptIn,
   AppSettings,
@@ -169,6 +170,30 @@ function PopupApp() {
                   {getMessage('noBlockedSitesYet')}
                 </p>
               )}
+            </div>
+
+            <div className="bg-warning-50 rounded-xl p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <Timer className="w-4 h-4 text-warning-500" />
+                <span className="text-xs font-medium text-gray-500">
+                  {getMessage('todayWastedTime')}
+                </span>
+              </div>
+              <p className="text-2xl font-bold text-warning-600">
+                {formatTimeLocalized(stats.wasteTime)}
+              </p>
+            </div>
+
+            <div className="bg-success-50 rounded-xl p-4">
+              <div className="flex items-center gap-2 mb-2">
+                <Unlock className="w-4 h-4 text-success-500" />
+                <span className="text-xs font-medium text-gray-500">
+                  {getMessage('todayUnblocks')}
+                </span>
+              </div>
+              <p className="text-2xl font-bold text-success-600">
+                {stats.unblockCount}
+              </p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

ポップアップの「今日のサマリー」セクションに以下の2つの新しいメトリクスを追加しました：

- **浪費時間**: 追跡サイトでの本日の閲覧時間を表示（Timer アイコン、warning カラー）
- **ブロック解除回数**: 本日のブロック解除回数を表示（Unlock アイコン、success カラー）

### 変更内容

- `src/popup.tsx`: 2x2 グリッドレイアウトに2つの新しいカードを追加
- `assets/_locales/en/messages.json`: 英語 i18n キー（todayWastedTime, todayUnblocks）を追加
- `assets/_locales/ja/messages.json`: 日本語 i18n キー（todayWastedTime, todayUnblocks）を追加
- `formatTimeLocalized` を使用して浪費時間をローカライズ表示

### 技術詳細

- `stats.wasteTime` と `stats.unblockCount` は #227 で追加されたメトリクス
- Timer、Unlock アイコンを lucide-react から追加
- 既存の2カード（ブロック回数、よくブロック）に加えて4カードのレイアウトに拡張

## Test plan

- [x] ビルドが成功することを確認（`npm run build`）
- [x] Lint エラーがないことを確認（`npm run lint`）
- [ ] ポップアップを開いて4つのカードが表示されることを確認
- [ ] 浪費時間が正しくフォーマット表示されることを確認（例: "23分" / "23 min"）
- [ ] ブロック解除回数が表示されることを確認
- [ ] 言語切り替え（日本語/英語）で表示が切り替わることを確認

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)