### PR TITLE
chore: CI を並列ジョブ化して実行時間を短縮

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,9 @@ jobs:
   # 全ジョブ完了確認（ブランチ保護ルール用）
   check:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build, test-e2e]
+    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build]
+    # test-e2e は Chrome 拡張が non-headless 必須のため CI では不安定。
+    # informational ジョブとして独立実行し、check ジョブの必須依存には含めない。
     steps:
       - name: All checks passed
         run: echo "All parallel CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ on:
     branches: [main, develop]
 
 jobs:
-  ci:
+  # 並列実行: Lint チェック
+  lint:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,19 +34,136 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+  # 並列実行: Type check
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Type check
         run: pnpm type-check
 
-      - name: Unit tests
-        run: pnpm test --run --passWithNoTests
+  # 並列実行: Unit tests (lib)
+  test-unit-lib:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests (lib)
+        run: pnpm test --run src/lib/
+
+  # 並列実行: Unit tests (hooks)
+  test-unit-hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests (hooks)
+        run: pnpm test --run src/hooks/
+
+  # 並列実行: Build
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
 
+  # 直列実行: E2E tests (build 完了後)
+  test-e2e:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: hashFiles('tests/e2e/**/*.spec.ts', 'tests/e2e/**/*.test.ts', 'playwright.config.ts') != ''
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: E2E tests
-        if: hashFiles('tests/e2e/**/*.spec.ts', 'tests/e2e/**/*.test.ts', 'playwright.config.ts') != ''
         continue-on-error: true # Chrome拡張E2Eは非headlessが必要で CI では不安定
         timeout-minutes: 10
         run: |
           pnpm exec playwright install --with-deps chromium
           xvfb-run --auto-servernum -- pnpm test:e2e
+
+  # 全ジョブ完了確認（ブランチ保護ルール用）
+  check:
+    runs-on: ubuntu-latest
+    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build]
+    steps:
+      - name: All checks passed
+        run: echo "All parallel CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build
+        run: pnpm build
+
       - name: E2E tests
         continue-on-error: true # Chrome拡張E2Eは非headlessが必要で CI では不安定
         timeout-minutes: 10
@@ -162,7 +165,7 @@ jobs:
   # 全ジョブ完了確認（ブランチ保護ルール用）
   check:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build]
+    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build, test-e2e]
     steps:
       - name: All checks passed
         run: echo "All parallel CI jobs completed successfully"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,6 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     needs: [build]
-    if: hashFiles('tests/e2e/**/*.spec.ts', 'tests/e2e/**/*.test.ts', 'playwright.config.ts') != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/tests/e2e/fixtures/extension.ts
+++ b/tests/e2e/fixtures/extension.ts
@@ -7,8 +7,12 @@ import path from 'path';
  * 拡張機能をロードした状態でテストを実行するための設定
  */
 
-// 拡張機能のビルドディレクトリパス
-const EXTENSION_PATH = path.join(__dirname, '../../../build/chrome-mv3-dev');
+// 拡張機能のビルドディレクトリパス（CI では pnpm build で chrome-mv3-prod を生成）
+import fs from 'fs';
+
+const PROD_PATH = path.join(__dirname, '../../../build/chrome-mv3-prod');
+const DEV_PATH = path.join(__dirname, '../../../build/chrome-mv3-dev');
+const EXTENSION_PATH = fs.existsSync(PROD_PATH) ? PROD_PATH : DEV_PATH;
 
 // カスタムフィクスチャの型定義
 export type ExtensionFixtures = {


### PR DESCRIPTION
## 概要

全ステップを1ジョブで直列実行していた CI を並列化し、実行時間を短縮しました。

## 変更内容

### 並列化されたジョブ構成

```
lint ──────────────┐
typecheck ─────────┤
test-unit-lib ─────┤
test-unit-hooks ───┤──→ check（全ジョブ完了確認）
build ─────────────┤
                   └──→ test-e2e（build 後）
```

### 各ジョブの役割

- **lint**: ESLint + Prettier format check
- **typecheck**: TypeScript type check
- **test-unit-lib**: `src/lib/` 配下の Unit tests
- **test-unit-hooks**: `src/hooks/` 配下の Unit tests
- **build**: Plasmo build
- **test-e2e**: E2E tests（build 完了後に実行、`needs: [build]`）
- **check**: 全並列ジョブの完了確認（ブランチ保護ルール用）

### 最適化ポイント

1. **並列実行**: 独立したチェック（lint、typecheck、テスト、build）を並列実行
2. **依存関係の明示**: E2E テストは build 完了後に実行
3. **キャッシュ活用**: 各ジョブで pnpm store のキャッシュを活用し install 時間を短縮
4. **完了確認ジョブ**: `check` ジョブで全並列ジョブの完了を待つ

## 期待される効果

- CI 全体の実行時間を **11分 → 5分以下** に短縮
- 個別ジョブの失敗が即座にフィードバックされる（例: lint エラーなら2分以内に通知）
- 並列実行により GitHub Actions の runner リソースを効率的に活用

## 注意事項

### ブランチ保護ルールの変更が必要

現在のブランチ保護ルールで Required なジョブ名が `ci` になっている場合、**`check`** に変更する必要があります。

この PR をマージする前に、PM がブランチ保護ルールを以下のように更新してください:

- 変更前: Required status check `ci`
- 変更後: Required status check `check`

## テスト計画

- [x] CI ワークフローの構文チェック（YAML lint）
- [ ] PR 作成後、GitHub Actions で全ジョブが並列実行されることを確認
- [ ] `check` ジョブが全ジョブ完了後に success になることを確認
- [ ] 実行時間が 5分以下になることを確認

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)