### PR TITLE
fix: E2Eテストのstorage操作エラーを修正

### DIFF
--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -4,7 +4,9 @@ import {
   setStorageData,
   clearStorage,
   clearStorageFromExtension,
-  getStorageData
+  getStorageData,
+  setStorageDataFromExtension,
+  getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS } from './helpers/constants';
 
@@ -23,9 +25,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
@@ -40,12 +40,10 @@ test.describe('Analytics - アナリティクス機能', () => {
       ]
     });
 
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -61,24 +59,23 @@ test.describe('Analytics - アナリティクス機能', () => {
     }
 
     // Analytics データを確認
-    const page2 = await context.newPage();
-    const analytics = (await getStorageData(page2, 'analytics')) as any;
+    const analytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
 
     expect(analytics.siteStats[TEST_DOMAINS.example]).toBeDefined();
     expect(
       analytics.siteStats[TEST_DOMAINS.example].blockCount
     ).toBeGreaterThanOrEqual(3);
-
-    await page2.close();
   });
 
   test('AN-002: Unblock History（ブロック解除サイト）が記録される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
@@ -93,11 +90,9 @@ test.describe('Analytics - アナリティクス機能', () => {
       ]
     });
 
-    await setStorageData(page, 'unblockHistory', {
+    await setStorageDataFromExtension(context, extensionId, 'unblockHistory', {
       entries: []
     });
-
-    await page.close();
 
     // Options ページでブロックを一時解除
     const optionsPage = await openOptions(context, extensionId, 'blocklist');
@@ -113,8 +108,10 @@ test.describe('Analytics - アナリティクス機能', () => {
     }
 
     // Unblock History を確認
-    const unblockHistory = (await getStorageData(
-      optionsPage,
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const unblockHistory = (await getStorageDataFromExtension(
+      context,
+      extensionId,
       'unblockHistory'
     )) as any;
     expect(unblockHistory.entries.length).toBeGreaterThan(0);
@@ -126,20 +123,16 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
     });
 
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     // 解除サイトにアクセス（ブロックリストに含まれていないサイト）
     const externalPage = await openExternalSite(
@@ -153,7 +146,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // トラッキングデータを確認
-    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+    const analytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
 
     // Heartbeatが記録されていることを確認（時間は短いが記録されている）
     if (analytics.siteStats[TEST_DOMAINS.reddit]) {
@@ -169,20 +166,16 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
     });
 
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     // 外部サイトにアクセス
     const externalPage = await openExternalSite(
@@ -194,7 +187,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Analytics データを確認
-    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+    const analytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
 
     // dailyStats に記録があることを確認
     const today = new Date().toISOString().slice(0, 10);
@@ -209,16 +206,12 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Opt-In が未決定の状態
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: null
     });
-
-    await page.close();
 
     // Options ページを開く
     const optionsPage = await openOptions(context, extensionId, 'analytics');
@@ -235,7 +228,11 @@ test.describe('Analytics - アナリティクス機能', () => {
 
     // 設定が保存されたことを確認
     await new Promise((resolve) => setTimeout(resolve, 300));
-    const settings = (await getStorageData(optionsPage, 'settings')) as any;
+    const settings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
     expect(settings.analyticsOptIn).toBeDefined();
     expect(settings.analyticsOptIn.enabled).toBe(true);
 
@@ -246,21 +243,17 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Opt-Out 状態
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
     });
 
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     // 外部サイトにアクセス
     const externalPage = await openExternalSite(
@@ -272,7 +265,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Analytics データが記録されていないことを確認
-    const analytics = (await getStorageData(externalPage, 'analytics')) as any;
+    const analytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
     expect(Object.keys(analytics.dailyStats).length).toBe(0);
 
     await externalPage.close();
@@ -282,16 +279,14 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
     });
 
     // Analytics データを設定
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {
         '2024-01-01': {
           date: '2024-01-01',
@@ -311,8 +306,6 @@ test.describe('Analytics - アナリティクス機能', () => {
       }
     });
 
-    await page.close();
-
     // Options ページを開く
     const optionsPage = await openOptions(context, extensionId, 'analytics');
 
@@ -325,7 +318,11 @@ test.describe('Analytics - アナリティクス機能', () => {
       await new Promise((resolve) => setTimeout(resolve, 500));
 
       // Analytics データがリセットされたことを確認
-      const analytics = (await getStorageData(optionsPage, 'analytics')) as any;
+      const analytics = (await getStorageDataFromExtension(
+        context,
+        extensionId,
+        'analytics'
+      )) as any;
       expect(Object.keys(analytics.dailyStats).length).toBe(0);
       expect(Object.keys(analytics.siteStats).length).toBe(0);
     }
@@ -337,15 +334,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
     });
-
-    await page.close();
 
     // オフラインモードに設定
     const externalPage = await openExternalSite(
@@ -358,10 +351,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // ローカルキューに保存されているか確認（実装に応じて調整）
-    const queueData = await externalPage.evaluate(async () => {
-      const result = await chrome.storage.local.get('heartbeatQueue');
-      return result.heartbeatQueue;
-    });
+    const queueData = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'heartbeatQueue'
+    )) as any;
 
     // キューが存在する場合は記録されていることを確認
     if (queueData) {
@@ -376,24 +370,20 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
     });
 
     // ダミーのキューデータを設定
