### PR TITLE
chore: E2E テストを通常 CI から分離し手動実行に変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,44 +130,10 @@ jobs:
       - name: Build
         run: pnpm build
 
-  # 直列実行: E2E tests (build 完了後)
-  test-e2e:
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: E2E tests
-        continue-on-error: true # Chrome拡張E2Eは非headlessが必要で CI では不安定
-        timeout-minutes: 10
-        run: |
-          pnpm exec playwright install --with-deps chromium
-          xvfb-run --auto-servernum -- pnpm test:e2e
-
   # 全ジョブ完了確認（ブランチ保護ルール用）
   check:
     runs-on: ubuntu-latest
     needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build]
-    # test-e2e は Chrome 拡張が non-headless 必須のため CI では不安定。
-    # informational ジョブとして独立実行し、check ジョブの必須依存には含めない。
     steps:
       - name: All checks passed
         run: echo "All parallel CI jobs completed successfully"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,42 @@
+name: E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'テスト対象ブランチ'
+        required: false
+        default: 'develop'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E tests
+        timeout-minutes: 10
+        run: xvfb-run --auto-servernum -- pnpm test:e2e


### PR DESCRIPTION
## 概要

E2E テストを通常の CI から分離し、手動実行ワークフローに変更しました。

## 変更内容

### `.github/workflows/ci.yml`
- E2E テストジョブを削除
- 他のジョブ（lint, typecheck, test-unit, build）は維持

### `.github/workflows/e2e.yml`（新規作成）
- `workflow_dispatch` トリガーで手動実行可能
- テスト対象ブランチを指定可能（デフォルト: develop）
- `continue-on-error` は削除（手動実行なので結果を確認する前提）

## 背景

Chrome 拡張の E2E テストは非 headless 環境が必要で、CI では不安定でした。手動実行に切り替えることで、必要なタイミングで確実にテストを実行できるようにします。

## テスト方法

GitHub Actions の "Actions" タブから "E2E Tests" ワークフローを選択し、"Run workflow" で手動実行できます。

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)