### PR TITLE
test: blocker のユニットテストを追加

### DIFF
--- a/src/background/__tests__/blocker.test.ts
+++ b/src/background/__tests__/blocker.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// storage / blockService / chromeApi をモックし、chrome API 呼び出しを検証する
+vi.mock('~/lib/storage', () => ({
+  getSettings: vi.fn()
+}));
+
+vi.mock('~/lib/blockService', () => ({
+  getBlockState: vi.fn(),
+  getActiveBlockedDomains: vi.fn(),
+  findBlockItemForDomain: vi.fn()
+}));
+
+vi.mock('~/lib/chromeApi', () => ({
+  isExtensionContextValid: vi.fn(() => true)
+}));
+
+import { getSettings } from '~/lib/storage';
+import { getBlockState, getActiveBlockedDomains } from '~/lib/blockService';
+import { isExtensionContextValid } from '~/lib/chromeApi';
+import {
+  updateBlockRules,
+  shouldBlockUrl,
+  blockExistingTabs
+} from '../blocker';
+import { DEFAULT_SETTINGS } from '~/types/storage';
+import { BLOCKER_CONFIG } from '~/constants/limits';
+
+interface UpdateRulesArg {
+  removeRuleIds: number[];
+  addRules: chrome.declarativeNetRequest.Rule[];
+}
+
+/** chrome API のグローバルモックを構築する */
+function setupChrome(overrides: Record<string, unknown> = {}) {
+  const chromeMock = {
+    declarativeNetRequest: {
+      getDynamicRules: vi.fn().mockResolvedValue([]),
+      updateDynamicRules: vi.fn().mockResolvedValue(undefined),
+      // 実装が参照する enum 値
+      RuleActionType: { REDIRECT: 'redirect' },
+      ResourceType: { MAIN_FRAME: 'main_frame' }
+    },
+    tabs: {
+      query: vi.fn().mockResolvedValue([]),
+      update: vi.fn().mockResolvedValue(undefined)
+    },
+    runtime: {
+      id: 'test-extension-id',
+      getURL: vi.fn(
+        (path: string) =>
+          `chrome-extension://test-id/${path.replace(/^\//, '')}`
+      )
+    },
+    ...overrides
+  };
+  (globalThis as Record<string, unknown>).chrome = chromeMock;
+  return chromeMock;
+}
+
+/** updateDynamicRules に渡された引数を取得する */
+function lastUpdateRulesArg(
+  chromeMock: ReturnType<typeof setupChrome>
+): UpdateRulesArg {
+  const calls = chromeMock.declarativeNetRequest.updateDynamicRules.mock.calls;
+  return calls[calls.length - 1][0] as UpdateRulesArg;
+}
+
+describe('blocker', () => {
+  let chromeMock: ReturnType<typeof setupChrome>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chromeMock = setupChrome();
+    vi.mocked(getSettings).mockResolvedValue({ ...DEFAULT_SETTINGS });
+    vi.mocked(getActiveBlockedDomains).mockResolvedValue([]);
+    vi.mocked(isExtensionContextValid).mockReturnValue(true);
+  });
+
+  describe('updateBlockRules', () => {
+    it('ブロック対象ドメインからリダイレクトルールを生成する', async () => {
+      vi.mocked(getActiveBlockedDomains).mockResolvedValue(['example.com']);
+
+      await updateBlockRules();
+
+      const arg = lastUpdateRulesArg(chromeMock);
+      expect(arg.addRules).toHaveLength(1);
+      expect(arg.addRules[0]).toMatchObject({
+        id: BLOCKER_CONFIG.RULE_ID_OFFSET,
+        priority: 1,
+        action: {
+          type: 'redirect',
+          redirect: { extensionPath: '/newtab.html' }
+        },
+        condition: {
+          urlFilter: '||example.com',
+          resourceTypes: ['main_frame']
+        }
+      });
+    });
+
+    it('ルール ID は RULE_ID_OFFSET から連番で割り当てる', async () => {
+      vi.mocked(getActiveBlockedDomains).mockResolvedValue([
+        'a.com',
+        'b.com',
+        'c.com'
+      ]);
+
+      await updateBlockRules();
+
+      const arg = lastUpdateRulesArg(chromeMock);
+      expect(arg.addRules.map((r) => r.id)).toEqual([
+        BLOCKER_CONFIG.RULE_ID_OFFSET,
+        BLOCKER_CONFIG.RULE_ID_OFFSET + 1,
+        BLOCKER_CONFIG.RULE_ID_OFFSET + 2
+      ]);
+    });
+
+    it('ワイルドカードドメインは *. を除いた urlFilter にする', async () => {
+      vi.mocked(getActiveBlockedDomains).mockResolvedValue(['*.example.com']);
+
+      await updateBlockRules();
+
+      const arg = lastUpdateRulesArg(chromeMock);
+      expect(arg.addRules[0].condition?.urlFilter).toBe('||example.com');
+    });
+
+    it('既存の動的ルールをすべて削除対象に含める', async () => {
+      chromeMock.declarativeNetRequest.getDynamicRules.mockResolvedValue([
+        { id: 1000 },
+        { id: 1001 }
+      ]);
+      vi.mocked(getActiveBlockedDomains).mockResolvedValue(['example.com']);
+
+      await updateBlockRules();
+
+      const arg = lastUpdateRulesArg(chromeMock);
+      expect(arg.removeRuleIds).toEqual([1000, 1001]);
+    });
+
+    it('ブロック対象が無い場合は削除のみ行う', async () => {
+      chromeMock.declarativeNetRequest.getDynamicRules.mockResolvedValue([
+        { id: 1000 }
+      ]);
+
+      await updateBlockRules();
+
+      const arg = lastUpdateRulesArg(chromeMock);
+      expect(arg.removeRuleIds).toEqual([1000]);
+      expect(arg.addRules).toEqual([]);
+    });
+
+    describe('一時停止中', () => {
+      beforeEach(() => {
+        vi.mocked(getSettings).mockResolvedValue({
+          ...DEFAULT_SETTINGS,
+          paused: true
+        });
+      });
+
+      it('既存ルールを全削除し、新規ルールを追加しない', async () => {
+        chromeMock.declarativeNetRequest.getDynamicRules.mockResolvedValue([
+          { id: 1000 },
+          { id: 1001 }
+        ]);
+
+        await updateBlockRules();
+
+        const arg = lastUpdateRulesArg(chromeMock);
+        expect(arg.removeRuleIds).toEqual([1000, 1001]);
+        expect(arg.addRules).toEqual([]);
+      });
+
+      it('ブロック対象の取得自体を行わない', async () => {
+        await updateBlockRules();
+
+        expect(getActiveBlockedDomains).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('shouldBlockUrl', () => {
+    it('ブロック状態と理由をそのまま返す', async () => {
+      vi.mocked(getBlockState).mockResolvedValue({
+        blocked: true,
+        reason: 'time_limit_exceeded'
+      });
+
+      const result = await shouldBlockUrl('https://example.com');
+
+      expect(result).toEqual({ blocked: true, reason: 'time_limit_exceeded' });
+      expect(getBlockState).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('ブロック対象外なら blocked: false を返す', async () => {
+      vi.mocked(getBlockState).mockResolvedValue({
+        blocked: false,
+        reason: null
+      });
+
+      const result = await shouldBlockUrl('https://example.com');
+
+      expect(result).toEqual({ blocked: false, reason: null });
+    });
+  });
+
+  describe('blockExistingTabs', () => {
+    beforeEach(() => {
+      vi.mocked(getBlockState).mockResolvedValue({
+        blocked: false,
+        reason: null
+      });
+    });
+
+    it('拡張機能コンテキストが無効なら何もしない', async () => {
+      vi.mocked(isExtensionContextValid).mockReturnValue(false);
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.query).not.toHaveBeenCalled();
+    });
+
+    it('ブロック対象のタブを newtab へリダイレクトする', async () => {
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://example.com/page' }
+      ]);
+      vi.mocked(getBlockState).mockResolvedValue({
+        blocked: true,
+        reason: null
+      });
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.update).toHaveBeenCalledWith(1, {
+        url: 'chrome-extension://test-id/newtab.html'
+      });
+    });
+
+    it('ブロック理由をクエリパラメータで渡す', async () => {
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://example.com' }
+      ]);
+      vi.mocked(getBlockState).mockResolvedValue({
+        blocked: true,
+        reason: 'time_limit_exceeded'
+      });
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.update).toHaveBeenCalledWith(1, {
+        url: 'chrome-extension://test-id/newtab.html?reason=time_limit_exceeded'
+      });
+    });
+
+    it('ブロック対象でないタブはリダイレクトしない', async () => {
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://example.com' }
+      ]);
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['chrome:// ページ', 'chrome://settings'],
+      ['拡張機能ページ', 'chrome-extension://test-id/options.html']
+    ])('%s は判定対象から除外する', async (_label, url) => {
+      chromeMock.tabs.query.mockResolvedValue([{ id: 1, url }]);
+
+      await blockExistingTabs();
+
+      expect(getBlockState).not.toHaveBeenCalled();
+      expect(chromeMock.tabs.update).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['id が無いタブ', { url: 'https://example.com' }],
+      ['url が無いタブ', { id: 1 }]
+    ])('%s はスキップする', async (_label, tab) => {
+      chromeMock.tabs.query.mockResolvedValue([tab]);
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.update).not.toHaveBeenCalled();
+    });
+
+    it('複数タブのうちブロック対象のみリダイレクトする', async () => {
+      chromeMock.tabs.query.mockResolvedValue([
+        { id: 1, url: 'https://blocked.com' },
+        { id: 2, url: 'https://allowed.com' },
+        { id: 3, url: 'chrome://settings' }
+      ]);
+      vi.mocked(getBlockState).mockImplementation(async (url: string) =>
+        url.includes('blocked.com')
+          ? { blocked: true, reason: null }
+          : { blocked: false, reason: null }
+      );
+
+      await blockExistingTabs();
+
+      expect(chromeMock.tabs.update).toHaveBeenCalledOnce();
+      expect(chromeMock.tabs.update).toHaveBeenCalledWith(1, {
+        url: 'chrome-extension://test-id/newtab.html'
+      });
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,17 +23,19 @@ export default defineConfig({
         'src/types/index.ts',
         'src/types/messages.ts',
         'src/types/report.ts',
-        'src/types/storageSchemas.ts'
+        'src/types/storageSchemas.ts',
+        // re-export のみのファイル（ロジックを持たず、実体は src/lib 側でテスト済み）
+        'src/background/time-limit.ts'
       ],
       reporter: ['text-summary', 'json-summary', 'html'],
       // 現状値を下回らないラインを下限とする（退行防止が目的）。
       // src/background と src/components が未テストのため低い水準から始め、
       // テスト追加に合わせて段階的に引き上げる
       thresholds: {
-        statements: 28,
+        statements: 29,
         branches: 80,
-        functions: 55,
-        lines: 28
+        functions: 56,
+        lines: 29
       }
     }
   },


### PR DESCRIPTION
## 概要

#309 の**第2弾**。`src/background/blocker.ts` にユニットテスト 18 件を追加する。

`declarativeNetRequest` のルール生成と既存タブのリダイレクトは、ブロック機能そのものの実行部分であり、壊れると「ブロックされない」という最悪の形で失敗する。chrome API をモックして、**実際に渡すルール定義の中身**を検証している。

## 追加したテスト（18 テスト）

### `updateBlockRules`

- ブロック対象ドメインから REDIRECT ルールを生成すること（`urlFilter` / `resourceTypes` / `extensionPath` の中身まで検証）
- ルール ID を `BLOCKER_CONFIG.RULE_ID_OFFSET` から連番で割り当てること
- ワイルドカードドメイン（`*.example.com`）を `||example.com` に変換すること
- 既存の動的ルールを全て `removeRuleIds` に含めること
- ブロック対象が無い場合は削除のみ行うこと
- **一時停止中**: 既存ルールを全削除し新規ルールを追加しないこと / ブロック対象の取得自体を行わないこと（不要な処理をしていないことの確認）

### `shouldBlockUrl`

- `getBlockState` の結果（ブロック状態と理由）をそのまま返すこと

### `blockExistingTabs`

- 拡張機能コンテキストが無効なら何もしないこと（Service Worker 再起動時の防御）
- ブロック対象のタブを newtab へリダイレクトすること
- ブロック理由を `?reason=` で渡すこと（ブロック画面のメッセージ切り替えに使われる）
- `chrome://` ページと拡張機能ページを判定対象から除外すること
- `id` / `url` が無いタブをスキップすること
- 複数タブのうちブロック対象のみリダイレクトすること

## カバレッジ

`blocker.ts`: **0% → 68.62%**（**Branches は 100%**）

未カバーの 84-127 行は、未使用のデッドコード 3 関数（`addBlockedDomain` / `removeBlockedDomain` / `isUrlBlocked`）のみ。これらは削除予定のためテストを書いていない。削除後は `blocker.ts` がほぼ 100% になる見込み。

### `time-limit.ts` をカバレッジ対象から除外

`src/background/time-limit.ts` は **`src/lib` からの re-export のみ**（33行、実行されるロジックを持たない）ため、`coverage.exclude` に追加した。実体は既にテスト済み。

- `timeLimitService`（31 テスト）
- `youtubeBlockService`（14 テスト）
- `blockService`（30 テスト）

この判断により、`src/types/index.ts` などの re-export ファイルと同じ扱いに揃った。

### 閾値の更新

| 指標 | 変更前 | 変更後 | 新しい閾値 |
| --- | --- | --- | --- |
| Statements / Lines | 28.46% | **29.08%** | 29% |
| Branches | 80.3% | **80.96%** | 80% |
| Functions | 56.01% | **56.25%** | 56% |

## 検証

- ユニットテスト **698 件**（`src/background` は 105 件）全 pass
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` / `pnpm build` 通過
- テストは #318 の知見どおり `src/background/__tests__/` 配下に配置（`messages/` 配下に置くと Plasmo のビルドが壊れる）

## 残作業（#309 は継続）

- `tracker.ts` — 時間計測
- `listeners/`（4ファイル）— chrome API のイベント配線
- `notifications.ts`

Refs #309