### PR TITLE
fix: ダッシュボードのロゴが表示されない問題を修正

### DIFF
--- a/src/options.tsx
+++ b/src/options.tsx
@@ -27,6 +27,7 @@ import {
   useSchedules,
   usePremiumStatus
 } from '~/hooks';
+import { getExtensionURL } from '~/lib/chromeApi';
 import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
@@ -181,7 +182,7 @@ function OptionsAppContent() {
         <div className="max-w-6xl mx-auto px-6 py-4">
           <div className="flex items-center gap-3">
             <img
-              src="/assets/images/logo.png"
+              src={getExtensionURL('assets/images/logo.png')}
               alt="VisionFocus Logo"
               className="h-8 w-8 object-contain"
             />


### PR DESCRIPTION
## Summary
- ダッシュボード（オプションページ）のヘッダーロゴが表示されない問題を修正
- 原因: `src/options.tsx` でロゴの `src` に `/assets/images/logo.png` という絶対パスを使用していた。Chrome拡張のページは `chrome-extension://` スキームで配信されるため、このパスでは画像を解決できない
- 修正: 既存の `getExtensionURL()` ラッパー（`chrome.runtime.getURL`）を使用して、正しい拡張機能内パスに変換

## 変更内容
- `src/options.tsx`: `getExtensionURL('assets/images/logo.png')` でロゴパスを解決するよう変更（既存パターンに準拠）

## Test plan
- [ ] ダッシュボード画面（オプションページ）でロゴが正常に表示されることを確認
- [ ] ポップアップのロゴ表示が壊れていないことを確認
- [ ] ビルド成功確認済み（`pnpm build` パス）
- [ ] 全593テスト通過確認済み（`pnpm vitest run` パス）

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)