### PR TITLE
fix: 設定画面のロゴが表示されない問題を修正

### DIFF
--- a/src/options.tsx
+++ b/src/options.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState } from 'react';
 
+// ロゴはバンドルに含めるため data-base64 スキームで import する。
+// getExtensionURL 経由だと web_accessible_resources 未宣言のファイルはビルド出力に含まれず 404 になる
+import logoBase64 from 'data-base64:assets/images/logo.png';
+
 import {
   Ban,
   Calendar,
@@ -27,7 +31,6 @@ import {
   useSchedules,
   usePremiumStatus
 } from '~/hooks';
-import { getExtensionURL } from '~/lib/chromeApi';
 import { getMessage } from '~/lib/i18n';
 import { storage } from '~/lib/storage';
 import { TABS, getTabFromHash, isValidTab, type TabName } from '~/constants';
@@ -182,7 +185,7 @@ function OptionsAppContent() {
         <div className="max-w-6xl mx-auto px-6 py-4">
           <div className="flex items-center gap-3">
             <img
-              src={getExtensionURL('assets/images/logo.png')}
+              src={logoBase64}
               alt="VisionFocus Logo"
               className="h-8 w-8 object-contain"
             />


### PR DESCRIPTION
## 概要

オプション画面（設定/ダッシュボード）ヘッダーのロゴが表示されない不具合を修正する。

## 原因

`src/options.tsx:185` が `getExtensionURL('assets/images/logo.png')` でロゴを参照していたが、**ビルド出力に `logo.png` が含まれていなかった**。

Plasmo は `package.json` の `web_accessible_resources` に宣言されたパスをビルド出力へコピーする。宣言されているのは `assets/images/backgrounds/*` のみで `logo.png` は対象外のため、`chrome-extension://.../assets/images/logo.png` が 404 になっていた。

## 修正内容

`src/components/features/Header/Header.tsx:5` が既に採用している `data-base64` スキームでの import に統一した。

```ts
import logoBase64 from 'data-base64:assets/images/logo.png';
```

これによりロゴがバンドルへ確実に含まれ、`web_accessible_resources` を追加せずに済む（拡張機能ページ内での利用のため外部公開は不要）。あわせて未使用になった `getExtensionURL` の import を削除した。

## 検証

- `pnpm build` 後、`build/chrome-mv3-prod/options.*.js` に PNG の data URI が 2 件（logo / icon）埋め込まれていることを確認
- `pnpm type-check` / `pnpm lint`（エラー 0・既存 warning のみ）/ `pnpm format:check` 通過
- ユニットテスト 593 件 全 pass

## 補足（別 Issue 化を提案）

`assets/images/logo.png` は **241KB / 幅 1648px** だが、ヘッダーでの表示サイズは `h-8 w-8`（32px）。base64 埋め込みにより options バンドルが約 320KB 増える。表示サイズに合わせたリサイズ版を用意すべきなので、別 Issue で対応したい。

Closes #300