-    await setStorageData(page, 'heartbeatQueue', [
+    await setStorageDataFromExtension(context, extensionId, 'heartbeatQueue', [
       {
         domain: TEST_DOMAINS.example,
         duration: 30,
         timestamp: new Date().toISOString()
       }
     ]);
-
-    await page.close();
 
     // ネットワークオンラインに復旧
     const externalPage = await openExternalSite(
@@ -406,10 +396,11 @@ test.describe('Analytics - アナリティクス機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // キューが送信されてクリアされたことを確認
-    const queueData = await externalPage.evaluate(async () => {
-      const result = await chrome.storage.local.get('heartbeatQueue');
-      return result.heartbeatQueue;
-    });
+    const queueData = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'heartbeatQueue'
+    )) as any;
 
     // キューが空になっている、またはundefined
     expect(queueData?.length || 0).toBe(0);
@@ -421,10 +412,8 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Opt-Out 状態
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() },
@@ -439,11 +428,9 @@ test.describe('Analytics - アナリティクス機能', () => {
       ]
     });
 
-    await setStorageData(page, 'unblockHistory', {
+    await setStorageDataFromExtension(context, extensionId, 'unblockHistory', {
       entries: []
     });
-
-    await page.close();
 
     // Options ページでブロック解除を試みる
     const optionsPage = await openOptions(context, extensionId, 'blocklist');
@@ -458,8 +445,9 @@ test.describe('Analytics - アナリティクス機能', () => {
     }
 
     // Unblock History に記録されないことを確認
-    const unblockHistory = (await getStorageData(
-      optionsPage,
+    const unblockHistory = (await getStorageDataFromExtension(
+      context,
+      extensionId,
       'unblockHistory'
     )) as any;
     expect(unblockHistory.entries.length).toBe(0);

--- a/tests/e2e/block.spec.ts
+++ b/tests/e2e/block.spec.ts
@@ -4,7 +4,8 @@ import {
   setStorageData,
   clearStorage,
   clearStorageFromExtension,
-  setStorageDataFromExtension
+  setStorageDataFromExtension,
+  getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS, SELECTORS } from './helpers/constants';
 
@@ -59,8 +60,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ワイルドカードでブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -73,7 +73,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -95,8 +94,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // 最初はブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -109,18 +107,15 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // ブロックリストから削除
-    const page2 = await context.newPage();
-    await setStorageData(page2, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: []
     });
-    await page2.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -143,8 +138,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -157,13 +151,11 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Pauseを有効化
-    const page2 = await context.newPage();
-    await setStorageData(page2, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: true,
       blockList: [
@@ -176,7 +168,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page2.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -198,8 +189,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // Pauseを有効化した状態で開始
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: true,
       blockList: [
@@ -212,13 +202,11 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Pauseを解除
-    const page2 = await context.newPage();
-    await setStorageData(page2, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -231,7 +219,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page2.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -252,8 +239,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // enabled: false でブロックアイテムを追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -266,7 +252,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -288,8 +273,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // 最初は無効化
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -302,13 +286,11 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // 有効化
-    const page2 = await context.newPage();
-    await setStorageData(page2, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -321,7 +303,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page2.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -342,8 +323,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -356,12 +336,13 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // declarativeNetRequest ルールを確認
     const rulesPage = await context.newPage();
+    await rulesPage.goto(`chrome-extension://${extensionId}/options.html`);
+    await rulesPage.waitForLoadState('domcontentloaded');
     const rules = await rulesPage.evaluate(async () => {
       return chrome.declarativeNetRequest.getDynamicRules();
     });
@@ -379,8 +360,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -393,7 +373,6 @@ test.describe('Block - ブロック機能', () => {
         }
       ]
     });
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -407,10 +386,11 @@ test.describe('Block - ブロック機能', () => {
 
     // lastBlockedDomain が記録されたことを確認
     await new Promise((resolve) => setTimeout(resolve, 500));
-    const lastBlocked = await blockedPage.evaluate(async () => {
-      const result = await chrome.storage.local.get('lastBlockedDomain');
-      return result.lastBlockedDomain;
-    });
+    const lastBlocked = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'lastBlockedDomain'
+    )) as any;
 
     expect(lastBlocked).toBe(TEST_DOMAINS.example);
 
@@ -422,8 +402,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    const page = await context.newPage();
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -438,12 +417,10 @@ test.describe('Block - ブロック機能', () => {
     });
 
     // Analytics データ初期化
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -465,10 +442,11 @@ test.describe('Block - ブロック機能', () => {
 
     // ブロック回数を確認
     await new Promise((resolve) => setTimeout(resolve, 500));
-    const analytics = await blockedPage2.evaluate(async () => {
-      const result = await chrome.storage.local.get('analytics');
-      return result.analytics;
-    });
+    const analytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
 
     const today = new Date().toISOString().slice(0, 10);
     expect(analytics.dailyStats[today].blockCount).toBeGreaterThanOrEqual(2);

--- a/tests/e2e/data.spec.ts
+++ b/tests/e2e/data.spec.ts
@@ -4,7 +4,9 @@ import {
   setStorageData,
   getStorageData,
   clearStorage,
-  clearStorageFromExtension
+  clearStorageFromExtension,
+  setStorageDataFromExtension,
+  getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS } from './helpers/constants';
 
@@ -23,10 +25,8 @@ test.describe('Data - データ永続化', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 設定を保存
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'ja',
       paused: true,
       blockList: [
@@ -41,24 +41,24 @@ test.describe('Data - データ永続化', () => {
     });
 
     // 保存された設定を取得
-    const savedSettings = (await getStorageData(page, 'settings')) as any;
+    const savedSettings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
 
     expect(savedSettings.language).toBe('ja');
     expect(savedSettings.paused).toBe(true);
     expect(savedSettings.blockList.length).toBe(1);
     expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.example);
-
-    await page.close();
   });
 
   test('DATA-002: ブラウザ再起動後も設定が保持される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 設定を保存
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -72,28 +72,25 @@ test.describe('Data - データ永続化', () => {
       ]
     });
 
-    await page.close();
-
-    // 新しいページを開いて設定を取得（ブラウザ再起動をシミュレート）
-    const page2 = await context.newPage();
-    const savedSettings = (await getStorageData(page2, 'settings')) as any;
+    // 設定を取得（ブラウザ再起動をシミュレート）
+    const savedSettings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
 
     expect(savedSettings.language).toBe('en');
     expect(savedSettings.paused).toBe(false);
     expect(savedSettings.blockList.length).toBe(1);
     expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.reddit);
-
-    await page2.close();
   });
 
   test('DATA-003: 拡張機能を無効化→有効化しても設定が保持される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 設定を保存
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'ja',
       paused: false,
       blockList: [
@@ -108,33 +105,35 @@ test.describe('Data - データ永続化', () => {
     });
 
     // 保存された設定を確認
-    const savedSettings = (await getStorageData(page, 'settings')) as any;
+    const savedSettings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
 
     expect(savedSettings.blockList.length).toBe(1);
     expect(savedSettings.blockList[0].domain).toBe(TEST_DOMAINS.twitter);
 
     // 実際の無効化/有効化は Playwright では困難なため、
     // chrome.storage.local が永続的であることを確認
-    await page.close();
 
-    // 新しいページで設定が保持されていることを確認
-    const page2 = await context.newPage();
-    const persistedSettings = (await getStorageData(page2, 'settings')) as any;
+    // 設定が保持されていることを確認
+    const persistedSettings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
 
     expect(persistedSettings.blockList.length).toBe(1);
     expect(persistedSettings.blockList[0].domain).toBe(TEST_DOMAINS.twitter);
-
-    await page2.close();
   });
 
   test('DATA-004: プリセット（Vision）が正しく保存される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Vision プリセットを保存
-    await setStorageData(page, 'vision', {
+    await setStorageDataFromExtension(context, extensionId, 'vision', {
       defaultSettings: {
         goalText: 'Focus on what matters',
         subText: 'Stay productive'
@@ -163,23 +162,23 @@ test.describe('Data - データ永続化', () => {
     });
 
     // 保存された Vision を取得
-    const savedVision = (await getStorageData(page, 'vision')) as any;
+    const savedVision = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'vision'
+    )) as any;
 
     expect(savedVision.presets.length).toBe(2);
     expect(savedVision.activePresetId).toBe('custom1');
     expect(savedVision.presets[1].name).toBe('Custom Preset');
-
-    await page.close();
   });
 
   test('DATA-005: スケジュールが正しく保存される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // スケジュール設定を保存
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       schedules: [
@@ -205,25 +204,25 @@ test.describe('Data - データ永続化', () => {
     });
 
     // 保存されたスケジュールを取得
-    const savedSettings = (await getStorageData(page, 'settings')) as any;
+    const savedSettings = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'settings'
+    )) as any;
 
     expect(savedSettings.schedules.length).toBe(2);
     expect(savedSettings.schedules[0].name).toBe('Work Hours');
     expect(savedSettings.schedules[1].days).toEqual([0, 6]);
-
-    await page.close();
   });
 
   test('DATA-006: Analytics データが正しく保存される', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     const today = new Date().toISOString().slice(0, 10);
 
     // Analytics データを保存
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {
         [today]: {
           date: today,
@@ -250,13 +249,15 @@ test.describe('Data - データ永続化', () => {
     });
 
     // 保存された Analytics を取得
-    const savedAnalytics = (await getStorageData(page, 'analytics')) as any;
+    const savedAnalytics = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'analytics'
+    )) as any;
 
     expect(savedAnalytics.dailyStats[today]).toBeDefined();
     expect(savedAnalytics.dailyStats[today].blockCount).toBe(15);
     expect(savedAnalytics.siteStats[TEST_DOMAINS.example].blockCount).toBe(10);
     expect(Object.keys(savedAnalytics.siteStats).length).toBe(2);
-
-    await page.close();
   });
 });

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -3,7 +3,8 @@ import { openPopup, openNewTab, openOptions } from './helpers/pages';
 import {
   setStorageData,
   clearStorage,
-  clearStorageFromExtension
+  clearStorageFromExtension,
+  setStorageDataFromExtension
 } from './helpers/storage';
 
 /**
@@ -21,15 +22,11 @@ test.describe('i18n - 多言語対応', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 英語に設定
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false
     });
-
-    await page.close();
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -48,15 +45,11 @@ test.describe('i18n - 多言語対応', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 日本語に設定
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'ja',
       paused: false
     });
-
-    await page.close();
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -75,15 +68,11 @@ test.describe('i18n - 多言語対応', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 最初は英語
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false
     });
-
-    await page.close();
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -116,15 +105,11 @@ test.describe('i18n - 多言語対応', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 日本語に設定
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'ja',
       paused: false
     });
-
-    await page.close();
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -158,15 +143,11 @@ test.describe('i18n - 多言語対応', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // 最初は英語
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false
     });
-
-    await page.close();
 
     // Options を開く
     const optionsPage = await openOptions(context, extensionId);

--- a/tests/e2e/interaction.spec.ts
+++ b/tests/e2e/interaction.spec.ts
@@ -3,7 +3,9 @@ import { openExternalSite, openPopup } from './helpers/pages';
 import {
   setStorageData,
   clearStorage,
-  clearStorageFromExtension
+  clearStorageFromExtension,
+  setStorageDataFromExtension,
+  getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS } from './helpers/constants';
 
@@ -22,10 +24,8 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Pause 有効 + Time Limit 超過
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: true, // Pause 有効
       blockList: [
@@ -43,7 +43,7 @@ test.describe('Interaction - 機能間相互作用', () => {
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
+    await setStorageDataFromExtension(context, extensionId, 'timeLimitUsage', {
       [TEST_DOMAINS.example]: {
         daily: {
           used: 10, // 超過
@@ -52,8 +52,6 @@ test.describe('Interaction - 機能間相互作用', () => {
         hourly: null
       }
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -74,14 +72,12 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     const now = new Date();
     const currentHour = now.getHours();
     const currentDay = now.getDay();
 
     // Pause 有効 + Schedule でブロック有効化時間帯
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: true, // Pause 有効
       blockList: [
@@ -106,8 +102,6 @@ test.describe('Interaction - 機能間相互作用', () => {
       ]
     });
 
-    await page.close();
-
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // サイトにアクセス（Pause が優先されてアクセス可能）
@@ -127,14 +121,12 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     const now = new Date();
     const currentHour = now.getHours();
     const currentDay = now.getDay();
 
     // Time Limit 未超過 + Schedule でブロック有効化時間帯
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       blockList: [
@@ -163,7 +155,7 @@ test.describe('Interaction - 機能間相互作用', () => {
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
+    await setStorageDataFromExtension(context, extensionId, 'timeLimitUsage', {
       [TEST_DOMAINS.example]: {
         daily: {
           used: 30, // 未超過
@@ -172,8 +164,6 @@ test.describe('Interaction - 機能間相互作用', () => {
         hourly: null
       }
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -193,14 +183,12 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     const now = new Date();
     const currentHour = now.getHours();
     const currentDay = now.getDay();
 
     // Pause 有効 + Time Limit 超過 + Schedule 有効
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: true, // Pause が最優先
       blockList: [
@@ -229,7 +217,7 @@ test.describe('Interaction - 機能間相互作用', () => {
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
+    await setStorageDataFromExtension(context, extensionId, 'timeLimitUsage', {
       [TEST_DOMAINS.example]: {
         daily: {
           used: 10, // 超過
@@ -238,8 +226,6 @@ test.describe('Interaction - 機能間相互作用', () => {
         hourly: null
       }
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
@@ -260,25 +246,21 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // Opt-Out 状態
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
     });
 
-    await setStorageData(page, 'unblockHistory', {
+    await setStorageDataFromExtension(context, extensionId, 'unblockHistory', {
       entries: []
     });
 
-    await setStorageData(page, 'analytics', {
+    await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
       siteStats: {}
     });
-
-    await page.close();
 
     // 外部サイトにアクセス
     const externalPage = await openExternalSite(
@@ -290,10 +272,11 @@ test.describe('Interaction - 機能間相互作用', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Unblock History が記録されないことを確認
-    const unblockHistory = await externalPage.evaluate(async () => {
-      const result = await chrome.storage.local.get('unblockHistory');
-      return result.unblockHistory;
-    });
+    const unblockHistory = (await getStorageDataFromExtension(
+      context,
+      extensionId,
+      'unblockHistory'
+    )) as any;
 
     expect(unblockHistory.entries.length).toBe(0);
 
@@ -304,10 +287,8 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // パスワード保護を有効化
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       password: {
@@ -316,8 +297,6 @@ test.describe('Interaction - 機能間相互作用', () => {
           '1b4f0e9851971998e732078544c96b36c3d01cedf7caa332359d6f1d83567014' // SHA-256("test1234")
       }
     });
-
-    await page.close();
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -341,10 +320,8 @@ test.describe('Interaction - 機能間相互作用', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
-
     // パスワード保護を有効化
-    await setStorageData(page, 'settings', {
+    await setStorageDataFromExtension(context, extensionId, 'settings', {
       language: 'en',
       paused: false,
       password: {
@@ -362,8 +339,6 @@ test.describe('Interaction - 機能間相互作用', () => {
         }
       ]
     });
-
-    await page.close();
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 


### PR DESCRIPTION
Closes #272

## Summary
- E2Eテストのパターン A（storage 操作の失敗）を修正
- テスト内での `setStorageData(page, ...)` を `setStorageDataFromExtension(context, extensionId, ...)` に変更
- 拡張機能ページ上で storage 操作を実行するように修正

## 修正ファイル
- `tests/e2e/analytics.spec.ts` - 全10テストを修正
- `tests/e2e/block.spec.ts` - 全10テストを修正
- `tests/e2e/data.spec.ts` - 全6テストを修正
- `tests/e2e/i18n.spec.ts` - 全5テストを修正
- `tests/e2e/interaction.spec.ts` - 全7テストを修正

## 修正内容
### 問題
テスト内で `setStorageData(page, ...)` を呼ぶ際、page が通常ページ（about:blank）のため `chrome.storage.local` が undefined で即座に失敗していた。

### 解決策
- `helpers/storage.ts` に既に存在する `setStorageDataFromExtension` / `getStorageDataFromExtension` を使用
- 拡張機能ページ（`chrome-extension://${extensionId}/options.html`）上で storage 操作を実行

## テスト結果
パターン A の修正により、storage 操作エラーは解消されました。
一部のテストはセレクタ不一致やタイムアウトなど、パターン B・C の問題が残っていますが、これらは別 Issue で対応します。

## Test plan
- [x] ユニットテスト: 593件全てパス
- [x] 型チェック・lint: エラーなし
- [x] E2Eテスト: storage操作エラーは解消、残りの問題は別対応

Generated with [Claude Code](https://claude.com/claude-code)