### PR TITLE
fix: 目標未設定時に目標が空欄で表示される問題を修正

### DIFF
--- a/assets/_locales/en/messages.json
+++ b/assets/_locales/en/messages.json
@@ -289,6 +289,14 @@
     "message": "Current Goal",
     "description": "Goal card label"
   },
+  "noGoalSet": {
+    "message": "No goal set yet - click to set one",
+    "description": "Prompt shown on the goal card when no goal is set"
+  },
+  "goalPreviewPlaceholder": {
+    "message": "Your goal will appear here",
+    "description": "Placeholder shown in the style settings preview when no goal is set"
+  },
   "saved": {
     "message": "Saved!",
     "description": "Save success feedback"

--- a/assets/_locales/ja/messages.json
+++ b/assets/_locales/ja/messages.json
@@ -289,6 +289,14 @@
     "message": "只今の目標",
     "description": "目標カードラベル"
   },
+  "noGoalSet": {
+    "message": "目標が未設定です。クリックして設定しましょう",
+    "description": "目標未設定時に目標カードへ表示する案内"
+  },
+  "goalPreviewPlaceholder": {
+    "message": "ここに目標が表示されます",
+    "description": "スタイル設定プレビューで目標未入力時に表示する文言"
+  },
   "saved": {
     "message": "保存しました",
     "description": "保存成功フィードバック"

--- a/src/components/features/GoalCard/GoalCard.stories.tsx
+++ b/src/components/features/GoalCard/GoalCard.stories.tsx
@@ -29,6 +29,13 @@ export const Default: Story = {
   }
 };
 
+// 目標未設定時は設定を促す案内が薄い文字で表示される
+export const NoGoal: Story = {
+  args: {
+    goalText: ''
+  }
+};
+
 export const LongText: Story = {
   args: {
     goalText:

--- a/src/components/features/GoalCard/GoalCard.tsx
+++ b/src/components/features/GoalCard/GoalCard.tsx
@@ -21,6 +21,9 @@ export function GoalCard({
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(goalText);
 
+  // 空文字・空白のみの場合は未設定として扱う
+  const hasGoal = goalText.trim().length > 0;
+
   const handleSave = () => {
     onEdit?.(editText);
     setIsEditing(false);
@@ -63,8 +66,13 @@ export function GoalCard({
               autoFocus
             />
           ) : (
-            <p className="text-base font-medium text-gray-800 line-clamp-2">
-              {goalText}
+            // 目標未設定時は空欄にせず、設定を促す案内を薄い文字で表示する
+            <p
+              className={`text-base line-clamp-2 ${
+                hasGoal ? 'font-medium text-gray-800' : 'text-gray-400 italic'
+              }`}
+            >
+              {hasGoal ? goalText : getMessage('noGoalSet')}
             </p>
           )}
         </div>

--- a/src/components/newtab/GoalDisplay.tsx
+++ b/src/components/newtab/GoalDisplay.tsx
@@ -56,11 +56,14 @@ export function GoalDisplay({
 
   return (
     <div className="group relative">
+      {/* 目標未設定時は空見出しにせず、設定を促す案内を薄く表示する */}
       <h1
-        className="drop-shadow-lg leading-tight transition-opacity duration-300"
+        className={`drop-shadow-lg leading-tight transition-opacity duration-300 ${
+          goalText.trim() ? '' : 'opacity-60 italic'
+        }`}
         style={{ color: textColor, ...fontStyle }}
       >
-        {goalText}
+        {goalText.trim() ? goalText : getMessage('noGoalSet')}
       </h1>
       {goalSubText && (
         <p

--- a/src/components/options/StylesTab.tsx
+++ b/src/components/options/StylesTab.tsx
@@ -100,7 +100,7 @@ export function StylesTab({ isPremium, featureLimits }: StylesTabProps) {
                     }}
                   >
                     {draftDisplaySettings.goalText ||
-                      'Your goal will appear here'}
+                      getMessage('goalPreviewPlaceholder')}
                   </p>
                   {draftDisplaySettings.goalSubText && (
                     <p

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -26,7 +26,6 @@ import { storage } from '~/lib/storage';
 import { formatTimeLocalized } from '~/lib/time';
 import { SettingsProvider, useSettings } from '~/contexts/SettingsContext';
 import type { AnalyticsOptIn } from '~/types/storage';
-import { DEFAULT_VISION } from '~/types/storage';
 
 import './styles/globals.css';
 
@@ -114,9 +113,7 @@ function PopupAppContent() {
         <QuickBlockButton currentDomain={currentDomain} onBlock={handleBlock} />
 
         <GoalCard
-          goalText={
-            displaySettings.goalText || DEFAULT_VISION.defaultSettings.goalText
-          }
+          goalText={displaySettings.goalText}
           onClick={handleGoalClick}
         />
 


### PR DESCRIPTION
## 概要

ポップアップの「只今の目標」カードで、目標未設定時に本文が空欄になる不具合を修正する。

## 原因

`src/popup.tsx:118` のフォールバック先 `DEFAULT_VISION.defaultSettings.goalText` が `src/types/vision.ts:38` で **空文字** と定義されているため、未設定時はフォールバックしても空欄のままだった（ラベルのみ表示される状態）。

## 修正内容

| ファイル | 内容 |
| --- | --- |
| `src/components/features/GoalCard/GoalCard.tsx` | 未設定（空文字・空白のみ）判定を追加し、`noGoalSet` の案内を薄いイタリック体で表示 |
| `src/components/newtab/GoalDisplay.tsx` | **同じ不具合があったため**同様に対応（未設定時に空の `h1` になっていた） |
| `src/components/options/StylesTab.tsx` | ハードコードされていた `'Your goal will appear here'` を i18n 化 |
| `src/popup.tsx` | 空文字へのフォールバックが無意味だったため削除。未使用の `DEFAULT_VISION` import も削除 |
| `assets/_locales/{ja,en}/messages.json` | `noGoalSet` / `goalPreviewPlaceholder` を追加 |
| `GoalCard.stories.tsx` | 未設定ケースの story `NoGoal` を追加 |

判定は `goalText.trim()` で行い、空白のみの入力も未設定として扱う。カードは従来どおりクリックで設定画面へ遷移するため、案内から設定操作へつながる。

### スコープ外の同種修正を含めた理由

Issue はポップアップのみを対象としていたが、`GoalDisplay`（新規タブのダッシュボード）に同一原因の不具合があり、片方だけ直すと表示が不統一になるため同 PR で対応した。

## 検証

- `pnpm type-check` / `pnpm lint`（エラー 0・既存 warning のみ）/ `pnpm format:check` / `pnpm build` 通過
- ユニットテスト 593 件 全 pass

## 補足

`GoalCard` / `GoalDisplay` はコンポーネントのユニットテストが存在しないため、今回の変更は Storybook の story 追加でカバーした。テスト体制の十分性は別途調査する。

Closes #301