### PR TITLE
fix: ブロックリストのURL入力欄が短い問題を修正

### DIFF
--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -178,7 +178,7 @@ export function BlocklistTab({
             value={newDomain}
             onChange={setNewDomain}
             placeholder={getMessage('domainPlaceholder')}
-            className="flex-1"
+            containerClassName="flex-1 min-w-0"
           />
           <Button onClick={onAddDomain}>
             <Plus className="w-4 h-4 mr-1" />


### PR DESCRIPTION
## Summary
- オプション画面のブロックリストURL入力欄で `className="flex-1"` が `<input>` 要素に適用されていたため、コンテナ `<div>` が親 flex コンテナ内で伸縮せず入力欄が短くなっていた
- `containerClassName="flex-1 min-w-0"` に変更し、コンテナレベルで正しく幅が確保されるよう修正
- ポップアップの `QuickBlockButton` で既に正しく使われているパターンに統一

## Changes
- `src/components/options/BlocklistTab.tsx`: `Input` の `className="flex-1"` を `containerClassName="flex-1 min-w-0"` に変更

## Test plan
- [ ] オプション画面のブロックリストでURL入力欄が全幅に広がっていることを確認
- [ ] 長いURL（例: `https://very-long-subdomain.example.com/path/to/something`）を入力してもレイアウトが崩れないことを確認
- [ ] 「追加」ボタンが入力欄の右に適切に配置されていることを確認
- [ ] レスポンシブ対応が壊れていないことを確認

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)