### PR TITLE
fix: E2E のストレージ操作を拡張機能コンテキストで行うよう修正

### DIFF
--- a/tests/e2e/helpers/pages.ts
+++ b/tests/e2e/helpers/pages.ts
@@ -41,6 +41,30 @@ export async function openNewTab(
 }
 
 /**
+ * chrome.storage を操作するためのページを開く
+ *
+ * chrome.storage.local は拡張機能のページ（chrome-extension:// スキーム）でしか
+ * 参照できない。context.newPage() で開いた about:blank に対して
+ * setStorageData / getStorageData を呼ぶと chrome が undefined になり、
+ * テストの準備段階で TypeError になる。
+ *
+ * ストレージ操作用のページが必要な場合は必ずこのヘルパーを使う。
+ *
+ * @param context - BrowserContext
+ * @param extensionId - 拡張機能ID
+ * @returns 拡張機能コンテキストのページ
+ */
+export async function openStoragePage(
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> {
+  const page = await context.newPage();
+  await page.goto(EXTENSION_URLS.options(extensionId));
+  await page.waitForLoadState('domcontentloaded');
+  return page;
+}
+
+/**
  * Options ページを開く
  *
  * @param context - BrowserContext

--- a/tests/e2e/options-style.spec.ts
+++ b/tests/e2e/options-style.spec.ts
@@ -450,38 +450,27 @@ test.describe('Options - Style Tab', () => {
     await page.close();
   });
 
-  test('OPT-ST16: Free ダウングレード時、2件目以降のプリセットがロックされる', async ({
+  test('OPT-ST16: Free ダウングレード時、上限を超えるプリセットがロックされる', async ({
     context,
     extensionId
   }) => {
-    // 複数プリセットを作成
+    // 無料版の上限（FEATURE_LIMITS.free.maxPresets = 3）を 1 件超える 4 件を用意する
     const setupPage = await openOptions(context, extensionId);
     await setStorageData(setupPage, 'vision', {
       defaultSettings: {
         goalText: 'Focus on what matters',
         subText: 'Stay productive'
       },
-      presets: [
-        {
-          id: 'default',
-          name: 'Default',
-          goalText: 'Focus on what matters',
-          subText: 'Stay productive',
-          textColor: '#ffffff',
-          backgroundColor: '#1a1a2e',
-          backgroundType: 'color'
-        },
-        {
-          id: 'preset2',
-          name: 'Preset 2',
-          goalText: 'Goal 2',
-          subText: 'Sub 2',
-          textColor: '#000000',
-          backgroundColor: '#ffffff',
-          backgroundType: 'color'
-        }
-      ],
-      activePresetId: 'default'
+      presets: [1, 2, 3, 4].map((n) => ({
+        id: `preset${n}`,
+        name: `Preset ${n}`,
+        goalText: `Goal ${n}`,
+        subText: `Sub ${n}`,
+        textColor: '#ffffff',
+        backgroundColor: '#1a1a2e',
+        backgroundType: 'color'
+      })),
+      activePresetId: 'preset1'
     });
     // Freeユーザー（Premiumなし）
     await setStorageData(setupPage, 'premium', {
@@ -491,18 +480,23 @@ test.describe('Options - Style Tab', () => {
 
     const page = await openOptions(context, extensionId, 'styles');
 
-    // 2件目のプリセットがロックされている（Lock アイコンが表示）
-    const preset2Button = page
+    // 上限内（1〜3件目）はロックされない
+    for (const n of [1, 2, 3]) {
+      const unlocked = page
+        .locator(SELECTORS.styles.presetButton)
+        .filter({ hasText: `Preset ${n}` });
+      await expect(unlocked).toBeVisible();
+      await expect(unlocked.locator('svg.lucide-lock')).toHaveCount(0);
+      await expect(unlocked).toBeEnabled();
+    }
+
+    // 上限を超える 4 件目はロックされる
+    const locked = page
       .locator(SELECTORS.styles.presetButton)
-      .filter({ hasText: 'Preset 2' });
-    await expect(preset2Button).toBeVisible();
-
-    // ロックアイコンが表示される
-    const lockIcon = preset2Button.locator('svg.lucide-lock');
-    await expect(lockIcon).toBeVisible();
-
-    // ボタンが無効化されている
-    await expect(preset2Button).toBeDisabled();
+      .filter({ hasText: 'Preset 4' });
+    await expect(locked).toBeVisible();
+    await expect(locked.locator('svg.lucide-lock')).toBeVisible();
+    await expect(locked).toBeDisabled();
 
     await page.close();
   });

--- a/tests/e2e/premium.spec.ts
+++ b/tests/e2e/premium.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures/extension';
-import { openOptions } from './helpers/pages';
+import { openOptions, openStoragePage } from './helpers/pages';
+import { SELECTORS } from './helpers/constants';
 import {
   setStorageData,
   getStorageData,
@@ -22,7 +23,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -60,7 +61,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -92,7 +93,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -124,7 +125,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -157,7 +158,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -237,7 +238,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -268,7 +269,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -302,7 +303,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -337,7 +338,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -373,11 +374,11 @@ test.describe('Premium - Premium 機能', () => {
     await optionsPage.close();
   });
 
-  test('PR-010: Free ダウングレード時、2件目以降のプリセットがロック', async ({
+  test('PR-010: Free ダウングレード時、上限を超えるプリセットがロック', async ({
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 最初は Premium
     await setStorageData(page, 'premium', {
@@ -385,48 +386,28 @@ test.describe('Premium - Premium 機能', () => {
       activatedAt: new Date().toISOString()
     });
 
-    // 3件のプリセットを設定
+    // 無料版の上限（FEATURE_LIMITS.free.maxPresets = 3）を 1 件超える 4 件を設定
     await setStorageData(page, 'vision', {
       defaultSettings: {
         goalText: 'Focus',
         subText: 'Stay productive'
       },
-      presets: [
-        {
-          id: '1',
-          name: 'Preset 1',
-          goalText: 'Goal 1',
-          subText: 'Sub 1',
-          textColor: '#fff',
-          backgroundColor: '#000',
-          backgroundType: 'color'
-        },
-        {
-          id: '2',
-          name: 'Preset 2',
-          goalText: 'Goal 2',
-          subText: 'Sub 2',
-          textColor: '#fff',
-          backgroundColor: '#111',
-          backgroundType: 'color'
-        },
-        {
-          id: '3',
-          name: 'Preset 3',
-          goalText: 'Goal 3',
-          subText: 'Sub 3',
-          textColor: '#fff',
-          backgroundColor: '#222',
-          backgroundType: 'color'
-        }
-      ],
+      presets: [1, 2, 3, 4].map((n) => ({
+        id: String(n),
+        name: `Preset ${n}`,
+        goalText: `Goal ${n}`,
+        subText: `Sub ${n}`,
+        textColor: '#fff',
+        backgroundColor: '#000',
+        backgroundType: 'color'
+      })),
       activePresetId: '1'
     });
 
     await page.close();
 
     // Premium を解除
-    const page2 = await context.newPage();
+    const page2 = await openStoragePage(context, extensionId);
     await setStorageData(page2, 'premium', {
       isPremium: false,
       activatedAt: null
@@ -437,11 +418,15 @@ test.describe('Premium - Premium 機能', () => {
     // Options の Styles タブを開く
     const optionsPage = await openOptions(context, extensionId, 'styles');
 
-    // 2件目以降のプリセットがロックされていることを確認
-    const lockedPreset = optionsPage.locator('text=/Locked|ロック/i');
-    if (await lockedPreset.isVisible()) {
-      expect(await lockedPreset.isVisible()).toBeTruthy();
-    }
+    // 上限を超える 4 件目がロックされていることを確認する。
+    // 以前は isVisible() を if で囲んでいたため、ロックが無くても pass する
+    // 空振りテストになっていた
+    const locked = optionsPage
+      .locator(SELECTORS.styles.presetButton)
+      .filter({ hasText: 'Preset 4' });
+    await expect(locked).toBeVisible();
+    await expect(locked.locator('svg.lucide-lock')).toBeVisible();
+    await expect(locked).toBeDisabled();
 
     await optionsPage.close();
   });
@@ -450,7 +435,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -481,7 +466,7 @@ test.describe('Premium - Premium 機能', () => {
     await page.close();
 
     // Premium を解除
-    const page2 = await context.newPage();
+    const page2 = await openStoragePage(context, extensionId);
     await setStorageData(page2, 'premium', {
       isPremium: false,
       activatedAt: null
@@ -504,7 +489,7 @@ test.describe('Premium - Premium 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Premium を有効化
     await setStorageData(page, 'premium', {
@@ -571,7 +556,7 @@ test.describe('Premium - Premium 機能', () => {
     await page.close();
 
     // Premium を解除
-    const page2 = await context.newPage();
+    const page2 = await openStoragePage(context, extensionId);
     await setStorageData(page2, 'premium', {
       isPremium: false,
       activatedAt: null

--- a/tests/e2e/time-limit.spec.ts
+++ b/tests/e2e/time-limit.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from './fixtures/extension';
-import { openExternalSite, openPopup, openOptions } from './helpers/pages';
+import {
+  openExternalSite,
+  openOptions,
+  openPopup,
+  openStoragePage
+} from './helpers/pages';
 import {
   setStorageData,
   clearStorage,
@@ -23,7 +28,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Daily Time Limit を設定
     await setStorageData(page, 'settings', {
@@ -55,7 +60,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Hourly Time Limit を設定
     await setStorageData(page, 'settings', {
@@ -87,7 +92,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Time Limit を1秒に設定
     await setStorageData(page, 'settings', {
@@ -143,7 +148,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 昨日の使用データを設定（resetAt が過去）
     const yesterday = new Date();
@@ -199,7 +204,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 1時間前の使用データを設定
     const oneHourAgo = new Date();
@@ -254,7 +259,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Time Limit を設定
     await setStorageData(page, 'settings', {
@@ -305,7 +310,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -346,7 +351,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // Pause 有効 + Time Limit 超過状態
     await setStorageData(page, 'settings', {
@@ -398,7 +403,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 23:59の resetAt を設定（現在時刻より1分後）
     const resetTime = new Date();
@@ -467,7 +472,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 09:59の resetAt を設定
     const resetTime = new Date();
@@ -531,7 +536,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 2つのサイトに異なる Time Limit を設定
     await setStorageData(page, 'settings', {

--- a/tests/e2e/youtube.spec.ts
+++ b/tests/e2e/youtube.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures/extension';
-import { openExternalSite } from './helpers/pages';
+import { openExternalSite, openStoragePage } from './helpers/pages';
 import {
   setStorageData,
   clearStorage,
@@ -23,7 +23,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // YouTube Shorts を非表示に設定
     await setStorageData(page, 'settings', {
@@ -63,7 +63,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -103,7 +103,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -141,7 +141,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // YouTube を完全ブロック
     await setStorageData(page, 'settings', {
@@ -177,7 +177,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // YouTube Time Limit を設定
     await setStorageData(page, 'settings', {
@@ -206,7 +206,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // YouTube Time Limit を設定
     await setStorageData(page, 'settings', {
@@ -267,7 +267,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // 最初は Shorts 非表示なし
     await setStorageData(page, 'settings', {
@@ -298,22 +298,22 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     });
     expect(shortsHidden).toBeFalsy();
 
-    // 設定を変更
-    await youtubePage.evaluate(async () => {
-      await chrome.storage.local.set({
-        settings: {
-          language: 'en',
-          paused: false,
-          youtube: {
-            blockAccess: false,
-            hideShorts: true, // 有効化
-            hideRecommendations: false,
-            hideComments: false,
-            timeLimit: null
-          }
-        }
-      });
+    // 設定を変更する。
+    // page.evaluate はページのメインワールドで実行されるため、コンテンツ
+    // スクリプトと違い chrome.storage を参照できない。拡張機能ページ経由で更新する
+    const updatePage = await openStoragePage(context, extensionId);
+    await setStorageData(updatePage, 'settings', {
+      language: 'en',
+      paused: false,
+      youtube: {
+        blockAccess: false,
+        hideShorts: true, // 有効化
+        hideRecommendations: false,
+        hideComments: false,
+        timeLimit: null
+      }
     });
+    await updatePage.close();
 
     // storage.watch が反応するまで待機
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -332,7 +332,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -365,7 +365,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
 
     await page.close();
 
-    const page2 = await context.newPage();
+    const page2 = await openStoragePage(context, extensionId);
     const analytics = (await getStorageData(page2, 'analytics')) as any;
 
     // YouTube のトラッキングデータが記録されていることを確認
@@ -379,7 +379,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     await setStorageData(page, 'settings', {
       language: 'en',
@@ -445,7 +445,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     context,
     extensionId
   }) => {
-    const page = await context.newPage();
+    const page = await openStoragePage(context, extensionId);
 
     // blockAccess と Time Limit を両方設定
     await setStorageData(page, 'settings', {


### PR DESCRIPTION
## 概要

#323（E2E の破綻）に対する**第1弾: ハーネス修正**。E2E が「テストの準備段階で落ちる」構造的欠陥を解消する。

## 問題

`chrome.storage.local` は**拡張機能のページ（`chrome-extension://` スキーム）でしか参照できない**。しかし 37 箇所で以下のようになっていた。

```ts
const page = await context.newPage();          // about:blank
await setStorageData(page, 'premium', { ... }); // → chrome が undefined
```

結果 `TypeError: Cannot read properties of undefined (reading 'local')` となり、**そのテストが何を検証したかったのかすら実行されていなかった**。

`tests/e2e/helpers/storage.ts` には対策用の `setStorageDataFromExtension` が既に実装されていたが、呼び出し側が置き換えられないまま放置されていた。

## 変更内容

### `openStoragePage` ヘルパーを追加（`tests/e2e/helpers/pages.ts`）

`options.html` を開いた Page を返す。テストは複数回のストレージ操作を同じ Page で行うため、都度開閉する既存の `*FromExtension` 系より差分が小さく、意図も読みやすい。なぜこのヘルパーが必要なのかをコメントで明記した。

### 37 箇所の置き換え

| spec | 箇所数 |
| --- | --- |
| premium | 15 |
| youtube | 11 |
| time-limit | 11 |

外部サイトを開く用途の `context.newPage()`（`popup` / `block` / `newtab-block-info` の 4 箇所）は**対象外**として残した。`.goto()` を伴うかどうかで機械的に判定し、目視で確認済み。

### `youtube.spec.ts` のメインワールド問題

`youtubePage.evaluate(() => chrome.storage.local.set(...))` としていた箇所があった。`page.evaluate` は**ページのメインワールド**で実行されるため、コンテンツスクリプトの isolated world とは異なり `chrome.storage` を参照できない。拡張機能ページ経由の更新に変更した。

### 実装と矛盾していた 2 テストの修正

- **OPT-ST16 / PR-010**: 無料版のプリセット上限は 3 件（`FEATURE_LIMITS.free.maxPresets`）なので 2 件目はロックされない。4 件用意して 4 件目がロックされること、および 1〜3 件目がロックされていないことを検証する形に変更
- **PR-010** は `if (await lockedPreset.isVisible())` で囲まれており、**ロックが無くても pass する空振りテスト**だった。無条件のアサーションに変更

## 効果

対象 3 spec（premium / youtube / time-limit、計 33 テスト）の実行結果:

| | 修正前 | 修正後 |
| --- | --- | --- |
| pass | **0** | **13** |
| fail | 33 | 20 |
| `chrome.storage` 起因のエラー | 34 | **0** |

実行時間も 35.8 秒に収まった（修正前はタイムアウト待ちで大幅に長かった）。

## 残る失敗について

残り 20 件の内訳は `expect(received).toBeTruthy` 10 件、`toBeLessThan` / `toBe` 各 2 件、`toBeVisible` 1 件など、**セレクタとアサーションの不整合**。ハーネスが直ったことで「残りの失敗はすべてセレクタ/アサーションの問題」と切り分けが確定した。

これは #323 の第2弾（`data-testid` への移行）で扱う。本 PR は**テストコードのみの変更**で実装に触れていないため、リグレッションリスクはない。

## 検証

- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` 通過
- 対象 3 spec をローカル実行して上記の数値を確認
- ユニットテスト（CI）に影響なし

Refs #323