### PR TITLE
fix: ポップアップでただいまの目標が表示されない問題を修正

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -18,7 +18,8 @@ import {
   useCurrentDomain,
   usePasswordVerification,
   usePopupActions,
-  usePremiumStatus
+  usePremiumStatus,
+  useResolvedPreset
 } from '~/hooks';
 import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
@@ -33,6 +34,11 @@ function PopupAppContent() {
   const { settings, setSettings, vision } = useSettings();
   const stats = useBackgroundStats(POPUP_STATS_POLLING_MS);
   const { isPremium } = usePremiumStatus();
+  const { displaySettings } = useResolvedPreset({
+    vision,
+    settings,
+    isPremium
+  });
   const { currentDomain, timeLimitInfo, clearDomain } = useCurrentDomain();
 
   const {
@@ -109,8 +115,7 @@ function PopupAppContent() {
 
         <GoalCard
           goalText={
-            vision?.defaultSettings?.goalText ||
-            DEFAULT_VISION.defaultSettings.goalText
+            displaySettings.goalText || DEFAULT_VISION.defaultSettings.goalText
           }
           onClick={handleGoalClick}
         />


### PR DESCRIPTION
## Summary
- ポップアップの GoalCard が `vision.defaultSettings.goalText` のみを参照していたため、プリセット有効時に目標テキストが表示されなかった
- newtab と同様に `useResolvedPreset` フックを使用して、アクティブなプリセット・スケジュール・プレミアム状態を考慮した正しい `displaySettings` から `goalText` を取得するよう修正

## Root Cause
`popup.tsx` で `GoalCard` の `goalText` プロパティに `vision?.defaultSettings?.goalText` を直接渡していた。ユーザーがプリセットを有効にしている場合（`activePresetId` が設定されている場合）、目標テキストはプリセットオブジェクト内に保存されるため、`defaultSettings` からは取得できなかった。

## Changes
- `src/popup.tsx`: `useResolvedPreset` フックを追加し、`displaySettings.goalText` を使用するよう修正

## Test plan
- [ ] プリセットが有効な状態でポップアップを開いた際に「ただいまの目標」が正常に表示されることを確認
- [ ] プリセットが無効（defaultSettings 使用）の場合も目標が正常に表示されることを確認
- [ ] スケジュールベースのプリセットが有効な場合も目標が正しく表示されることを確認
- [ ] 目標が未設定の場合の空状態表示が適切であることを確認
- [ ] 目標の文字数が多い場合でも崩れないことを確認
- [ ] 全テスト（593件）パス済み、TypeScript 型チェックエラーなし

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)