### PR TITLE
fix: i18n ハードコード文字列を翻訳キーに置換

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -42,14 +42,8 @@
     }
   },
   "wastedTime": {
-    "message": "$TIME$ wasted on this site",
-    "description": "Wasted time display on blocked page",
-    "placeholders": {
-      "time": {
-        "content": "$1",
-        "example": "2 hr 15 min"
-      }
-    }
+    "message": "Wasted Time",
+    "description": "Wasted time label"
   },
   "topBlockedSites": {
     "message": "Top Blocked Sites",
@@ -324,8 +318,8 @@
     "description": "Goal sub-message label"
   },
   "goalSubTextPlaceholder": {
-    "message": "e.g., One step at a time",
-    "description": "Goal sub-message placeholder"
+    "message": "Add a motivational message...",
+    "description": "Goal sub-text placeholder"
   },
   "textColor": {
     "message": "Text Color",
@@ -534,10 +528,6 @@
   "goalTextPlaceholder": {
     "message": "What's your main focus today?",
     "description": "Goal text placeholder"
-  },
-  "goalSubTextPlaceholder": {
-    "message": "Add a motivational message...",
-    "description": "Goal sub-text placeholder"
   },
   "previewText": {
     "message": "Preview",
@@ -1221,10 +1211,6 @@
     "message": "Add sites to track their blocking status and usage time.",
     "description": "No tracked sites description"
   },
-  "wastedTime": {
-    "message": "Wasted Time",
-    "description": "Wasted time label"
-  },
   "wastedTimeSite": {
     "message": "Wasted Time by Site",
     "description": "Wasted time by site section title"
@@ -1857,10 +1843,6 @@
     "message": "Image downloaded successfully.",
     "description": "Download success message"
   },
-  "topBlockedSite": {
-    "message": "Most Blocked",
-    "description": "Top blocked site label"
-  },
   "passwordProtection": {
     "message": "Password Protection",
     "description": "Password protection section title"
@@ -2108,5 +2090,13 @@
   "languageSelectDescription": {
     "message": "Select the language for the dashboard",
     "description": "Language selection description"
+  },
+  "youtubeTimeLimitReached": {
+    "message": "YouTube time limit reached. Take a break!",
+    "description": "Message shown when YouTube time limit is exceeded"
+  },
+  "youtubeHomeFeedHidden": {
+    "message": "Home feed is hidden",
+    "description": "Message shown when YouTube home feed is hidden"
   }
 }

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -42,14 +42,8 @@
     }
   },
   "wastedTime": {
-    "message": "このサイトで $TIME$ 浪費",
-    "description": "ブロック中画面での浪費時間表示",
-    "placeholders": {
-      "time": {
-        "content": "$1",
-        "example": "2時間15分"
-      }
-    }
+    "message": "浪費時間",
+    "description": "浪費時間ラベル"
   },
   "topBlockedSites": {
     "message": "よくブロックしたサイト",
@@ -324,8 +318,8 @@
     "description": "目標サブメッセージラベル"
   },
   "goalSubTextPlaceholder": {
-    "message": "例: 一歩ずつ前へ",
-    "description": "目標サブメッセージプレースホルダー"
+    "message": "モチベーションメッセージを追加...",
+    "description": "目標サブテキストプレースホルダー"
   },
   "textColor": {
     "message": "文字色",
@@ -534,10 +528,6 @@
   "goalTextPlaceholder": {
     "message": "今日の主な目標は？",
     "description": "目標テキストプレースホルダー"
-  },
-  "goalSubTextPlaceholder": {
-    "message": "モチベーションメッセージを追加...",
-    "description": "目標サブテキストプレースホルダー"
   },
   "previewText": {
     "message": "プレビュー",
@@ -1221,10 +1211,6 @@
     "message": "サイトを追加して、ブロック状況や利用時間を追跡しましょう。",
     "description": "追跡中サイトなし説明"
   },
-  "wastedTime": {
-    "message": "浪費時間",
-    "description": "浪費時間ラベル"
-  },
   "wastedTimeSite": {
     "message": "サイト別浪費時間",
     "description": "サイト別浪費時間セクションタイトル"
@@ -1458,8 +1444,8 @@
     "description": "今日のブロック回数ラベル"
   },
   "topBlockedSite": {
-    "message": "よくブロック",
-    "description": "一番ブロックしているサイトラベル"
+    "message": "最もブロック",
+    "description": "最もブロックしたサイトラベル"
   },
   "blockingDays": {
     "message": "継続日数",
@@ -1857,10 +1843,6 @@
     "message": "画像をダウンロードしました。",
     "description": "ダウンロード成功メッセージ"
   },
-  "topBlockedSite": {
-    "message": "最もブロック",
-    "description": "最もブロックしたサイトラベル"
-  },
   "passwordProtection": {
     "message": "パスワード保護",
     "description": "パスワード保護セクションタイトル"
@@ -2108,5 +2090,13 @@
   "languageSelectDescription": {
     "message": "ダッシュボードの表示言語を選択してください",
     "description": "言語選択の説明"
+  },
+  "youtubeTimeLimitReached": {
+    "message": "YouTube の利用時間制限に達しました。休憩しましょう！",
+    "description": "YouTube の利用時間制限を超えた時に表示されるメッセージ"
+  },
+  "youtubeHomeFeedHidden": {
+    "message": "ホームフィードが隠れています",
+    "description": "YouTube のホームフィードが非表示の時に表示されるメッセージ"
   }
 }

--- a/src/components/features/ReportCard/WeeklyChart.tsx
+++ b/src/components/features/ReportCard/WeeklyChart.tsx
@@ -16,8 +16,14 @@ interface WeeklyChartProps {
   dailyBlockCounts: number[];
 }
 
-// 曜日ラベル
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+/**
+ * 曜日ラベルを i18n から取得
+ */
+function getDayLabels(): string[] {
+  return ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'].map((key) =>
+    getMessage(key)
+  );
+}
 
 /**
  * 週次チャート用のフォーマット（秒 → 分/時間）
@@ -37,8 +43,9 @@ export function WeeklyChart({
   dailyBreakdown,
   dailyBlockCounts
 }: WeeklyChartProps) {
+  const dayLabels = getDayLabels();
   const chartData = dailyBreakdown.map((d, i) => ({
-    day: DAY_LABELS[i] || `D${i + 1}`,
+    day: dayLabels[i] || `D${i + 1}`,
     wasteTime: Math.round(d.wasteTime / 60), // 分に変換
     blockCount: dailyBlockCounts[i] || 0
   }));

--- a/src/contents/youtube.ts
+++ b/src/contents/youtube.ts
@@ -8,6 +8,7 @@ import {
   AnalyticsDataSchema,
   YouTubeSettingsSchema
 } from '~/types/messageSchemas';
+import { getMessage } from '~/lib/i18n';
 
 // Run only on YouTube
 export const config: PlasmoCSConfig = {
@@ -97,13 +98,14 @@ function generateCSS(settings: YouTubeSettings): string {
 
   // If time limit is exceeded, hide all content
   if (timeLimitExceeded) {
+    const timeLimitMessage = getMessage('youtubeTimeLimitReached');
     rules.push(`
       /* Time limit exceeded - hide all YouTube content */
       ytd-app #content {
         display: none !important;
       }
       ytd-app::after {
-        content: 'YouTube time limit reached. Take a break!';
+        content: '${timeLimitMessage}';
         display: flex;
         align-items: center;
         justify-content: center;
@@ -184,6 +186,7 @@ function generateCSS(settings: YouTubeSettings): string {
   }
 
   if (settings.hideHomeFeed) {
+    const homeFeedHiddenMessage = getMessage('youtubeHomeFeedHidden');
     rules.push(`
       /* Hide home feed - show only search bar */
       ${SELECTORS.homeFeed},
@@ -193,7 +196,7 @@ function generateCSS(settings: YouTubeSettings): string {
       }
       /* Show a message instead */
       ytd-browse[page-subtype="home"]::after {
-        content: 'ホームフィードが隠れています';
+        content: '${homeFeedHiddenMessage}';
         display: block;
         text-align: center;
         padding: 100px 20px;


### PR DESCRIPTION
Closes #258

## 変更内容

### 1. WeeklyChart.tsx の DAY_LABELS を i18n 化
- ハードコードされていた `['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']` を削除
- `getDayLabels()` 関数を追加し、`getMessage()` で曜日ラベルを取得
- 既存の `mon`, `tue`, `wed`, `thu`, `fri`, `sat`, `sun` キーを使用

### 2. youtube.ts の YouTube time limit メッセージを i18n 化
- ハードコードされていた `'YouTube time limit reached. Take a break!'` を削除
- `youtubeTimeLimitReached` キーを新規追加
  - EN: "YouTube time limit reached. Take a break!"
  - JA: "YouTube の利用時間制限に達しました。休憩しましょう！"

### 3. youtube.ts の YouTube home feed メッセージを i18n 化
- ハードコードされていた `'ホームフィードが隠れています'` を削除
- `youtubeHomeFeedHidden` キーを新規追加
  - EN: "Home feed is hidden"
  - JA: "ホームフィードが隠れています"

## テスト結果

```
✓ pnpm type-check: パス
✓ pnpm lint: パス（既存の警告のみ）
✓ pnpm test --run: 593 tests パス
```

## 影響範囲

- 週次レポートチャートの曜日表示が日本語環境では日本語で表示される
- YouTube の時間制限メッセージが日本語環境では日本語で表示される
- YouTube のホームフィード非表示メッセージが英語環境では英語で表示される