### PR TITLE
feat: YouTube ブロックセクションに制限タイプ選択を追加

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -1643,6 +1643,14 @@
     "message": "Resets hourly",
     "description": "Hourly reset note"
   },
+  "timeLimitSettings": {
+    "message": "Time Limit Settings",
+    "description": "Time limit settings section title"
+  },
+  "currentSetting": {
+    "message": "Current setting",
+    "description": "Label for current setting display"
+  },
   "timeLimitWarning": {
     "message": "Only $TIME$ remaining!",
     "description": "Warning when time is running low",

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -1643,6 +1643,14 @@
     "message": "毎時リセット",
     "description": "時間リセット注記"
   },
+  "timeLimitSettings": {
+    "message": "時間制限の設定",
+    "description": "時間制限設定セクションのタイトル"
+  },
+  "currentSetting": {
+    "message": "現在の設定",
+    "description": "現在の設定表示ラベル"
+  },
   "timeLimitWarning": {
     "message": "残り $TIME$ です！",
     "description": "残り時間が少ない場合の警告",

--- a/src/components/options/blocklist/YouTubeSection.tsx
+++ b/src/components/options/blocklist/YouTubeSection.tsx
@@ -256,7 +256,9 @@ export function YouTubeSection({
                 </label>
                 <Select
                   value={selectedType}
-                  onChange={(value) => handleTypeChange(value as LimitTypeOption)}
+                  onChange={(value) =>
+                    handleTypeChange(value as LimitTypeOption)
+                  }
                   options={typeOptions}
                 />
               </div>

--- a/src/components/options/blocklist/YouTubeSection.tsx
+++ b/src/components/options/blocklist/YouTubeSection.tsx
@@ -16,7 +16,7 @@ import { Card, Toggle, Select, Button } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
 import { YouTubeFeatureToggle } from './YouTubeFeatureToggle';
 import { TIME_LIMIT_CONFIG, roundToNearestPreset } from '~/constants/limits';
-import type { YouTubeSettings, TimeLimit, TimeLimitType } from '~/types/storage';
+import type { YouTubeSettings, TimeLimitType } from '~/types/storage';
 
 interface YouTubeSectionProps {
   youtube: YouTubeSettings;

--- a/src/components/options/blocklist/YouTubeSection.tsx
+++ b/src/components/options/blocklist/YouTubeSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState, useEffect, useRef } from 'react';
 import {
   Youtube,
   ShieldBan,
@@ -7,24 +7,96 @@ import {
   MessageSquare,
   LayoutPanelLeft,
   Home,
-  Info
+  Info,
+  Clock,
+  Check
 } from 'lucide-react';
 
-import { Card, Toggle } from '~/components/ui';
+import { Card, Toggle, Select, Button } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
 import { YouTubeFeatureToggle } from './YouTubeFeatureToggle';
-import type { YouTubeSettings } from '~/types/storage';
+import { TIME_LIMIT_CONFIG, roundToNearestPreset } from '~/constants/limits';
+import type { YouTubeSettings, TimeLimit, TimeLimitType } from '~/types/storage';
 
 interface YouTubeSectionProps {
   youtube: YouTubeSettings;
   onYouTubeChange: (youtube: YouTubeSettings) => void;
 }
 
+const SAVED_FEEDBACK_DURATION_MS = 2000;
+
+type LimitTypeOption = 'always' | 'daily' | 'hourly';
+
 export function YouTubeSection({
   youtube,
   onYouTubeChange
 }: YouTubeSectionProps) {
   const isEnabled = youtube?.enabled ?? false;
+  const blockAccessEnabled = youtube?.blockAccess ?? false;
+
+  const [showSaved, setShowSaved] = useState(false);
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (savedTimerRef.current) {
+        clearTimeout(savedTimerRef.current);
+      }
+    };
+  }, []);
+
+  const showSavedFeedback = useCallback(() => {
+    setShowSaved(true);
+    if (savedTimerRef.current) {
+      clearTimeout(savedTimerRef.current);
+    }
+    savedTimerRef.current = setTimeout(() => {
+      setShowSaved(false);
+      savedTimerRef.current = null;
+    }, SAVED_FEEDBACK_DURATION_MS);
+  }, []);
+
+  // 現在の保存済み値
+  const currentType: LimitTypeOption = youtube?.timeLimit
+    ? youtube.timeLimit.type
+    : 'always';
+
+  // 現在の保存済み分数
+  const currentMinutes = youtube?.timeLimit
+    ? Math.floor(youtube.timeLimit.limitSeconds / 60)
+    : currentType === 'daily'
+      ? TIME_LIMIT_CONFIG.DEFAULT_DAILY_LIMIT / 60
+      : TIME_LIMIT_CONFIG.DEFAULT_HOURLY_LIMIT / 60;
+
+  // 既存の制限時間を取得し、プリセット値に丸める
+  const getInitialMinutes = () => {
+    if (!youtube?.timeLimit) {
+      return currentType === 'daily'
+        ? TIME_LIMIT_CONFIG.DEFAULT_DAILY_LIMIT / 60
+        : TIME_LIMIT_CONFIG.DEFAULT_HOURLY_LIMIT / 60;
+    }
+
+    const existingMinutes = Math.floor(youtube.timeLimit.limitSeconds / 60);
+    // 既存の値がプリセット外の場合、最も近いプリセット値に丸める
+    return roundToNearestPreset(existingMinutes, youtube.timeLimit.type);
+  };
+
+  // ローカルステートで編集中の値を管理
+  const [selectedType, setSelectedType] =
+    useState<LimitTypeOption>(currentType);
+  const [minutes, setMinutes] = useState(getInitialMinutes());
+
+  // 保存済み値が変更されたときにローカルステートを更新
+  useEffect(() => {
+    setSelectedType(currentType);
+    setMinutes(currentMinutes);
+  }, [currentType, currentMinutes]);
+
+  // 変更があるかチェック
+  const hasChanges =
+    selectedType !== currentType ||
+    (selectedType !== 'always' && minutes !== currentMinutes);
 
   const handleToggle = useCallback(
     (key: keyof YouTubeSettings) => (checked: boolean) => {
@@ -32,6 +104,61 @@ export function YouTubeSection({
     },
     [youtube, onYouTubeChange]
   );
+
+  const handleTypeChange = useCallback((newType: LimitTypeOption) => {
+    setSelectedType(newType);
+
+    // タイプ変更時にデフォルトのプリセット値を設定
+    if (newType !== 'always') {
+      const defaultMinutes =
+        newType === 'daily'
+          ? TIME_LIMIT_CONFIG.DEFAULT_DAILY_LIMIT / 60
+          : TIME_LIMIT_CONFIG.DEFAULT_HOURLY_LIMIT / 60;
+      const presetMinutes = roundToNearestPreset(defaultMinutes, newType);
+      setMinutes(presetMinutes);
+    }
+  }, []);
+
+  const handleMinutesChange = useCallback((value: string) => {
+    const newMinutes = parseInt(value, 10);
+    if (isNaN(newMinutes) || newMinutes < 1) return;
+    setMinutes(newMinutes);
+  }, []);
+
+  // 保存ボタンのハンドラー
+  const handleSave = useCallback(() => {
+    if (selectedType === 'always') {
+      onYouTubeChange({ ...youtube, timeLimit: null });
+    } else {
+      onYouTubeChange({
+        ...youtube,
+        timeLimit: {
+          type: selectedType as TimeLimitType,
+          limitSeconds: minutes * 60
+        }
+      });
+    }
+    showSavedFeedback();
+  }, [selectedType, minutes, youtube, onYouTubeChange, showSavedFeedback]);
+
+  const typeOptions = [
+    { value: 'always', label: getMessage('alwaysBlocked') },
+    { value: 'daily', label: getMessage('dailyLimit') },
+    { value: 'hourly', label: getMessage('hourlyLimit') }
+  ];
+
+  // プリセット選択肢を生成（タイプに応じて daily または hourly のプリセットを使用）
+  const getPresetOptions = () => {
+    const presets =
+      selectedType === 'daily'
+        ? TIME_LIMIT_CONFIG.DAILY_PRESET_MINUTES
+        : TIME_LIMIT_CONFIG.HOURLY_PRESET_MINUTES;
+
+    return presets.map((preset) => ({
+      value: preset.toString(),
+      label: `${preset} ${getMessage('minutes')}`
+    }));
+  };
 
   const features = [
     {
@@ -112,6 +239,77 @@ export function YouTubeSection({
             onChange={handleToggle('blockAccess')}
             disabled={!isEnabled}
           />
+
+          {/* Time Limit Settings for Block Access */}
+          {blockAccessEnabled && (
+            <div className="mt-3 ml-8 p-3 bg-gray-50 rounded-lg space-y-3">
+              <div className="flex items-center gap-2 mb-2">
+                <Clock className="w-4 h-4 text-gray-600" />
+                <h4 className="text-sm font-medium text-gray-700">
+                  {getMessage('timeLimitSettings')}
+                </h4>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  {getMessage('timeLimitType')}
+                </label>
+                <Select
+                  value={selectedType}
+                  onChange={(value) => handleTypeChange(value as LimitTypeOption)}
+                  options={typeOptions}
+                />
+              </div>
+
+              {selectedType !== 'always' && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">
+                    {getMessage('timeLimitDuration')}
+                  </label>
+                  <Select
+                    value={minutes.toString()}
+                    onChange={handleMinutesChange}
+                    options={getPresetOptions()}
+                  />
+                  <p className="text-xs text-gray-400 mt-1">
+                    {selectedType === 'daily'
+                      ? getMessage('resetDaily')
+                      : getMessage('resetHourly')}
+                  </p>
+                </div>
+              )}
+
+              {/* 保存ボタン */}
+              <div className="flex items-center gap-2">
+                <Button
+                  onClick={handleSave}
+                  disabled={!hasChanges}
+                  size="sm"
+                  variant="primary"
+                >
+                  {getMessage('save')}
+                </Button>
+                {showSaved && (
+                  <div className="flex items-center gap-1 text-xs text-success-600 animate-fade-in">
+                    <Check className="w-3 h-3" />
+                    <span>{getMessage('saved')}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Current settings display */}
+              {youtube?.timeLimit && (
+                <div className="text-xs text-gray-500 pt-2 border-t border-gray-200">
+                  {getMessage('currentSetting')}:{' '}
+                  {youtube.timeLimit.type === 'daily'
+                    ? getMessage('dailyLimit')
+                    : getMessage('hourlyLimit')}{' '}
+                  - {Math.floor(youtube.timeLimit.limitSeconds / 60)}{' '}
+                  {getMessage('minutes')}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
Closes #237

## Summary

YouTube へのアクセスをブロックするセクションに、通常のブロックリストと同様の制限タイプ選択機能を追加しました。ユーザーは YouTube ブロックに対して「常時ブロック」「日次制限」「時間制限」を選択し、制限時間をプリセットから設定できます。

## Changes

### UI 実装
- **制限タイプ選択**: 常時ブロック / 日次制限 / 時間制限
- **制限時間プリセット**: 
  - 日次: 5/15/30/60分
  - 時間: 5/10/15/30分
- **保存ボタン**: 変更を確定するボタン（変更がない場合は無効化）
- **保存完了フィードバック**: チェックマークとメッセージで保存完了を通知
- **現在の設定表示**: 保存済みの制限タイプと時間を表示

### 実装詳細
- `TimeLimitEditor` コンポーネントのロジックとパターンを踏襲
- `YouTubeSettings` 型に既存の `timeLimit` フィールドを活用
- 制限タイプ変更時に適切なデフォルト値を設定
- プリセット値への自動丸め処理

### 国際化対応
英語・日本語メッセージファイルに以下を追加:
- `timeLimitSettings`: "Time Limit Settings" / "時間制限の設定"
- `currentSetting`: "Current setting" / "現在の設定"

## Test Plan

- [ ] YouTube ブロックセクションで「YouTube へのアクセスをブロック」を ON にする
- [ ] 制限タイプ選択が表示されることを確認
- [ ] 「常時ブロック」を選択して保存 → 設定が反映されることを確認
- [ ] 「日次制限」を選択して 30 分を設定 → 保存が成功することを確認
- [ ] 「時間制限」を選択して 15 分を設定 → 保存が成功することを確認
- [ ] 保存完了時にチェックマークが表示されることを確認
- [ ] 現在の設定が正しく表示されることを確認
- [ ] 英語・日本語の両方で表示が正しいことを確認

## Screenshots

_(手動テスト時に追加)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)