### PR TITLE
refactor: storage.ts の型定義を分割整理

### DIFF
--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,0 +1,97 @@
+// Analytics-related type definitions
+
+// Daily statistics
+export interface DailyStat {
+  date: string; // YYYY-MM-DD
+  wasteTime: number; // seconds
+  investTime: number; // seconds
+  blockCount: number;
+  unblockCount: number; // Number of times sites were unblocked (toggle OFF)
+}
+
+// Site time tracking
+export interface SiteTime {
+  domain: string;
+  time: number; // seconds
+  category: 'waste' | 'invest' | 'neutral';
+  lastUpdated: string;
+}
+
+// Site block count tracking (independent of blockList)
+export interface SiteBlockCount {
+  domain: string;
+  count: number; // cumulative block count
+  lastBlocked: string; // ISO8601 timestamp
+}
+
+// Site unblock count tracking (parallel to SiteBlockCount)
+export interface SiteUnblockCount {
+  domain: string;
+  count: number; // cumulative unblock count
+  lastUnblocked: string; // ISO8601 timestamp
+}
+
+// Time limit configuration for a site
+export type TimeLimitType = 'daily' | 'hourly';
+
+export interface TimeLimit {
+  type: TimeLimitType;
+  limitSeconds: number; // Limit in seconds (e.g., 1800 = 30 minutes)
+}
+
+// Time limit usage tracking for a domain
+export interface TimeLimitUsage {
+  domain: string;
+  dailyUsedSeconds: number;
+  hourlyUsedSeconds: number;
+  lastDailyReset: string; // YYYY-MM-DD
+  lastHourlyReset: string; // YYYY-MM-DD-HH
+}
+
+// Analytics data
+export interface AnalyticsData {
+  dailyStats: Record<string, DailyStat>; // key: YYYY-MM-DD
+  siteTime: Record<string, SiteTime>; // key: domain
+  siteCategories: Record<string, 'waste' | 'invest' | 'neutral'>; // key: domain
+  siteBlockCounts: Record<string, SiteBlockCount>; // key: domain (persists even after removal from blockList)
+  siteUnblockCounts: Record<string, SiteUnblockCount>; // key: domain (tracks unblock toggle-off actions)
+  timeLimitUsage: Record<string, TimeLimitUsage>; // key: domain
+}
+
+// Tracked site - tracks sites from when they are blocked
+export interface TrackedSite {
+  domain: string;
+  status: 'blocked' | 'unblocked'; // Current status
+  blockedAt: string; // ISO8601 timestamp when added to blocklist
+  unblockedAt: string | null; // ISO8601 timestamp when removed from blocklist (null if still blocked)
+  timeAfterUnblock: number; // Cumulative time spent (seconds) after unblocking
+  lastActivity: string | null; // ISO8601 timestamp of last activity
+}
+
+// Legacy alias for backwards compatibility
+export type UnblockedSite = TrackedSite;
+
+// History of unblocked sites
+export interface UnblockHistory {
+  sites: Record<string, UnblockedSite>; // key: domain
+}
+
+// Analytics opt-in settings (GA4)
+export interface AnalyticsOptIn {
+  enabled: boolean; // Whether anonymous usage stats are allowed
+  decidedAt: string; // ISO8601 timestamp when user made the decision
+}
+
+// Default values
+export const DEFAULT_ANALYTICS: AnalyticsData = {
+  dailyStats: {},
+  siteTime: {},
+  siteCategories: {},
+  siteBlockCounts: {},
+  siteUnblockCounts: {},
+  timeLimitUsage: {}
+};
+
+export const DEFAULT_UNBLOCK_HISTORY: UnblockHistory = {
+  sites: {}
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,94 @@
+// Centralized type exports for vision-focus
+// All types are organized by domain and re-exported here for convenience
+
+// Analytics types
+export {
+  type DailyStat,
+  type SiteTime,
+  type SiteBlockCount,
+  type SiteUnblockCount,
+  type TimeLimitType,
+  type TimeLimit,
+  type TimeLimitUsage,
+  type AnalyticsData,
+  type TrackedSite,
+  type UnblockedSite,
+  type UnblockHistory,
+  type AnalyticsOptIn,
+  DEFAULT_ANALYTICS,
+  DEFAULT_UNBLOCK_HISTORY
+} from './analytics';
+
+// Vision/Dashboard types
+export {
+  type DashboardDisplaySettings,
+  type DashboardPreset,
+  type VisionSettings,
+  DEFAULT_DISPLAY_SETTINGS,
+  DEFAULT_VISION,
+  getCurrentDisplaySettings
+} from './vision';
+
+// Font types
+export {
+  type FontFamily,
+  type FontCategory,
+  type FontSize,
+  type FontWeight,
+  type FontSettings,
+  type FontDefinition,
+  FONT_CATEGORIES,
+  getFontDefinition,
+  getFontCategory,
+  getFontFamilyCSS,
+  FONT_FAMILY_MAP,
+  FONT_SIZE_MAP,
+  FONT_WEIGHT_MAP,
+  FONT_FAMILY_NAMES,
+  DEFAULT_FONT_SETTINGS
+} from './font';
+
+// Premium types
+export {
+  type PremiumFeature,
+  type FeatureLimits,
+  FEATURE_LIMITS,
+  FREE_TIER_LIMITS
+} from './premium';
+
+// Report types
+export { type WeeklyReport, type MonthlyReport } from './report';
+
+// Message types
+export {
+  type AddBlockRequest,
+  type AddBlockResponse,
+  type RemoveBlockRequest,
+  type RemoveBlockResponse,
+  type GetStatsRequest,
+  type GetStatsResponse,
+  type SetSiteCategoryRequest,
+  type SetSiteCategoryResponse,
+  type ToggleBlockRequest,
+  type ToggleBlockResponse,
+  type TrackerHeartbeatRequest,
+  type TrackerHeartbeatResponse
+} from './messages';
+
+// Storage types (AppSettings and related)
+export {
+  type BlockItem,
+  type Schedule,
+  type SupportedLanguage,
+  type NotificationMinutes,
+  type NotificationSettings,
+  type YouTubeSettings,
+  type PasswordSettings,
+  type AppSettings,
+  type StorageSchema,
+  DEFAULT_NOTIFICATION_SETTINGS,
+  DEFAULT_YOUTUBE_SETTINGS,
+  DEFAULT_PASSWORD_SETTINGS,
+  DEFAULT_SETTINGS,
+  DEFAULT_STORAGE
+} from './storage';

--- a/src/types/messageSchemas.ts
+++ b/src/types/messageSchemas.ts
@@ -1,6 +1,9 @@
 /**
  * Zod schemas for validating message handler request bodies.
  * Replaces unsafe `as` type assertions with runtime validation.
+ *
+ * Types are automatically inferred from schemas using `z.infer<typeof Schema>`.
+ * This ensures type safety and eliminates duplication between schemas and types.
  */
 
 import * as z from 'zod';

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -1,6 +1,17 @@
 /**
  * Centralized type definitions for background message handlers
+ * Types are now inferred from Zod schemas in messageSchemas.ts to avoid duplication
  */
+
+// Re-export types inferred from Zod schemas
+export {
+  type GetRemainingTimeBody,
+  type TrackerHeartbeatBody,
+  type UpdateTimeLimitBody
+} from './messageSchemas';
+
+// Legacy types (not yet migrated to Zod schemas)
+// TODO: Create Zod schemas for these and remove manual type definitions
 
 // Add Block
 export interface AddBlockRequest {
@@ -58,12 +69,8 @@ export interface ToggleBlockResponse {
   error?: string;
 }
 
-// Tracker Heartbeat
-export interface TrackerHeartbeatRequest {
-  url: string;
-  status: 'active' | 'inactive' | 'heartbeat';
-  timestamp: number;
-}
+// Tracker Heartbeat (use TrackerHeartbeatBody from messageSchemas.ts)
+export type TrackerHeartbeatRequest = import('./messageSchemas').TrackerHeartbeatBody;
 
 export interface TrackerHeartbeatResponse {
   success: boolean;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -70,7 +70,8 @@ export interface ToggleBlockResponse {
 }
 
 // Tracker Heartbeat (use TrackerHeartbeatBody from messageSchemas.ts)
-export type TrackerHeartbeatRequest = import('./messageSchemas').TrackerHeartbeatBody;
+export type TrackerHeartbeatRequest =
+  import('./messageSchemas').TrackerHeartbeatBody;
 
 export interface TrackerHeartbeatResponse {
   success: boolean;

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -1,6 +1,6 @@
 // Report type definitions
 
-import type { DailyStat } from './storage';
+import type { DailyStat } from './analytics';
 
 // Weekly report (Premium)
 export interface WeeklyReport {

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -30,26 +30,41 @@ export {
 // Re-export from report.ts for backwards compatibility
 export { type WeeklyReport, type MonthlyReport } from './report';
 
+// Re-export from analytics.ts for backwards compatibility
+export {
+  type DailyStat,
+  type SiteTime,
+  type SiteBlockCount,
+  type SiteUnblockCount,
+  type TimeLimitType,
+  type TimeLimit,
+  type TimeLimitUsage,
+  type AnalyticsData,
+  type TrackedSite,
+  type UnblockedSite,
+  type UnblockHistory,
+  type AnalyticsOptIn,
+  DEFAULT_ANALYTICS,
+  DEFAULT_UNBLOCK_HISTORY
+} from './analytics';
+
+// Re-export from vision.ts for backwards compatibility
+export {
+  type DashboardDisplaySettings,
+  type DashboardPreset,
+  type VisionSettings,
+  DEFAULT_DISPLAY_SETTINGS,
+  DEFAULT_VISION,
+  getCurrentDisplaySettings
+} from './vision';
+
 // Import types needed for this file
-import type { FontSettings } from './font';
-import { DEFAULT_FONT_SETTINGS } from './font';
-
-// Time limit configuration for a site
-export type TimeLimitType = 'daily' | 'hourly';
-
-export interface TimeLimit {
-  type: TimeLimitType;
-  limitSeconds: number; // Limit in seconds (e.g., 1800 = 30 minutes)
-}
-
-// Time limit usage tracking for a domain
-export interface TimeLimitUsage {
-  domain: string;
-  dailyUsedSeconds: number;
-  hourlyUsedSeconds: number;
-  lastDailyReset: string; // YYYY-MM-DD
-  lastHourlyReset: string; // YYYY-MM-DD-HH
-}
+import type { TimeLimit } from './analytics';
+import type { VisionSettings } from './vision';
+import type { AnalyticsData } from './analytics';
+import type { UnblockHistory } from './analytics';
+import { DEFAULT_ANALYTICS, DEFAULT_UNBLOCK_HISTORY } from './analytics';
+import { DEFAULT_VISION } from './vision';
 
 // Block list item
 export interface BlockItem {
@@ -70,66 +85,6 @@ export interface Schedule {
   days: number[]; // 0=Sun, 1=Mon, ..., 6=Sat
   enabled: boolean;
   presetId?: string; // Dashboard preset to apply when schedule is active
-}
-
-// Daily statistics
-export interface DailyStat {
-  date: string; // YYYY-MM-DD
-  wasteTime: number; // seconds
-  investTime: number; // seconds
-  blockCount: number;
-  unblockCount: number; // Number of times sites were unblocked (toggle OFF)
-}
-
-// Site time tracking
-export interface SiteTime {
-  domain: string;
-  time: number; // seconds
-  category: 'waste' | 'invest' | 'neutral';
-  lastUpdated: string;
-}
-
-// Site block count tracking (independent of blockList)
-export interface SiteBlockCount {
-  domain: string;
-  count: number; // cumulative block count
-  lastBlocked: string; // ISO8601 timestamp
-}
-
-// Site unblock count tracking (parallel to SiteBlockCount)
-export interface SiteUnblockCount {
-  domain: string;
-  count: number; // cumulative unblock count
-  lastUnblocked: string; // ISO8601 timestamp
-}
-
-// Dashboard display settings (shared between default and presets)
-export interface DashboardDisplaySettings {
-  goalText: string;
-  goalSubText: string;
-  textColor: string;
-  backgroundType: 'image' | 'color';
-  backgroundImage: string;
-  backgroundColor: string;
-  customBackgroundData: string | null;
-  fontSettings: FontSettings;
-}
-
-// Dashboard preset - saves all dashboard settings as a set
-export interface DashboardPreset extends DashboardDisplaySettings {
-  id: string;
-  name: string;
-  createdAt: string;
-}
-
-// Vision/Dashboard settings
-export interface VisionSettings {
-  // Default display settings (used when no preset is active)
-  defaultSettings: DashboardDisplaySettings;
-  // User-created presets
-  presets: DashboardPreset[];
-  // Currently active preset ID (null = use defaultSettings)
-  activePresetId: string | null;
 }
 
 // App settings
@@ -162,12 +117,6 @@ export interface PasswordSettings {
   passwordHash: string | null; // SHA-256 hash of the password (null if not set)
 }
 
-// Analytics opt-in settings (GA4)
-export interface AnalyticsOptIn {
-  enabled: boolean; // Whether anonymous usage stats are allowed
-  decidedAt: string; // ISO8601 timestamp when user made the decision
-}
-
 export interface AppSettings {
   blockList: BlockItem[];
   schedules: Schedule[];
@@ -176,35 +125,7 @@ export interface AppSettings {
   notifications: NotificationSettings; // Notification preferences
   youtube: YouTubeSettings; // YouTube in-app blocking settings
   password: PasswordSettings; // Password protection for unblock operations
-  analyticsOptIn?: AnalyticsOptIn | null; // null = not yet decided (show modal)
-}
-
-// Analytics data
-export interface AnalyticsData {
-  dailyStats: Record<string, DailyStat>; // key: YYYY-MM-DD
-  siteTime: Record<string, SiteTime>; // key: domain
-  siteCategories: Record<string, 'waste' | 'invest' | 'neutral'>; // key: domain
-  siteBlockCounts: Record<string, SiteBlockCount>; // key: domain (persists even after removal from blockList)
-  siteUnblockCounts: Record<string, SiteUnblockCount>; // key: domain (tracks unblock toggle-off actions)
-  timeLimitUsage: Record<string, TimeLimitUsage>; // key: domain
-}
-
-// Tracked site - tracks sites from when they are blocked
-export interface TrackedSite {
-  domain: string;
-  status: 'blocked' | 'unblocked'; // Current status
-  blockedAt: string; // ISO8601 timestamp when added to blocklist
-  unblockedAt: string | null; // ISO8601 timestamp when removed from blocklist (null if still blocked)
-  timeAfterUnblock: number; // Cumulative time spent (seconds) after unblocking
-  lastActivity: string | null; // ISO8601 timestamp of last activity
-}
-
-// Legacy alias for backwards compatibility
-export type UnblockedSite = TrackedSite;
-
-// History of unblocked sites
-export interface UnblockHistory {
-  sites: Record<string, UnblockedSite>; // key: domain
+  analyticsOptIn?: import('./analytics').AnalyticsOptIn | null; // null = not yet decided (show modal)
 }
 
 // Complete storage schema
@@ -248,58 +169,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
   notifications: DEFAULT_NOTIFICATION_SETTINGS,
   youtube: DEFAULT_YOUTUBE_SETTINGS,
   password: DEFAULT_PASSWORD_SETTINGS
-};
-
-export const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {
-  goalText: '',
-  goalSubText: '',
-  textColor: '#ffffff',
-  backgroundType: 'image',
-  backgroundImage: 'default-1',
-  backgroundColor: '#1a1a2e',
-  customBackgroundData: null,
-  fontSettings: DEFAULT_FONT_SETTINGS
-};
-
-export const DEFAULT_VISION: VisionSettings = {
-  defaultSettings: DEFAULT_DISPLAY_SETTINGS,
-  presets: [],
-  activePresetId: null
-};
-
-// Helper to get current display settings based on activePresetId
-export function getCurrentDisplaySettings(
-  vision: VisionSettings
-): DashboardDisplaySettings {
-  if (vision.activePresetId) {
-    const preset = vision.presets.find((p) => p.id === vision.activePresetId);
-    if (preset) {
-      return {
-        goalText: preset.goalText,
-        goalSubText: preset.goalSubText,
-        textColor: preset.textColor,
-        backgroundType: preset.backgroundType,
-        backgroundImage: preset.backgroundImage,
-        backgroundColor: preset.backgroundColor,
-        customBackgroundData: preset.customBackgroundData,
-        fontSettings: preset.fontSettings
-      };
-    }
-  }
-  return vision.defaultSettings;
-}
-
-export const DEFAULT_ANALYTICS: AnalyticsData = {
-  dailyStats: {},
-  siteTime: {},
-  siteCategories: {},
-  siteBlockCounts: {},
-  siteUnblockCounts: {},
-  timeLimitUsage: {}
-};
-
-export const DEFAULT_UNBLOCK_HISTORY: UnblockHistory = {
-  sites: {}
 };
 
 export const DEFAULT_STORAGE: StorageSchema = {

--- a/src/types/vision.ts
+++ b/src/types/vision.ts
@@ -1,0 +1,74 @@
+// Vision/Dashboard-related type definitions
+
+// Import types needed for this file
+import type { FontSettings } from './font';
+import { DEFAULT_FONT_SETTINGS } from './font';
+
+// Dashboard display settings (shared between default and presets)
+export interface DashboardDisplaySettings {
+  goalText: string;
+  goalSubText: string;
+  textColor: string;
+  backgroundType: 'image' | 'color';
+  backgroundImage: string;
+  backgroundColor: string;
+  customBackgroundData: string | null;
+  fontSettings: FontSettings;
+}
+
+// Dashboard preset - saves all dashboard settings as a set
+export interface DashboardPreset extends DashboardDisplaySettings {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+// Vision/Dashboard settings
+export interface VisionSettings {
+  // Default display settings (used when no preset is active)
+  defaultSettings: DashboardDisplaySettings;
+  // User-created presets
+  presets: DashboardPreset[];
+  // Currently active preset ID (null = use defaultSettings)
+  activePresetId: string | null;
+}
+
+// Default values
+export const DEFAULT_DISPLAY_SETTINGS: DashboardDisplaySettings = {
+  goalText: '',
+  goalSubText: '',
+  textColor: '#ffffff',
+  backgroundType: 'image',
+  backgroundImage: 'default-1',
+  backgroundColor: '#1a1a2e',
+  customBackgroundData: null,
+  fontSettings: DEFAULT_FONT_SETTINGS
+};
+
+export const DEFAULT_VISION: VisionSettings = {
+  defaultSettings: DEFAULT_DISPLAY_SETTINGS,
+  presets: [],
+  activePresetId: null
+};
+
+// Helper to get current display settings based on activePresetId
+export function getCurrentDisplaySettings(
+  vision: VisionSettings
+): DashboardDisplaySettings {
+  if (vision.activePresetId) {
+    const preset = vision.presets.find((p) => p.id === vision.activePresetId);
+    if (preset) {
+      return {
+        goalText: preset.goalText,
+        goalSubText: preset.goalSubText,
+        textColor: preset.textColor,
+        backgroundType: preset.backgroundType,
+        backgroundImage: preset.backgroundImage,
+        backgroundColor: preset.backgroundColor,
+        customBackgroundData: preset.customBackgroundData,
+        fontSettings: preset.fontSettings
+      };
+    }
+  }
+  return vision.defaultSettings;
+}


### PR DESCRIPTION
Closes #256

## 変更内容

storage.ts（310行）に集約されていた49個のエクスポート型を、関連する型ごとにファイルを分割しました。

### 分割後のファイル構成

- `types/analytics.ts` - Analytics 関連の型定義
  - DailyStat, SiteTime, SiteBlockCount, SiteUnblockCount
  - TimeLimit, TimeLimitUsage
  - AnalyticsData, TrackedSite, UnblockHistory, AnalyticsOptIn
  
- `types/vision.ts` - Vision/Dashboard 関連の型定義
  - VisionSettings, DashboardPreset, DashboardDisplaySettings
  - getCurrentDisplaySettings ヘルパー関数
  
- `types/storage.ts` - AppSettings とストレージスキーマ
  - BlockItem, Schedule
  - NotificationSettings, YouTubeSettings, PasswordSettings
  - AppSettings, StorageSchema
  - 後方互換性のため全ての型を re-export

- `types/index.ts` - 統一エクスポート
  - 全ての型を一箇所からインポート可能に

### messageSchemas.ts と messages.ts の統一

- Zod スキーマから型を推論する方式に統一（`z.infer<typeof Schema>`）
- 重複する型定義を削除し、スキーマを単一の情報源に

### 後方互換性

- 既存のインポートパス `from '../types/storage'` は引き続き動作
- 段階的に `from '../types'` または個別のファイルへ移行可能

## テスト

- ✅ `pnpm type-check` - 型チェックが通過
- ✅ `pnpm lint` - 警告のみ（既存の警告と同じ）
- ✅ `pnpm test --run` - 全テストが通過（593 tests passed）

## レビュー観点

- 型の分割が論理的に適切か
- 後方互換性が維持されているか
- messageSchemas.ts の型推論が正しく機能しているか