### PR TITLE
refactor: Props Drilling を Context API で解消

### DIFF
--- a/src/components/options/AnalyticsTab.stories.tsx
+++ b/src/components/options/AnalyticsTab.stories.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { AnalyticsTab } from './AnalyticsTab';
+import { SettingsProvider } from '~/contexts/SettingsContext';
 import type { UnblockHistory, AnalyticsData } from '~/types/storage';
-import { DEFAULT_SETTINGS } from '~/types/storage';
 
 const mockUnblockHistory: UnblockHistory = {
   sites: {
@@ -122,9 +122,11 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-        <Story />
-      </div>
+      <SettingsProvider>
+        <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+          <Story />
+        </div>
+      </SettingsProvider>
     )
   ]
 } satisfies Meta<typeof AnalyticsTab>;
@@ -136,7 +138,6 @@ export const FreeTier: Story = {
   args: {
     unblockHistory: mockUnblockHistory,
     analyticsData: mockAnalytics,
-    settings: DEFAULT_SETTINGS,
     isPremium: false,
     onReblock: (domain) => alert(`Reblock: ${domain}`),
     onReset: () => alert('Reset analytics'),
@@ -150,7 +151,6 @@ export const Premium: Story = {
   args: {
     unblockHistory: mockUnblockHistory,
     analyticsData: mockAnalytics,
-    settings: DEFAULT_SETTINGS,
     isPremium: true,
     onReblock: (domain) => alert(`Reblock: ${domain}`),
     onReset: () => alert('Reset analytics'),
@@ -171,7 +171,6 @@ export const Empty: Story = {
       siteUnblockCounts: {},
       timeLimitUsage: {}
     },
-    settings: DEFAULT_SETTINGS,
     isPremium: false,
     onReblock: () => {},
     onReset: () => {},

--- a/src/components/options/AnalyticsTab.tsx
+++ b/src/components/options/AnalyticsTab.tsx
@@ -3,11 +3,8 @@ import { Plus } from 'lucide-react';
 
 import { Card, Button, Input } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
-import type {
-  UnblockHistory,
-  AnalyticsData,
-  AppSettings
-} from '~/types/storage';
+import { useSettings } from '~/contexts/SettingsContext';
+import type { UnblockHistory, AnalyticsData } from '~/types/storage';
 
 import {
   AnalyticsExportBar,
@@ -19,7 +16,6 @@ import {
 interface AnalyticsTabProps {
   unblockHistory: UnblockHistory;
   analyticsData: AnalyticsData;
-  settings: AppSettings | null;
   isPremium: boolean;
   onReblock: (domain: string) => void;
   onReset: () => void;
@@ -31,7 +27,6 @@ interface AnalyticsTabProps {
 export function AnalyticsTab({
   unblockHistory,
   analyticsData,
-  settings,
   isPremium,
   onReblock,
   onReset,
@@ -39,6 +34,7 @@ export function AnalyticsTab({
   onRefresh,
   onAddSite
 }: AnalyticsTabProps) {
+  const { settings } = useSettings();
   const [newSiteDomain, setNewSiteDomain] = useState('');
 
   const handleAddSite = () => {

--- a/src/components/options/BlocklistTab.stories.tsx
+++ b/src/components/options/BlocklistTab.stories.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { BlocklistTab } from './BlocklistTab';
+import { SettingsProvider } from '~/contexts/SettingsContext';
 import type {
   AppSettings,
   BlockItem,
@@ -120,21 +121,22 @@ const BlocklistTabWrapper = () => {
   };
 
   return (
-    <BlocklistTab
-      settings={settings}
-      newDomain={newDomain}
-      setNewDomain={setNewDomain}
-      blockError={blockError}
-      onAddDomain={handleAddDomain}
-      onRemoveDomain={handleRemoveDomain}
-      onToggleDomain={handleToggleDomain}
-      onUpdateTimeLimit={() => {}}
-      onUpdateNotifications={handleUpdateNotifications}
-      siteBlockCounts={{}}
-      timeLimitUsage={{}}
-      youtube={settings.youtube}
-      onYouTubeChange={handleYouTubeChange}
-    />
+    <SettingsProvider>
+      <BlocklistTab
+        newDomain={newDomain}
+        setNewDomain={setNewDomain}
+        blockError={blockError}
+        onAddDomain={handleAddDomain}
+        onRemoveDomain={handleRemoveDomain}
+        onToggleDomain={handleToggleDomain}
+        onUpdateTimeLimit={() => {}}
+        onUpdateNotifications={handleUpdateNotifications}
+        siteBlockCounts={{}}
+        timeLimitUsage={{}}
+        youtube={settings.youtube}
+        onYouTubeChange={handleYouTubeChange}
+      />
+    </SettingsProvider>
   );
 };
 
@@ -153,7 +155,6 @@ const meta = {
     )
   ],
   args: {
-    settings: mockSettings,
     newDomain: '',
     setNewDomain: () => {},
     blockError: '',

--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -12,8 +12,8 @@ import {
   YouTubeSection,
   DomainListItem
 } from '~/components/options/blocklist';
+import { useSettings } from '~/contexts/SettingsContext';
 import type {
-  AppSettings,
   BlockItem,
   SiteBlockCount,
   TimeLimit,
@@ -23,7 +23,6 @@ import type {
 } from '~/types/storage';
 
 interface BlocklistTabProps {
-  settings: AppSettings | undefined;
   newDomain: string;
   setNewDomain: (value: string) => void;
   blockError: string;
@@ -39,7 +38,6 @@ interface BlocklistTabProps {
 }
 
 export function BlocklistTab({
-  settings,
   newDomain,
   setNewDomain,
   blockError,
@@ -53,6 +51,7 @@ export function BlocklistTab({
   youtube,
   onYouTubeChange
 }: BlocklistTabProps) {
+  const { settings } = useSettings();
   // Password protection state
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);

--- a/src/components/options/HelpTab.stories.tsx
+++ b/src/components/options/HelpTab.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { HelpTab } from './HelpTab';
-import { DEFAULT_SETTINGS } from '~/types/storage';
+import { SettingsProvider } from '~/contexts/SettingsContext';
 
 const meta = {
   title: 'Options/HelpTab',
@@ -14,9 +14,11 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-        <Story />
-      </div>
+      <SettingsProvider>
+        <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+          <Story />
+        </div>
+      </SettingsProvider>
     )
   ]
 } satisfies Meta<typeof HelpTab>;
@@ -26,7 +28,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    settings: DEFAULT_SETTINGS,
     onSettingsChange: () => alert('Settings changed'),
     onPasswordUpdate: async () => alert('Password updated'),
     onAnalyticsOptInChange: async () => alert('Analytics opt-in changed')
@@ -34,7 +35,5 @@ export const Default: Story = {
 };
 
 export const WithoutCallbacks: Story = {
-  args: {
-    settings: DEFAULT_SETTINGS
-  }
+  args: {}
 };

--- a/src/components/options/HelpTab.tsx
+++ b/src/components/options/HelpTab.tsx
@@ -9,9 +9,9 @@ import { HelpTroubleshooting } from '~/components/options/HelpTroubleshooting';
 import { HelpDataPrivacy } from '~/components/options/HelpDataPrivacy';
 import { HelpSettingsBackup } from '~/components/options/HelpSettingsBackup';
 import { getMessage, getSupportedLanguages } from '~/lib/i18n';
+import { useSettings } from '~/contexts/SettingsContext';
 import type {
   PasswordSettings,
-  AppSettings,
   AnalyticsOptIn,
   SupportedLanguage
 } from '~/types/storage';
@@ -21,7 +21,6 @@ const VERSION = '1.0.0';
 
 interface HelpTabProps {
   onSettingsChange?: () => void;
-  settings?: AppSettings;
   onPasswordUpdate?: (settings: PasswordSettings) => Promise<void>;
   onAnalyticsOptInChange?: (optIn: AnalyticsOptIn) => Promise<void>;
   onLanguageChange?: (language: SupportedLanguage | null) => Promise<void>;
@@ -29,11 +28,11 @@ interface HelpTabProps {
 
 export function HelpTab({
   onSettingsChange,
-  settings,
   onPasswordUpdate,
   onAnalyticsOptInChange,
   onLanguageChange
 }: HelpTabProps) {
+  const { settings } = useSettings();
   return (
     <div className="space-y-6">
       {/* Getting Started */}

--- a/src/components/options/SchedulesTab.stories.tsx
+++ b/src/components/options/SchedulesTab.stories.tsx
@@ -3,8 +3,9 @@ import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { SchedulesTab } from './SchedulesTab';
-import type { AppSettings, VisionSettings, Schedule } from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_VISION } from '~/types/storage';
+import { SettingsProvider } from '~/contexts/SettingsContext';
+import type { AppSettings, Schedule } from '~/types/storage';
+import { DEFAULT_SETTINGS } from '~/types/storage';
 
 const mockSchedules: Schedule[] = [
   {
@@ -30,7 +31,6 @@ const SchedulesTabWrapper = () => {
     ...DEFAULT_SETTINGS,
     schedules: mockSchedules
   });
-  const [vision] = useState<VisionSettings>(DEFAULT_VISION);
 
   const handleAddSchedule = () => {
     alert('Add schedule modal would open here');
@@ -57,14 +57,14 @@ const SchedulesTabWrapper = () => {
   };
 
   return (
-    <SchedulesTab
-      settings={settings}
-      vision={vision}
-      onAddSchedule={handleAddSchedule}
-      onEditSchedule={handleEditSchedule}
-      onDeleteSchedule={handleDeleteSchedule}
-      onToggleSchedule={handleToggleSchedule}
-    />
+    <SettingsProvider>
+      <SchedulesTab
+        onAddSchedule={handleAddSchedule}
+        onEditSchedule={handleEditSchedule}
+        onDeleteSchedule={handleDeleteSchedule}
+        onToggleSchedule={handleToggleSchedule}
+      />
+    </SettingsProvider>
   );
 };
 
@@ -83,8 +83,6 @@ const meta = {
     )
   ],
   args: {
-    settings: DEFAULT_SETTINGS,
-    vision: DEFAULT_VISION,
     onAddSchedule: () => {},
     onEditSchedule: () => {},
     onDeleteSchedule: () => {},
@@ -101,13 +99,13 @@ export const Default: Story = {
 
 export const Empty: Story = {
   render: () => (
-    <SchedulesTab
-      settings={DEFAULT_SETTINGS}
-      vision={DEFAULT_VISION}
-      onAddSchedule={() => alert('Add schedule')}
-      onEditSchedule={() => {}}
-      onDeleteSchedule={() => {}}
-      onToggleSchedule={() => {}}
-    />
+    <SettingsProvider>
+      <SchedulesTab
+        onAddSchedule={() => alert('Add schedule')}
+        onEditSchedule={() => {}}
+        onDeleteSchedule={() => {}}
+        onToggleSchedule={() => {}}
+      />
+    </SettingsProvider>
   )
 };

--- a/src/components/options/SchedulesTab.tsx
+++ b/src/components/options/SchedulesTab.tsx
@@ -3,15 +3,14 @@ import { Plus, Trash2, Info } from 'lucide-react';
 
 import { Button, Card, Toggle } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
-import type { AppSettings, Schedule, VisionSettings } from '~/types/storage';
+import { useSettings } from '~/contexts/SettingsContext';
+import type { Schedule } from '~/types/storage';
 
 import { WeeklyCalendar } from './WeeklyCalendar';
 
 const DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'] as const;
 
 interface SchedulesTabProps {
-  settings: AppSettings | undefined;
-  vision: VisionSettings | undefined;
   onAddSchedule: () => void;
   onEditSchedule: (schedule: Schedule) => void;
   onDeleteSchedule: (id: string) => void;
@@ -19,13 +18,12 @@ interface SchedulesTabProps {
 }
 
 export function SchedulesTab({
-  settings,
-  vision,
   onAddSchedule,
   onEditSchedule,
   onDeleteSchedule,
   onToggleSchedule
 }: SchedulesTabProps) {
+  const { settings, vision } = useSettings();
   return (
     <div className="space-y-6">
       {/* Weekly Calendar */}

--- a/src/components/options/modals/AnalyticsOptInModal.tsx
+++ b/src/components/options/modals/AnalyticsOptInModal.tsx
@@ -4,18 +4,23 @@ import { BarChart3 } from 'lucide-react';
 
 import { Button } from '~/components/ui';
 import { getMessage } from '~/lib/i18n';
+import { useSettings } from '~/contexts/SettingsContext';
 
 interface AnalyticsOptInModalProps {
-  isOpen: boolean;
   onAllow: () => void;
   onDeny: () => void;
 }
 
 export function AnalyticsOptInModal({
-  isOpen,
   onAllow,
   onDeny
 }: AnalyticsOptInModalProps) {
+  const { settings } = useSettings();
+
+  const isOpen =
+    settings?.analyticsOptIn === undefined ||
+    settings?.analyticsOptIn === null;
+
   if (!isOpen) return null;
 
   return (

--- a/src/components/options/modals/AnalyticsOptInModal.tsx
+++ b/src/components/options/modals/AnalyticsOptInModal.tsx
@@ -18,8 +18,7 @@ export function AnalyticsOptInModal({
   const { settings } = useSettings();
 
   const isOpen =
-    settings?.analyticsOptIn === undefined ||
-    settings?.analyticsOptIn === null;
+    settings?.analyticsOptIn === undefined || settings?.analyticsOptIn === null;
 
   if (!isOpen) return null;
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect } from 'react';
+import type { ReactNode } from 'react';
+
+import { useStorage } from '@plasmohq/storage/hook';
+
+import { storage } from '~/lib/storage';
+import { setCurrentLanguage } from '~/lib/i18n';
+import type { AppSettings, VisionSettings } from '~/types/storage';
+import { DEFAULT_SETTINGS, DEFAULT_VISION } from '~/types/storage';
+
+interface SettingsContextValue {
+  settings: AppSettings | undefined;
+  setSettings: (settings: AppSettings | undefined) => void;
+  vision: VisionSettings | undefined;
+  setVision: (vision: VisionSettings | undefined) => void;
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(
+  undefined
+);
+
+interface SettingsProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Settings Context Provider
+ * settings と vision を Context API で管理し、options.tsx の Props Drilling を解消する
+ */
+export function SettingsProvider({ children }: SettingsProviderProps) {
+  const [settings, setSettings] = useStorage<AppSettings>(
+    {
+      key: 'settings',
+      instance: storage
+    },
+    DEFAULT_SETTINGS
+  );
+
+  const [vision, setVision] = useStorage<VisionSettings>(
+    {
+      key: 'vision',
+      instance: storage
+    },
+    DEFAULT_VISION
+  );
+
+  // Sync language setting with i18n module
+  useEffect(() => {
+    if (settings?.language !== undefined) {
+      setCurrentLanguage(settings.language);
+    }
+  }, [settings?.language]);
+
+  return (
+    <SettingsContext.Provider
+      value={{ settings, setSettings, vision, setVision }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+/**
+ * Settings Context Hook
+ * settings と vision にアクセスするためのカスタムフック
+ */
+export function useSettings(): SettingsContextValue {
+  const context = useContext(SettingsContext);
+  if (!context) {
+    throw new Error('useSettings must be used within a SettingsProvider');
+  }
+  return context;
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,0 +1,1 @@
+export { SettingsProvider, useSettings } from './SettingsContext';

--- a/src/options.stories.tsx
+++ b/src/options.stories.tsx
@@ -10,8 +10,7 @@ import {
   PremiumTab,
   HelpTab
 } from '~/components/options';
-import type { AppSettings } from '~/types/storage';
-import { DEFAULT_SETTINGS } from '~/types/storage';
+import { SettingsProvider, useSettings } from '~/contexts/SettingsContext';
 
 import './styles/globals.css';
 
@@ -24,16 +23,15 @@ const tabs = [
 
 type TabId = (typeof tabs)[number]['id'];
 
-function OptionsDemo() {
+function OptionsDemoContent() {
   const [activeTab, setActiveTab] = useState<TabId>('blocklist');
-  const [settings] = useState<AppSettings>(DEFAULT_SETTINGS);
+  const { settings } = useSettings();
 
   const renderTabContent = () => {
     switch (activeTab) {
       case 'blocklist':
         return (
           <BlocklistTab
-            settings={settings}
             newDomain=""
             setNewDomain={() => {}}
             blockError=""
@@ -49,8 +47,6 @@ function OptionsDemo() {
       case 'schedules':
         return (
           <SchedulesTab
-            settings={settings}
-            vision={undefined}
             onAddSchedule={() => alert('Add schedule')}
             onEditSchedule={() => {}}
             onDeleteSchedule={() => {}}
@@ -68,7 +64,6 @@ function OptionsDemo() {
       case 'help':
         return (
           <HelpTab
-            settings={settings}
             onSettingsChange={() => {}}
             onPasswordUpdate={async () => {}}
             onAnalyticsOptInChange={async () => {}}
@@ -109,6 +104,14 @@ function OptionsDemo() {
   );
 }
 
+function OptionsDemo() {
+  return (
+    <SettingsProvider>
+      <OptionsDemoContent />
+    </SettingsProvider>
+  );
+}
+
 const meta = {
   title: 'Pages/Options',
   component: OptionsDemo,
@@ -125,39 +128,38 @@ export const Default: Story = {};
 
 const SchedulesViewWrapper = () => {
   const [activeTab, setActiveTab] = useState<TabId>('schedules');
-  const [settings] = useState<AppSettings>(DEFAULT_SETTINGS);
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        <div className="bg-white rounded-lg shadow-sm">
-          <div className="border-b border-gray-200 px-6 py-4">
-            <h1 className="text-2xl font-bold text-gray-900">
-              VisionFocus Settings
-            </h1>
-          </div>
-          <Tabs
-            tabs={tabs.map((tab) => ({
-              id: tab.id,
-              label: tab.label,
-              icon: <tab.icon className="w-4 h-4" />
-            }))}
-            activeTab={activeTab}
-            onChange={(id) => setActiveTab(id as TabId)}
-          />
-          <div className="p-6">
-            <SchedulesTab
-              settings={settings}
-              vision={undefined}
-              onAddSchedule={() => alert('Add schedule')}
-              onEditSchedule={() => {}}
-              onDeleteSchedule={() => {}}
-              onToggleSchedule={() => {}}
+    <SettingsProvider>
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-6xl mx-auto px-4 py-8">
+          <div className="bg-white rounded-lg shadow-sm">
+            <div className="border-b border-gray-200 px-6 py-4">
+              <h1 className="text-2xl font-bold text-gray-900">
+                VisionFocus Settings
+              </h1>
+            </div>
+            <Tabs
+              tabs={tabs.map((tab) => ({
+                id: tab.id,
+                label: tab.label,
+                icon: <tab.icon className="w-4 h-4" />
+              }))}
+              activeTab={activeTab}
+              onChange={(id) => setActiveTab(id as TabId)}
             />
+            <div className="p-6">
+              <SchedulesTab
+                onAddSchedule={() => alert('Add schedule')}
+                onEditSchedule={() => {}}
+                onDeleteSchedule={() => {}}
+                onToggleSchedule={() => {}}
+              />
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </SettingsProvider>
   );
 };
 

--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { useStorage } from '@plasmohq/storage/hook';
 import {
   Ban,
   Calendar,
@@ -28,20 +27,17 @@ import {
   useSchedules,
   usePremiumStatus
 } from '~/hooks';
-import { getMessage, setCurrentLanguage } from '~/lib/i18n';
+import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
+import { SettingsProvider, useSettings } from '~/contexts/SettingsContext';
 import type {
   AnalyticsOptIn,
-  AppSettings,
-  VisionSettings,
   YouTubeSettings,
   PasswordSettings,
   UnblockHistory
 } from '~/types/storage';
 import {
-  DEFAULT_SETTINGS,
-  DEFAULT_VISION,
   DEFAULT_YOUTUBE_SETTINGS,
   DEFAULT_UNBLOCK_HISTORY
 } from '~/types/storage';
@@ -49,21 +45,8 @@ import { incrementYouTubeBlockCount } from '~/lib/youtubeBlockService';
 
 import './styles/globals.css';
 
-function OptionsApp() {
-  const [settings, setSettings] = useStorage<AppSettings>(
-    {
-      key: 'settings',
-      instance: storage
-    },
-    DEFAULT_SETTINGS
-  );
-  const [vision, setVision] = useStorage<VisionSettings>(
-    {
-      key: 'vision',
-      instance: storage
-    },
-    DEFAULT_VISION
-  );
+function OptionsAppContent() {
+  const { settings, setSettings, vision, setVision } = useSettings();
 
   // Read initial tab from URL hash (e.g., #help)
   const [activeTab, setActiveTab] = useState<TabName>(() =>
@@ -83,13 +66,6 @@ function OptionsApp() {
   const blocklist = useBlocklist({ settings, setSettings });
   const license = useLicense();
   const schedules = useSchedules({ settings, setSettings });
-
-  // Sync language setting with i18n module
-  useEffect(() => {
-    if (settings?.language !== undefined) {
-      setCurrentLanguage(settings.language);
-    }
-  }, [settings?.language]);
 
   // YouTube settings handler with block count and unblockHistory tracking
   const handleYouTubeChange = async (youtube: YouTubeSettings) => {
@@ -237,7 +213,6 @@ function OptionsApp() {
         {/* Block List Tab */}
         {activeTab === TABS.BLOCKLIST && (
           <BlocklistTab
-            settings={settings}
             newDomain={blocklist.newDomain}
             setNewDomain={blocklist.setNewDomain}
             blockError={blocklist.blockError}
@@ -256,8 +231,6 @@ function OptionsApp() {
         {/* Schedules Tab */}
         {activeTab === TABS.SCHEDULES && (
           <SchedulesTab
-            settings={settings}
-            vision={vision}
             onAddSchedule={schedules.openAddSchedule}
             onEditSchedule={schedules.openEditSchedule}
             onDeleteSchedule={schedules.handleDeleteSchedule}
@@ -270,7 +243,6 @@ function OptionsApp() {
           <AnalyticsTab
             unblockHistory={analytics.unblockHistory}
             analyticsData={analytics.analyticsData}
-            settings={settings}
             isPremium={isPremium}
             onReblock={analytics.handleReblock}
             onReset={analytics.handleResetAnalytics}
@@ -292,13 +264,12 @@ function OptionsApp() {
         {/* Help Tab */}
         {activeTab === TABS.HELP && (
           <HelpTab
-            settings={settings}
             onAnalyticsOptInChange={handleAnalyticsOptIn}
             onSettingsChange={async () => {
               // Reload settings and vision after import
               const [newSettings, newVision] = await Promise.all([
-                storage.get('settings') as Promise<AppSettings | undefined>,
-                storage.get('vision') as Promise<VisionSettings | undefined>
+                storage.get('settings') as Promise<typeof settings>,
+                storage.get('vision') as Promise<typeof vision>
               ]);
               if (newSettings) setSettings(newSettings);
               if (newVision) setVision(newVision);
@@ -324,10 +295,6 @@ function OptionsApp() {
       />
       {/* Analytics Opt-In Modal (shown once on first visit if not yet decided) */}
       <AnalyticsOptInModal
-        isOpen={
-          settings?.analyticsOptIn === undefined ||
-          settings?.analyticsOptIn === null
-        }
         onAllow={() =>
           handleAnalyticsOptIn({
             enabled: true,
@@ -342,6 +309,14 @@ function OptionsApp() {
         }
       />
     </div>
+  );
+}
+
+function OptionsApp() {
+  return (
+    <SettingsProvider>
+      <OptionsAppContent />
+    </SettingsProvider>
   );
 }
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback } from 'react';
 
-import { useStorage } from '@plasmohq/storage/hook';
 import { Ban, Shield, TrendingUp, Clock, Timer, Unlock } from 'lucide-react';
 
 import {
@@ -24,24 +23,14 @@ import {
 import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { formatTimeLocalized } from '~/lib/time';
-import type {
-  AnalyticsOptIn,
-  AppSettings,
-  VisionSettings
-} from '~/types/storage';
-import { DEFAULT_SETTINGS, DEFAULT_VISION } from '~/types/storage';
+import { SettingsProvider, useSettings } from '~/contexts/SettingsContext';
+import type { AnalyticsOptIn } from '~/types/storage';
+import { DEFAULT_VISION } from '~/types/storage';
 
 import './styles/globals.css';
 
-function PopupApp() {
-  const [settings, setSettings] = useStorage<AppSettings>(
-    { key: 'settings', instance: storage },
-    DEFAULT_SETTINGS
-  );
-  const [vision] = useStorage<VisionSettings>(
-    { key: 'vision', instance: storage },
-    DEFAULT_VISION
-  );
+function PopupAppContent() {
+  const { settings, setSettings, vision } = useSettings();
   const stats = useBackgroundStats(POPUP_STATS_POLLING_MS);
   const { isPremium } = usePremiumStatus();
   const { currentDomain, timeLimitInfo, clearDomain } = useCurrentDomain();
@@ -211,10 +200,6 @@ function PopupApp() {
 
       {/* Analytics Opt-In Modal */}
       <AnalyticsOptInModal
-        isOpen={
-          settings?.analyticsOptIn === undefined ||
-          settings?.analyticsOptIn === null
-        }
         onAllow={() =>
           handleAnalyticsOptIn({
             enabled: true,
@@ -243,6 +228,14 @@ function PopupApp() {
         />
       )}
     </div>
+  );
+}
+
+function PopupApp() {
+  return (
+    <SettingsProvider>
+      <PopupAppContent />
+    </SettingsProvider>
   );
 }
 


### PR DESCRIPTION
Closes #255

## 概要

`src/options.tsx` で発生していた Props Drilling を Context API で解消しました。settings と vision を SettingsContext で一元管理することで、コンポーネント階層が深い場合でも効率的に状態を共有できるようになりました。

## 変更内容

### 新規作成
- `src/contexts/SettingsContext.tsx`: settings と vision を管理する Context Provider
- `src/contexts/index.ts`: Context のエクスポート

### 主な変更
1. **options.tsx**
   - SettingsProvider でラップ
   - 各タブコンポーネントへの settings/vision props を削除
   - useSettings() フックで Context から取得

2. **タブコンポーネント**
   - `BlocklistTab`: settings を props から削除、useSettings() で取得
   - `SchedulesTab`: settings/vision を props から削除、useSettings() で取得
   - `HelpTab`: settings を props から削除、useSettings() で取得
   - `AnalyticsTab`: settings を props から削除、useSettings() で取得

3. **AnalyticsOptInModal**
   - isOpen 判定を内部に移動
   - useSettings() で settings を取得して判定

4. **popup.tsx**
   - SettingsProvider でラップ
   - AnalyticsOptInModal の isOpen props を削除

5. **Storybook ファイル**
   - 各タブの Stories に SettingsProvider を追加
   - settings/vision props を削除

## テスト結果

```bash
✓ pnpm type-check: 型エラーなし
✓ pnpm lint: エラーなし (警告のみ)
✓ pnpm test: 全593テスト通過
```

## レビューポイント

- SettingsContext の設計が適切か
- useSettings() フックの使用箇所が適切か
- Storybook での SettingsProvider の配置が正しいか

🤖 Generated with [Claude Code](https://claude.com/claude-code)