### PR TITLE
refactor: ReportCard.tsx を分割（567行 → 複数ファイル）

### DIFF
--- a/src/components/features/ReportCard/EmptyReport.tsx
+++ b/src/components/features/ReportCard/EmptyReport.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { BarChart3 } from 'lucide-react';
+
+interface EmptyReportProps {
+  message: string;
+}
+
+/**
+ * 空のレポート状態を表示するコンポーネント
+ */
+export function EmptyReport({ message }: EmptyReportProps) {
+  return (
+    <div className="text-center py-8">
+      <BarChart3 className="w-12 h-12 text-gray-300 mx-auto mb-3" />
+      <p className="text-sm text-gray-500">{message}</p>
+    </div>
+  );
+}

--- a/src/components/features/ReportCard/MonthlyTrendChart.tsx
+++ b/src/components/features/ReportCard/MonthlyTrendChart.tsx
@@ -33,9 +33,7 @@ function formatChartMinutes(seconds: number): string {
 /**
  * 月次トレンドチャート: 週別の無駄時間（棒グラフ）+ ブロック数（折れ線グラフ）
  */
-export function MonthlyTrendChart({
-  weeklyBreakdown
-}: MonthlyTrendChartProps) {
+export function MonthlyTrendChart({ weeklyBreakdown }: MonthlyTrendChartProps) {
   const chartData = weeklyBreakdown.map((w, i) => ({
     week: `W${i + 1}`,
     wasteTime: Math.round(w.wasteTime / 60), // 分に変換

--- a/src/components/features/ReportCard/MonthlyTrendChart.tsx
+++ b/src/components/features/ReportCard/MonthlyTrendChart.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import {
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ComposedChart
+} from 'recharts';
+import { getMessage } from '~/lib/i18n';
+
+interface MonthlyTrendChartProps {
+  weeklyBreakdown: {
+    weekStart: string;
+    wasteTime: number;
+    blockCount: number;
+  }[];
+}
+
+/**
+ * 月次チャート用のフォーマット（秒 → 分/時間）
+ */
+function formatChartMinutes(seconds: number): string {
+  const totalMinutes = Math.round(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const mins = totalMinutes % 60;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+/**
+ * 月次トレンドチャート: 週別の無駄時間（棒グラフ）+ ブロック数（折れ線グラフ）
+ */
+export function MonthlyTrendChart({
+  weeklyBreakdown
+}: MonthlyTrendChartProps) {
+  const chartData = weeklyBreakdown.map((w, i) => ({
+    week: `W${i + 1}`,
+    wasteTime: Math.round(w.wasteTime / 60), // 分に変換
+    blockCount: w.blockCount
+  }));
+
+  const maxWaste = Math.max(...chartData.map((d) => d.wasteTime), 1);
+  const useHours = maxWaste >= 120;
+  const displayData = useHours
+    ? chartData.map((d) => ({ ...d, wasteTime: d.wasteTime / 60 }))
+    : chartData;
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <ComposedChart data={displayData}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="week" stroke="#6b7280" fontSize={12} />
+        <YAxis
+          yAxisId="waste"
+          stroke="#ef4444"
+          fontSize={12}
+          tickFormatter={(v: number) => (useHours ? `${v}h` : `${v}m`)}
+        />
+        <YAxis
+          yAxisId="block"
+          orientation="right"
+          stroke="#3b82f6"
+          fontSize={12}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: '#fff',
+            border: '1px solid #e5e7eb',
+            borderRadius: '8px'
+          }}
+          formatter={(value: number, name: string) => {
+            if (name === 'wasteTime') {
+              return [
+                formatChartMinutes(useHours ? value * 3600 : value * 60),
+                getMessage('wasteTime')
+              ];
+            }
+            return [value, getMessage('blockedCount')];
+          }}
+        />
+        <Bar
+          yAxisId="waste"
+          dataKey="wasteTime"
+          fill="#fca5a5"
+          radius={[4, 4, 0, 0]}
+          name="wasteTime"
+        />
+        <Line
+          yAxisId="block"
+          type="monotone"
+          dataKey="blockCount"
+          stroke="#3b82f6"
+          strokeWidth={2}
+          dot={{ fill: '#3b82f6', strokeWidth: 2, r: 3 }}
+          name="blockCount"
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/features/ReportCard/RankedList.tsx
+++ b/src/components/features/ReportCard/RankedList.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { getMessage } from '~/lib/i18n';
+import { formatTime } from '~/lib/time';
+
+interface RankedListItem {
+  domain: string;
+  value: number;
+}
+
+interface RankedListProps {
+  items: RankedListItem[];
+  /** 値の表示タイプ（時間 or カウント） */
+  valueType: 'time' | 'count';
+  /** 背景色（Tailwindクラス） */
+  bgColor: string;
+  /** テキスト色（Tailwindクラス） */
+  textColor: string;
+}
+
+/**
+ * ランキングリストコンポーネント
+ * TopSitesList と TopBlockedSitesList の共通化
+ */
+export function RankedList({
+  items,
+  valueType,
+  bgColor,
+  textColor
+}: RankedListProps) {
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-gray-400 text-center py-2">
+        {getMessage('noData')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {items.slice(0, 3).map((item, index) => (
+        <div
+          key={item.domain}
+          className={`flex items-center justify-between p-2 ${bgColor} rounded-lg`}
+        >
+          <div className="flex items-center gap-2">
+            <span className="w-5 h-5 flex items-center justify-center text-xs font-medium text-gray-500 bg-white rounded-full">
+              {index + 1}
+            </span>
+            <span className="text-sm font-medium text-gray-800 truncate max-w-[120px]">
+              {item.domain}
+            </span>
+          </div>
+          <span className={`text-sm font-medium ${textColor}`}>
+            {valueType === 'time' ? formatTime(item.value) : item.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/features/ReportCard/ReportCard.tsx
+++ b/src/components/features/ReportCard/ReportCard.tsx
@@ -1,39 +1,24 @@
 import React from 'react';
-import {
-  TrendingUp,
-  TrendingDown,
-  Minus,
-  Shield,
-  Clock,
-  ChevronLeft,
-  ChevronRight,
-  Calendar,
-  BarChart3,
-  Unlock
-} from 'lucide-react';
-import {
-  Bar,
-  Line,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  ResponsiveContainer,
-  ComposedChart
-} from 'recharts';
+import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { Card, Button } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
-import { formatTime } from '~/lib/time';
 import { formatWeekRange, formatMonth } from '~/lib/report';
 import type { WeeklyReport, MonthlyReport } from '~/types/report';
+
+import { TrendIcon } from './TrendIcon';
+import { StatsGrid } from './StatsGrid';
+import { RankedList } from './RankedList';
+import { WeeklyChart } from './WeeklyChart';
+import { MonthlyTrendChart } from './MonthlyTrendChart';
+import { EmptyReport } from './EmptyReport';
 
 interface WeeklyReportCardProps {
   report: WeeklyReport | null;
   onPrevious: () => void;
   onNext: () => void;
   canGoNext: boolean;
-  isCurrentWeek?: boolean; // 当週の途中経過かどうか
+  isCurrentWeek?: boolean;
 }
 
 interface MonthlyReportCardProps {
@@ -41,380 +26,12 @@ interface MonthlyReportCardProps {
   onPrevious: () => void;
   onNext: () => void;
   canGoNext: boolean;
-  isCurrentMonth?: boolean; // 当月の途中経過かどうか
+  isCurrentMonth?: boolean;
 }
 
-// Trend icon component
-function TrendIcon({ trend }: { trend: 'improving' | 'declining' | 'stable' }) {
-  if (trend === 'improving') {
-    return (
-      <div className="flex items-center gap-1 text-success-600">
-        <TrendingUp className="w-4 h-4" />
-        <span className="text-sm font-medium">{getMessage('improving')}</span>
-      </div>
-    );
-  }
-  if (trend === 'declining') {
-    return (
-      <div className="flex items-center gap-1 text-danger-600">
-        <TrendingDown className="w-4 h-4" />
-        <span className="text-sm font-medium">{getMessage('declining')}</span>
-      </div>
-    );
-  }
-  return (
-    <div className="flex items-center gap-1 text-gray-500">
-      <Minus className="w-4 h-4" />
-      <span className="text-sm font-medium">{getMessage('stable')}</span>
-    </div>
-  );
-}
-
-// Format waste time change percent for display
-function formatChangePercent(value: number | null): string {
-  if (value === null) {
-    return getMessage('noComparisonData');
-  }
-  const sign = value > 0 ? '+' : '';
-  return `${sign}${value.toFixed(1)}%`;
-}
-
-// Stats grid component
-function StatsGrid({
-  wasteTime,
-  blockCount,
-  unblockCount,
-  wasteTimeChangePercent
-}: {
-  wasteTime: number;
-  blockCount: number;
-  unblockCount: number;
-  wasteTimeChangePercent: number | null;
-}) {
-  // Determine color for change percent: negative (less waste) = green, positive (more waste) = red
-  const getChangeColor = (value: number | null) => {
-    if (value === null)
-      return {
-        bg: 'bg-gray-50',
-        text: 'text-gray-600',
-        label: 'text-gray-500'
-      };
-    if (value < 0)
-      return {
-        bg: 'bg-success-50',
-        text: 'text-success-700',
-        label: 'text-success-600'
-      };
-    if (value > 0)
-      return {
-        bg: 'bg-danger-50',
-        text: 'text-danger-700',
-        label: 'text-danger-600'
-      };
-    return { bg: 'bg-gray-50', text: 'text-gray-700', label: 'text-gray-500' };
-  };
-
-  const changeColors = getChangeColor(wasteTimeChangePercent);
-
-  return (
-    <div className="grid grid-cols-4 gap-4">
-      <div className="text-center p-3 bg-danger-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-danger-600 mb-1">
-          <Clock className="w-4 h-4" />
-        </div>
-        <p className="text-lg font-bold text-danger-700">
-          {formatTime(wasteTime)}
-        </p>
-        <p className="text-xs text-danger-600">{getMessage('wasteTime')}</p>
-      </div>
-      <div className={`text-center p-3 ${changeColors.bg} rounded-lg`}>
-        <div
-          className={`flex items-center justify-center gap-1 ${changeColors.label} mb-1`}
-        >
-          {wasteTimeChangePercent !== null && wasteTimeChangePercent < 0 ? (
-            <TrendingDown className="w-4 h-4" />
-          ) : wasteTimeChangePercent !== null && wasteTimeChangePercent > 0 ? (
-            <TrendingUp className="w-4 h-4" />
-          ) : (
-            <Minus className="w-4 h-4" />
-          )}
-        </div>
-        <p className={`text-lg font-bold ${changeColors.text}`}>
-          {formatChangePercent(wasteTimeChangePercent)}
-        </p>
-        <p className={`text-xs ${changeColors.label}`}>
-          {getMessage('previousPeriodComparison')}
-        </p>
-      </div>
-      <div className="text-center p-3 bg-info-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-info-600 mb-1">
-          <Shield className="w-4 h-4" />
-        </div>
-        <p className="text-lg font-bold text-info-700">{blockCount}</p>
-        <p className="text-xs text-info-600">{getMessage('blockedCount')}</p>
-      </div>
-      <div className="text-center p-3 bg-warning-50 rounded-lg">
-        <div className="flex items-center justify-center gap-1 text-warning-600 mb-1">
-          <Unlock className="w-4 h-4" />
-        </div>
-        <p className="text-lg font-bold text-warning-700">{unblockCount}</p>
-        <p className="text-xs text-warning-600">
-          {getMessage('unblockedCount')}
-        </p>
-      </div>
-    </div>
-  );
-}
-
-// Top waste sites list component
-function TopSitesList({
-  sites
-}: {
-  sites: { domain: string; time: number }[];
-}) {
-  if (sites.length === 0) {
-    return (
-      <p className="text-sm text-gray-400 text-center py-2">
-        {getMessage('noData')}
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      {sites.slice(0, 3).map((site, index) => (
-        <div
-          key={site.domain}
-          className="flex items-center justify-between p-2 bg-danger-50 rounded-lg"
-        >
-          <div className="flex items-center gap-2">
-            <span className="w-5 h-5 flex items-center justify-center text-xs font-medium text-gray-500 bg-white rounded-full">
-              {index + 1}
-            </span>
-            <span className="text-sm font-medium text-gray-800 truncate max-w-[120px]">
-              {site.domain}
-            </span>
-          </div>
-          <span className="text-sm font-medium text-danger-600">
-            {formatTime(site.time)}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Top blocked sites list component
-function TopBlockedSitesList({
-  sites
-}: {
-  sites: { domain: string; count: number }[];
-}) {
-  if (sites.length === 0) {
-    return (
-      <p className="text-sm text-gray-400 text-center py-2">
-        {getMessage('noData')}
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      {sites.slice(0, 3).map((site, index) => (
-        <div
-          key={site.domain}
-          className="flex items-center justify-between p-2 bg-info-50 rounded-lg"
-        >
-          <div className="flex items-center gap-2">
-            <span className="w-5 h-5 flex items-center justify-center text-xs font-medium text-gray-500 bg-white rounded-full">
-              {index + 1}
-            </span>
-            <span className="text-sm font-medium text-gray-800 truncate max-w-[120px]">
-              {site.domain}
-            </span>
-          </div>
-          <span className="text-sm font-medium text-info-600">
-            {site.count}
-          </span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// Day labels for chart
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-
-// Format minutes for chart tooltip
-function formatMinutes(seconds: number): string {
-  const totalMinutes = Math.round(seconds / 60);
-  const hours = Math.floor(totalMinutes / 60);
-  const mins = totalMinutes % 60;
-  if (hours > 0) return `${hours}h ${mins}m`;
-  return `${mins}m`;
-}
-
-// Weekly combined chart: daily waste time bars + block count line
-function WeeklyChart({
-  dailyBreakdown,
-  dailyBlockCounts
-}: {
-  dailyBreakdown: { wasteTime: number; blockCount: number }[];
-  dailyBlockCounts: number[];
-}) {
-  const chartData = dailyBreakdown.map((d, i) => ({
-    day: DAY_LABELS[i] || `D${i + 1}`,
-    wasteTime: Math.round(d.wasteTime / 60), // Convert to minutes for display
-    blockCount: dailyBlockCounts[i] || 0
-  }));
-
-  const maxWaste = Math.max(...chartData.map((d) => d.wasteTime), 1);
-  const useHours = maxWaste >= 120;
-  const displayData = useHours
-    ? chartData.map((d) => ({ ...d, wasteTime: d.wasteTime / 60 }))
-    : chartData;
-
-  return (
-    <ResponsiveContainer width="100%" height={200}>
-      <ComposedChart data={displayData}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-        <XAxis dataKey="day" stroke="#6b7280" fontSize={12} />
-        <YAxis
-          yAxisId="waste"
-          stroke="#ef4444"
-          fontSize={12}
-          tickFormatter={(v: number) => (useHours ? `${v}h` : `${v}m`)}
-        />
-        <YAxis
-          yAxisId="block"
-          orientation="right"
-          stroke="#3b82f6"
-          fontSize={12}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: '#fff',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px'
-          }}
-          formatter={(value: number, name: string) => {
-            if (name === 'wasteTime') {
-              return [
-                formatMinutes(useHours ? value * 3600 : value * 60),
-                getMessage('wasteTime')
-              ];
-            }
-            return [value, getMessage('blockedCount')];
-          }}
-        />
-        <Bar
-          yAxisId="waste"
-          dataKey="wasteTime"
-          fill="#fca5a5"
-          radius={[4, 4, 0, 0]}
-          name="wasteTime"
-        />
-        <Line
-          yAxisId="block"
-          type="monotone"
-          dataKey="blockCount"
-          stroke="#3b82f6"
-          strokeWidth={2}
-          dot={{ fill: '#3b82f6', strokeWidth: 2, r: 3 }}
-          name="blockCount"
-        />
-      </ComposedChart>
-    </ResponsiveContainer>
-  );
-}
-
-// Monthly weekly trend chart: waste time bars + block count line
-function MonthlyTrendChart({
-  weeklyBreakdown
-}: {
-  weeklyBreakdown: {
-    weekStart: string;
-    wasteTime: number;
-    blockCount: number;
-  }[];
-}) {
-  const chartData = weeklyBreakdown.map((w, i) => ({
-    week: `W${i + 1}`,
-    wasteTime: Math.round(w.wasteTime / 60), // Convert to minutes
-    blockCount: w.blockCount
-  }));
-
-  const maxWaste = Math.max(...chartData.map((d) => d.wasteTime), 1);
-  const useHours = maxWaste >= 120;
-  const displayData = useHours
-    ? chartData.map((d) => ({ ...d, wasteTime: d.wasteTime / 60 }))
-    : chartData;
-
-  return (
-    <ResponsiveContainer width="100%" height={200}>
-      <ComposedChart data={displayData}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-        <XAxis dataKey="week" stroke="#6b7280" fontSize={12} />
-        <YAxis
-          yAxisId="waste"
-          stroke="#ef4444"
-          fontSize={12}
-          tickFormatter={(v: number) => (useHours ? `${v}h` : `${v}m`)}
-        />
-        <YAxis
-          yAxisId="block"
-          orientation="right"
-          stroke="#3b82f6"
-          fontSize={12}
-        />
-        <Tooltip
-          contentStyle={{
-            backgroundColor: '#fff',
-            border: '1px solid #e5e7eb',
-            borderRadius: '8px'
-          }}
-          formatter={(value: number, name: string) => {
-            if (name === 'wasteTime') {
-              return [
-                formatMinutes(useHours ? value * 3600 : value * 60),
-                getMessage('wasteTime')
-              ];
-            }
-            return [value, getMessage('blockedCount')];
-          }}
-        />
-        <Bar
-          yAxisId="waste"
-          dataKey="wasteTime"
-          fill="#fca5a5"
-          radius={[4, 4, 0, 0]}
-          name="wasteTime"
-        />
-        <Line
-          yAxisId="block"
-          type="monotone"
-          dataKey="blockCount"
-          stroke="#3b82f6"
-          strokeWidth={2}
-          dot={{ fill: '#3b82f6', strokeWidth: 2, r: 3 }}
-          name="blockCount"
-        />
-      </ComposedChart>
-    </ResponsiveContainer>
-  );
-}
-
-// Empty state component
-function EmptyReport({ message }: { message: string }) {
-  return (
-    <div className="text-center py-8">
-      <BarChart3 className="w-12 h-12 text-gray-300 mx-auto mb-3" />
-      <p className="text-sm text-gray-500">{message}</p>
-    </div>
-  );
-}
-
-// Weekly Report Card
+/**
+ * 週次レポートカード
+ */
 export function WeeklyReportCard({
   report,
   onPrevious,
@@ -492,13 +109,29 @@ export function WeeklyReportCard({
               <h4 className="text-sm font-medium text-danger-700 mb-2">
                 {getMessage('topWasteSites')}
               </h4>
-              <TopSitesList sites={report.topWasteSites} />
+              <RankedList
+                items={report.topWasteSites.map((site) => ({
+                  domain: site.domain,
+                  value: site.time
+                }))}
+                valueType="time"
+                bgColor="bg-danger-50"
+                textColor="text-danger-600"
+              />
             </div>
             <div>
               <h4 className="text-sm font-medium text-info-700 mb-2">
                 {getMessage('topBlockedSites')}
               </h4>
-              <TopBlockedSitesList sites={report.topBlockedSites} />
+              <RankedList
+                items={report.topBlockedSites.map((site) => ({
+                  domain: site.domain,
+                  value: site.count
+                }))}
+                valueType="count"
+                bgColor="bg-info-50"
+                textColor="text-info-600"
+              />
             </div>
           </div>
         </div>
@@ -507,7 +140,9 @@ export function WeeklyReportCard({
   );
 }
 
-// Monthly Report Card
+/**
+ * 月次レポートカード
+ */
 export function MonthlyReportCard({
   report,
   onPrevious,
@@ -579,13 +214,29 @@ export function MonthlyReportCard({
               <h4 className="text-sm font-medium text-danger-700 mb-2">
                 {getMessage('topWasteSites')}
               </h4>
-              <TopSitesList sites={report.topWasteSites} />
+              <RankedList
+                items={report.topWasteSites.map((site) => ({
+                  domain: site.domain,
+                  value: site.time
+                }))}
+                valueType="time"
+                bgColor="bg-danger-50"
+                textColor="text-danger-600"
+              />
             </div>
             <div>
               <h4 className="text-sm font-medium text-info-700 mb-2">
                 {getMessage('topBlockedSites')}
               </h4>
-              <TopBlockedSitesList sites={report.topBlockedSites} />
+              <RankedList
+                items={report.topBlockedSites.map((site) => ({
+                  domain: site.domain,
+                  value: site.count
+                }))}
+                valueType="count"
+                bgColor="bg-info-50"
+                textColor="text-info-600"
+              />
             </div>
           </div>
         </div>

--- a/src/components/features/ReportCard/StatsGrid.tsx
+++ b/src/components/features/ReportCard/StatsGrid.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import {
+  Clock,
+  Shield,
+  Unlock,
+  TrendingUp,
+  TrendingDown,
+  Minus
+} from 'lucide-react';
+import { getMessage } from '~/lib/i18n';
+import { formatTime } from '~/lib/time';
+
+interface StatsGridProps {
+  wasteTime: number;
+  blockCount: number;
+  unblockCount: number;
+  wasteTimeChangePercent: number | null;
+}
+
+/**
+ * 変化率を表示用にフォーマット
+ */
+function formatChangePercent(value: number | null): string {
+  if (value === null) {
+    return getMessage('noComparisonData');
+  }
+  const sign = value > 0 ? '+' : '';
+  return `${sign}${value.toFixed(1)}%`;
+}
+
+/**
+ * 変化率の色を決定
+ * ネガティブ（無駄時間が減少）= 緑、ポジティブ（増加）= 赤
+ */
+function getChangeColor(value: number | null) {
+  if (value === null)
+    return {
+      bg: 'bg-gray-50',
+      text: 'text-gray-600',
+      label: 'text-gray-500'
+    };
+  if (value < 0)
+    return {
+      bg: 'bg-success-50',
+      text: 'text-success-700',
+      label: 'text-success-600'
+    };
+  if (value > 0)
+    return {
+      bg: 'bg-danger-50',
+      text: 'text-danger-700',
+      label: 'text-danger-600'
+    };
+  return { bg: 'bg-gray-50', text: 'text-gray-700', label: 'text-gray-500' };
+}
+
+/**
+ * 統計情報グリッドコンポーネント
+ * 無駄時間、変化率、ブロック数、アンブロック数を表示
+ */
+export function StatsGrid({
+  wasteTime,
+  blockCount,
+  unblockCount,
+  wasteTimeChangePercent
+}: StatsGridProps) {
+  const changeColors = getChangeColor(wasteTimeChangePercent);
+
+  return (
+    <div className="grid grid-cols-4 gap-4">
+      <div className="text-center p-3 bg-danger-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-danger-600 mb-1">
+          <Clock className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-danger-700">
+          {formatTime(wasteTime)}
+        </p>
+        <p className="text-xs text-danger-600">{getMessage('wasteTime')}</p>
+      </div>
+      <div className={`text-center p-3 ${changeColors.bg} rounded-lg`}>
+        <div
+          className={`flex items-center justify-center gap-1 ${changeColors.label} mb-1`}
+        >
+          {wasteTimeChangePercent !== null && wasteTimeChangePercent < 0 ? (
+            <TrendingDown className="w-4 h-4" />
+          ) : wasteTimeChangePercent !== null && wasteTimeChangePercent > 0 ? (
+            <TrendingUp className="w-4 h-4" />
+          ) : (
+            <Minus className="w-4 h-4" />
+          )}
+        </div>
+        <p className={`text-lg font-bold ${changeColors.text}`}>
+          {formatChangePercent(wasteTimeChangePercent)}
+        </p>
+        <p className={`text-xs ${changeColors.label}`}>
+          {getMessage('previousPeriodComparison')}
+        </p>
+      </div>
+      <div className="text-center p-3 bg-info-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-info-600 mb-1">
+          <Shield className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-info-700">{blockCount}</p>
+        <p className="text-xs text-info-600">{getMessage('blockedCount')}</p>
+      </div>
+      <div className="text-center p-3 bg-warning-50 rounded-lg">
+        <div className="flex items-center justify-center gap-1 text-warning-600 mb-1">
+          <Unlock className="w-4 h-4" />
+        </div>
+        <p className="text-lg font-bold text-warning-700">{unblockCount}</p>
+        <p className="text-xs text-warning-600">
+          {getMessage('unblockedCount')}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/ReportCard/TrendIcon.tsx
+++ b/src/components/features/ReportCard/TrendIcon.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { getMessage } from '~/lib/i18n';
+
+interface TrendIconProps {
+  trend: 'improving' | 'declining' | 'stable';
+}
+
+/**
+ * トレンドアイコンコンポーネント
+ * 改善・悪化・安定のトレンドを視覚的に表示する
+ */
+export function TrendIcon({ trend }: TrendIconProps) {
+  if (trend === 'improving') {
+    return (
+      <div className="flex items-center gap-1 text-success-600">
+        <TrendingUp className="w-4 h-4" />
+        <span className="text-sm font-medium">{getMessage('improving')}</span>
+      </div>
+    );
+  }
+  if (trend === 'declining') {
+    return (
+      <div className="flex items-center gap-1 text-danger-600">
+        <TrendingDown className="w-4 h-4" />
+        <span className="text-sm font-medium">{getMessage('declining')}</span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-1 text-gray-500">
+      <Minus className="w-4 h-4" />
+      <span className="text-sm font-medium">{getMessage('stable')}</span>
+    </div>
+  );
+}

--- a/src/components/features/ReportCard/WeeklyChart.tsx
+++ b/src/components/features/ReportCard/WeeklyChart.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ComposedChart
+} from 'recharts';
+import { getMessage } from '~/lib/i18n';
+
+interface WeeklyChartProps {
+  dailyBreakdown: { wasteTime: number; blockCount: number }[];
+  dailyBlockCounts: number[];
+}
+
+// 曜日ラベル
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+/**
+ * 週次チャート用のフォーマット（秒 → 分/時間）
+ */
+function formatChartMinutes(seconds: number): string {
+  const totalMinutes = Math.round(seconds / 60);
+  const hours = Math.floor(totalMinutes / 60);
+  const mins = totalMinutes % 60;
+  if (hours > 0) return `${hours}h ${mins}m`;
+  return `${mins}m`;
+}
+
+/**
+ * 週次複合チャート: 日別の無駄時間（棒グラフ）+ ブロック数（折れ線グラフ）
+ */
+export function WeeklyChart({
+  dailyBreakdown,
+  dailyBlockCounts
+}: WeeklyChartProps) {
+  const chartData = dailyBreakdown.map((d, i) => ({
+    day: DAY_LABELS[i] || `D${i + 1}`,
+    wasteTime: Math.round(d.wasteTime / 60), // 分に変換
+    blockCount: dailyBlockCounts[i] || 0
+  }));
+
+  const maxWaste = Math.max(...chartData.map((d) => d.wasteTime), 1);
+  const useHours = maxWaste >= 120;
+  const displayData = useHours
+    ? chartData.map((d) => ({ ...d, wasteTime: d.wasteTime / 60 }))
+    : chartData;
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <ComposedChart data={displayData}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+        <XAxis dataKey="day" stroke="#6b7280" fontSize={12} />
+        <YAxis
+          yAxisId="waste"
+          stroke="#ef4444"
+          fontSize={12}
+          tickFormatter={(v: number) => (useHours ? `${v}h` : `${v}m`)}
+        />
+        <YAxis
+          yAxisId="block"
+          orientation="right"
+          stroke="#3b82f6"
+          fontSize={12}
+        />
+        <Tooltip
+          contentStyle={{
+            backgroundColor: '#fff',
+            border: '1px solid #e5e7eb',
+            borderRadius: '8px'
+          }}
+          formatter={(value: number, name: string) => {
+            if (name === 'wasteTime') {
+              return [
+                formatChartMinutes(useHours ? value * 3600 : value * 60),
+                getMessage('wasteTime')
+              ];
+            }
+            return [value, getMessage('blockedCount')];
+          }}
+        />
+        <Bar
+          yAxisId="waste"
+          dataKey="wasteTime"
+          fill="#fca5a5"
+          radius={[4, 4, 0, 0]}
+          name="wasteTime"
+        />
+        <Line
+          yAxisId="block"
+          type="monotone"
+          dataKey="blockCount"
+          stroke="#3b82f6"
+          strokeWidth={2}
+          dot={{ fill: '#3b82f6', strokeWidth: 2, r: 3 }}
+          name="blockCount"
+        />
+      </ComposedChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
Closes #252

## 概要
`ReportCard.tsx` を複数のサブコンポーネントに分割し、保守性を向上させました。

## 変更内容

### 新規作成ファイル
```
ReportCard/
├── TrendIcon.tsx            (36行) - トレンド表示
├── StatsGrid.tsx            (117行) - 統計情報グリッド
├── RankedList.tsx           (60行) - ランキングリスト（共通化）
├── WeeklyChart.tsx          (104行) - 週次チャート
├── MonthlyTrendChart.tsx    (103行) - 月次トレンドチャート
├── EmptyReport.tsx          (18行) - 空レポート表示
└── ReportCard.tsx           (246行) - メインエクスポート
```

### リファクタリング詳細
1. **TopSitesList と TopBlockedSitesList を RankedList に統合**
   - valueType で time/count を切り替え
   - 背景色・テキスト色をpropsで渡す

2. **formatMinutes の処理**
   - 元の formatMinutes は各チャート内で formatChartMinutes として定義
   - lib/time.ts の formatTime を使用（データ表示用）

3. **WeeklyReportCard と MonthlyReportCard**
   - 統合せず個別に維持（ヘッダー・チャートが異なるため）

## テスト結果
```
✓ Type Check: OK
✓ Lint: OK (既存の警告のみ)
✓ Tests: 593 passed
```

## レビュー観点
- [x] コンポーネント分割が適切か
- [x] 各コンポーネントの責務が明確か
- [x] 既存機能が維持されているか
- [x] 日本語コメントが適切に記載されているか

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>