### PR TITLE
test: カバレッジ計測の設定を修正し CI に閾値を導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,38 @@ jobs:
       - name: Unit tests (hooks)
         run: pnpm test --run src/hooks/
 
+  # 並列実行: カバレッジ（閾値を下回ると失敗する）
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
   # 並列実行: Build
   build:
     runs-on: ubuntu-latest
@@ -133,7 +165,7 @@ jobs:
   # 全ジョブ完了確認（ブランチ保護ルール用）
   check:
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, build]
+    needs: [lint, typecheck, test-unit-lib, test-unit-hooks, coverage, build]
     steps:
       - name: All checks passed
         run: echo "All parallel CI jobs completed successfully"

--- a/README.md
+++ b/README.md
@@ -82,15 +82,27 @@ Claude Code で以下のスラッシュコマンドが使用可能です：
 
 環境構築後（`/project:setup` 実行後）に使用可能：
 
-| コマンド        | 説明                                |
-| --------------- | ----------------------------------- |
-| `pnpm dev`      | 開発サーバー起動（HMR対応）         |
-| `pnpm build`    | 本番ビルド（build/chrome-mv3-prod） |
-| `pnpm package`  | Chrome Web Store用zipファイル作成   |
-| `pnpm lint`     | ESLint 実行                         |
-| `pnpm format`   | Prettier でフォーマット             |
-| `pnpm test`     | Vitest で単体テスト                 |
-| `pnpm test:e2e` | Playwright で E2E テスト            |
+| コマンド             | 説明                                |
+| -------------------- | ----------------------------------- |
+| `pnpm dev`           | 開発サーバー起動（HMR対応）         |
+| `pnpm build`         | 本番ビルド（build/chrome-mv3-prod） |
+| `pnpm package`       | Chrome Web Store用zipファイル作成   |
+| `pnpm lint`          | ESLint 実行                         |
+| `pnpm format`        | Prettier でフォーマット             |
+| `pnpm test`          | Vitest で単体テスト                 |
+| `pnpm test:coverage` | カバレッジ計測（閾値チェック付き）  |
+| `pnpm test:e2e`      | Playwright で E2E テスト            |
+
+**カバレッジ:**
+
+```bash
+pnpm test:coverage
+```
+
+- 集計対象は `src/**`（story・テストコード・型定義のみのファイルは除外）
+- 閾値を下回ると失敗する。CI の `coverage` ジョブでも同じチェックが走る
+- 詳細な HTML レポートは `coverage/index.html` に出力される
+- 閾値は退行防止のための下限値。テスト追加に合わせて `vitest.config.ts` で段階的に引き上げる
 
 **E2E テストの前提条件:**
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "plasmo build",
     "package": "plasmo package",
     "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,34 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
-    exclude: ['tests/e2e/**', 'node_modules/**']
+    exclude: ['tests/e2e/**', 'node_modules/**'],
+    coverage: {
+      provider: 'v8',
+      // src 配下のみを集計対象にする。
+      // include を指定しないと storybook-static/ や build/ のビルド成果物まで
+      // 集計に含まれ、カバレッジの数値が実態を表さなくなる
+      include: ['src/**'],
+      exclude: [
+        'src/**/*.stories.tsx',
+        'src/**/__tests__/**',
+        'src/test/**',
+        // 型定義のみのファイル（実行されるコードを持たない）
+        'src/types/index.ts',
+        'src/types/messages.ts',
+        'src/types/report.ts',
+        'src/types/storageSchemas.ts'
+      ],
+      reporter: ['text-summary', 'json-summary', 'html'],
+      // 現状値を下回らないラインを下限とする（退行防止が目的）。
+      // src/background と src/components が未テストのため低い水準から始め、
+      // テスト追加に合わせて段階的に引き上げる
+      thresholds: {
+        statements: 24,
+        branches: 77,
+        functions: 52,
+        lines: 24
+      }
+    }
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## 概要

カバレッジ計測が実態を表していない問題を修正し、退行防止のための閾値チェックを CI に追加する。

## 問題

`vitest.config.ts` に `coverage` 設定が無く `include` が未指定のため、集計対象が無制限になっていた。

- `storybook-static/` や `build/` のビルド成果物が集計に含まれる
- **テストコード自身が集計に含まれる**（テストファイルは当然 100% 実行されるため数値を大きく押し上げる）

結果として表示値は **42.33%** だったが、`src` のプロダクションコードのみの実測値は **24.23%** で、20 ポイント近く実態と乖離していた。この状態ではカバレッジを判断材料に使えない。

## 変更内容

### `vitest.config.ts`

`coverage` 設定を追加した。

- `include: ['src/**']` — 集計対象を src のみに限定
- `exclude` — story / テストコード / `src/test/**` / 型定義のみのファイル（`types/index.ts`・`messages.ts`・`report.ts`・`storageSchemas.ts`）
- `reporter` — `text-summary`（サマリ）・`json-summary`（機械可読）・`html`（詳細調査用）
- `thresholds` — 下記の現状値を下限として設定

### 閾値（現状値ベース）

| 指標 | 実測値 | 閾値 |
| --- | --- | --- |
| Statements | 24.23% | 24% |
| Branches | 77.57% | 77% |
| Functions | 52.58% | 52% |
| Lines | 24.23% | 24% |

**目的は退行防止**であり、達成目標ではない。`src/background`（17ファイル・テスト0件）と `src/components`（65コンポーネント・テスト0件）が未テストのため低い水準から始め、#309 / #311 / #312 でのテスト追加に合わせて段階的に引き上げる。

Branches が 77% と高いのは、テスト済みの `src/lib` / `src/hooks` が分岐を丁寧に網羅している一方、未テストのファイルには分岐自体が少ない（表示系が多い）ためと考えられる。

### `.github/workflows/ci.yml`

- `coverage` ジョブを追加（他ジョブと並列実行）。閾値を下回ると失敗する
- カバレッジレポートを artifact として保存（保持 7 日）。CI 上で詳細を確認できる
- ブランチ保護用の `check` ジョブの `needs` に `coverage` を追加

### その他

- `pnpm test:coverage` スクリプトを追加
- README の npm Scripts 表と、カバレッジ運用の説明を追記

## 検証

- `pnpm test:coverage` がローカルで pass（閾値クリア）
- 集計対象からビルド成果物・テストコードが除外されていることを確認
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` 通過
- ユニットテスト 593 件 全 pass

## 備考

本 PR はテスト十分性調査の結果に基づく改善の 1 件目。以降 #309（background のテスト）→ #310（E2E の定期実行）の順で進める。

Closes #308