### PR TITLE
refactor: 未使用のデッドコードを削除

### DIFF
--- a/src/background/blocker.ts
+++ b/src/background/blocker.ts
@@ -1,7 +1,5 @@
-import { generateId } from '~/lib/domain';
 import { getSettings } from '~/lib/storage';
 import { BLOCKER_CONFIG } from '~/constants/limits';
-import type { BlockItem } from '~/types/storage';
 import {
   getBlockState,
   getActiveBlockedDomains,
@@ -78,52 +76,6 @@ export async function shouldBlockUrl(
     blocked: state.blocked,
     reason: state.reason
   };
-}
-
-// Legacy function for backward compatibility
-export async function isUrlBlocked(url: string): Promise<boolean> {
-  const result = await shouldBlockUrl(url);
-  return result.blocked;
-}
-
-// Add domain to block list and update rules
-export async function addBlockedDomain(
-  domain: string,
-  isWildcard: boolean
-): Promise<boolean> {
-  const settings = await getSettings();
-
-  // Check free tier limit
-  if (settings.blockList.length >= 5) {
-    // TODO: Check premium status
-    return false;
-  }
-
-  const newItem: BlockItem = {
-    id: generateId(),
-    domain: isWildcard ? `*.${domain.replace('*.', '')}` : domain,
-    isWildcard,
-    createdAt: new Date().toISOString(),
-    enabled: true
-  };
-
-  settings.blockList.push(newItem);
-
-  const { setSettings } = await import('~/lib/storage');
-  await setSettings(settings);
-  await updateBlockRules();
-
-  return true;
-}
-
-// Remove domain from block list
-export async function removeBlockedDomain(id: string): Promise<void> {
-  const settings = await getSettings();
-  settings.blockList = settings.blockList.filter((item) => item.id !== id);
-
-  const { setSettings } = await import('~/lib/storage');
-  await setSettings(settings);
-  await updateBlockRules();
 }
 
 // Check all open tabs and redirect any that match blocked domains

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,8 +25,7 @@ export {
   type DashboardPreset,
   type VisionSettings,
   DEFAULT_DISPLAY_SETTINGS,
-  DEFAULT_VISION,
-  getCurrentDisplaySettings
+  DEFAULT_VISION
 } from './vision';
 
 // Font types

--- a/src/types/storage.ts
+++ b/src/types/storage.ts
@@ -54,8 +54,7 @@ export {
   type DashboardPreset,
   type VisionSettings,
   DEFAULT_DISPLAY_SETTINGS,
-  DEFAULT_VISION,
-  getCurrentDisplaySettings
+  DEFAULT_VISION
 } from './vision';
 
 // Import types needed for this file

--- a/src/types/vision.ts
+++ b/src/types/vision.ts
@@ -50,25 +50,3 @@ export const DEFAULT_VISION: VisionSettings = {
   presets: [],
   activePresetId: null
 };
-
-// Helper to get current display settings based on activePresetId
-export function getCurrentDisplaySettings(
-  vision: VisionSettings
-): DashboardDisplaySettings {
-  if (vision.activePresetId) {
-    const preset = vision.presets.find((p) => p.id === vision.activePresetId);
-    if (preset) {
-      return {
-        goalText: preset.goalText,
-        goalSubText: preset.goalSubText,
-        textColor: preset.textColor,
-        backgroundType: preset.backgroundType,
-        backgroundImage: preset.backgroundImage,
-        backgroundColor: preset.backgroundColor,
-        customBackgroundData: preset.customBackgroundData,
-        fontSettings: preset.fontSettings
-      };
-    }
-  }
-  return vision.defaultSettings;
-}


### PR DESCRIPTION
## 概要

呼び出し箇所が存在しない関数 4 件と、その re-export を削除する。

## 削除した対象

### `src/background/blocker.ts`

| 関数 | 備考 |
| --- | --- |
| `isUrlBlocked` | `shouldBlockUrl` の旧 API |
| `removeBlockedDomain` | 未使用 |
| `addBlockedDomain` | 未使用。**かつ現行仕様と矛盾していた** |

`addBlockedDomain` は以下を含んでいた。

```ts
// Check free tier limit
if (settings.blockList.length >= 5) {
  // TODO: Check premium status
  return false;
}
```

正しい判定は `canAddToBlocklist`（`src/lib/license.ts`）で、実際の上限は `FEATURE_LIMITS`（`src/types/premium.ts:28`）の `maxBlockList: Infinity` = **無料版も無制限**。この関数は誰かが使えばそのままバグになる状態だった。#307（無料版のブロック数の仕様矛盾）の混乱の一因でもある。

未使用になった `generateId` / `BlockItem` の import も削除した。

### `src/types/vision.ts`

`getCurrentDisplaySettings` と、`src/types/storage.ts` / `src/types/index.ts` の re-export 2 箇所を削除。同等のロジックは `src/hooks/useResolvedPreset.ts` に実装済みで、そちらはスケジュール連動と Free 制限も考慮しており上位互換。

## カバレッジ

| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| `src/background/blocker.ts` | 68.62% | **100%** |
| `src/types/vision.ts` | 47.22% | **100%** |

全体は 29.08% → **29.2%**（Functions 56.25% → 56.96%）。デッドコード削除は分母が減るため伸びは小さい。既存の閾値（29 / 80 / 56 / 29）で引き続き pass するため、閾値の変更は行っていない。

## 検証

- ユニットテスト **698 件** 全 pass（削除により壊れたテストは無し）
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` / `pnpm build` 通過
- `grep` で `getCurrentDisplaySettings` / 削除した 3 関数の参照が 0 件であることを確認

差分は 74 行削除 / 2 行追加で、追加分は import 文の整理のみ。

Closes #320
Closes #314