### PR TITLE
test: options ブロックリストタブの E2E を data-testid ベースへ移行

### DIFF
--- a/src/components/options/BlocklistTab.tsx
+++ b/src/components/options/BlocklistTab.tsx
@@ -175,12 +175,13 @@ export function BlocklistTab({
         </h2>
         <div className="flex gap-2">
           <Input
+            data-testid="blocklist-domain-input"
             value={newDomain}
             onChange={setNewDomain}
             placeholder={getMessage('domainPlaceholder')}
             containerClassName="flex-1 min-w-0"
           />
-          <Button onClick={onAddDomain}>
+          <Button data-testid="blocklist-add-button" onClick={onAddDomain}>
             <Plus className="w-4 h-4 mr-1" />
             {getMessage('add')}
           </Button>

--- a/src/components/options/blocklist/DomainListItem.tsx
+++ b/src/components/options/blocklist/DomainListItem.tsx
@@ -24,16 +24,18 @@ export function DomainListItem({
   onUpdateTimeLimit
 }: DomainListItemProps) {
   return (
-    <div className="py-3">
+    <div className="py-3" data-testid="blocklist-item">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           <Toggle
             checked={item.enabled}
             onChange={(checked) => onToggle(item.id, checked)}
             size="sm"
+            data-testid="blocklist-item-toggle"
           />
           <div>
             <p
+              data-testid="blocklist-item-domain"
               className={`font-medium ${item.enabled ? 'text-gray-900' : 'text-gray-400'}`}
             >
               {item.isWildcard && (
@@ -56,7 +58,12 @@ export function DomainListItem({
             </span>
           )}
         </div>
-        <Button variant="ghost" size="sm" onClick={() => onRemove(item.id)}>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onRemove(item.id)}
+          data-testid="blocklist-item-remove"
+        >
           <Trash2 className="w-4 h-4 text-danger-500" />
         </Button>
       </div>

--- a/src/components/options/modals/UnblockConfirmModal/UnblockConfirmModal.tsx
+++ b/src/components/options/modals/UnblockConfirmModal/UnblockConfirmModal.tsx
@@ -116,6 +116,7 @@ export function UnblockConfirmModal({
         <div className="space-y-2">
           <button
             type="button"
+            data-testid="unblock-confirm-hold-button"
             onPointerDown={handlePointerDown}
             onPointerUp={handlePointerUp}
             onPointerLeave={handlePointerLeave}
@@ -145,7 +146,12 @@ export function UnblockConfirmModal({
         </div>
 
         <div className="pt-2">
-          <Button variant="secondary" onClick={onClose} className="w-full">
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            className="w-full"
+            data-testid="unblock-confirm-cancel"
+          >
             {getMessage('cancel')}
           </Button>
         </div>

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -74,6 +74,8 @@ export const SELECTORS = {
     analyticsOptInDeny: '[data-testid="analytics-optin-deny"]',
     passwordModal: '[role="dialog"]',
     unblockConfirm: '[role="dialog"]',
+    unblockConfirmHoldButton: '[data-testid="unblock-confirm-hold-button"]',
+    unblockConfirmCancel: '[data-testid="unblock-confirm-cancel"]',
     passwordConfirmButton: '[data-testid="password-modal-confirm"]',
     passwordCancelButton: '[data-testid="password-modal-cancel"]'
   },
@@ -114,10 +116,12 @@ export const SELECTORS = {
     analyticsTab: '[data-testid="tab-analytics"]',
     premiumTab: '[data-testid="tab-license"]',
     helpTab: '[data-testid="tab-help"]',
-    domainInput: 'input[type="text"]',
-    addButton: 'button',
-    deleteButton:
-      'button[title*="削除"], button[title*="Delete"], button[title*="Remove"]',
+    domainInput: '[data-testid="blocklist-domain-input"]',
+    addButton: '[data-testid="blocklist-add-button"]',
+    listItem: '[data-testid="blocklist-item"]',
+    itemDomain: '[data-testid="blocklist-item-domain"]',
+    itemToggle: '[data-testid="blocklist-item-toggle"]',
+    deleteButton: '[data-testid="blocklist-item-remove"]',
     toggle: '[role="switch"]',
     youtubeSection: 'text=/YouTube/i',
     notificationSection: 'text=/Notification|通知/i'

--- a/tests/e2e/helpers/pages.ts
+++ b/tests/e2e/helpers/pages.ts
@@ -41,6 +41,33 @@ export async function openNewTab(
 }
 
 /**
+ * Unblock 確認モーダルの長押しボタンを、確定するまで押し続ける
+ *
+ * 実装は 5 秒間の長押しで確定する（UnblockConfirmModal の HOLD_DURATION_MS）。
+ * 単純なクリックでは確定しないため、ポインタを押したまま待機する。
+ *
+ * @param page - モーダルが表示されているページ
+ */
+export async function holdUnblockConfirm(page: Page): Promise<void> {
+  const button = page.locator('[data-testid="unblock-confirm-hold-button"]');
+  await button.waitFor({ state: 'visible' });
+
+  const box = await button.boundingBox();
+  if (!box) throw new Error('長押しボタンの位置を取得できない');
+
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+
+  // 確定するとモーダルが閉じるので、それを待つ（最長 8 秒）。
+  // 固定待機だと進捗の進み方に左右されるため、状態で待つ
+  try {
+    await button.waitFor({ state: 'detached', timeout: 8000 });
+  } finally {
+    await page.mouse.up();
+  }
+}
+
+/**
  * chrome.storage を操作するためのページを開く
  *
  * chrome.storage.local は拡張機能のページ（chrome-extension:// スキーム）でしか

--- a/tests/e2e/options-blocklist.spec.ts
+++ b/tests/e2e/options-blocklist.spec.ts
@@ -4,7 +4,10 @@ import {
   setupTestStorage,
   clearStorage,
   setStorageData,
-  TEST_DATA
+  TEST_DATA,
+  SELECTORS,
+  getStorageData,
+  holdUnblockConfirm
 } from './helpers';
 
 /**
@@ -33,18 +36,15 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     const page = await openOptions(context, extensionId);
 
     // ブロックリストタブをクリック
-    const blocklistTab = page
-      .locator('button')
-      .filter({ hasText: /Block.*List|ブロックリスト/i });
+    const blocklistTab = page.locator(SELECTORS.options.blocklistTab);
     await expect(blocklistTab).toBeVisible();
     await blocklistTab.click();
 
     // ブロックリストタブがアクティブになる
-    await expect(blocklistTab).toHaveClass(/border-primary-500/);
+    await expect(blocklistTab).toHaveAttribute('aria-selected', 'true');
 
     // ドメイン追加フォームが表示される
-    const addDomainInput = page.locator('input[type="text"]').first();
-    await expect(addDomainInput).toBeVisible();
+    await expect(page.locator(SELECTORS.options.domainInput)).toBeVisible();
 
     await page.close();
   });
@@ -56,25 +56,22 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     const page = await openOptions(context, extensionId, 'blocklist');
 
     // ドメイン入力フィールドに reddit.com を入力
-    const input = page.locator('input[type="text"]').first();
+    const input = page.locator(SELECTORS.options.domainInput);
     await input.fill('reddit.com');
 
     // 追加ボタンをクリック
-    const addButton = page
-      .locator('button')
-      .filter({ hasText: /Add|追加|Block|ブロック/i })
-      .first();
-    await addButton.click();
+    await page.locator(SELECTORS.options.addButton).click();
 
     // ブロックリストに追加されたことを確認
-    const domainItem = page.locator('text=/reddit.com/i');
-    await expect(domainItem.first()).toBeVisible();
+    const domainItem = page.locator(SELECTORS.options.itemDomain);
+    await expect(domainItem.first()).toContainText('reddit.com');
 
     // ストレージに保存されたことを確認
-    const blockList = await page.evaluate(async () => {
-      const result = await chrome.storage.local.get('settings');
-      return result.settings?.blockList || [];
-    });
+    const settings = await getStorageData<{ blockList?: unknown[] }>(
+      page,
+      'settings'
+    );
+    const blockList = settings?.blockList ?? [];
 
     expect(blockList).toEqual(
       expect.arrayContaining([
@@ -95,25 +92,22 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     const page = await openOptions(context, extensionId, 'blocklist');
 
     // ワイルドカード付きドメインを入力
-    const input = page.locator('input[type="text"]').first();
+    const input = page.locator(SELECTORS.options.domainInput);
     await input.fill('*.reddit.com');
 
     // 追加ボタンをクリック
-    const addButton = page
-      .locator('button')
-      .filter({ hasText: /Add|追加|Block|ブロック/i })
-      .first();
-    await addButton.click();
+    await page.locator(SELECTORS.options.addButton).click();
 
-    // ブロックリストに追加されたことを確認
-    const domainItem = page.locator('text=/\\*\\.reddit\\.com/i');
-    await expect(domainItem.first()).toBeVisible();
+    // ブロックリストに追加されたことを確認（*. は別要素で描画される）
+    const domainItem = page.locator(SELECTORS.options.itemDomain);
+    await expect(domainItem.first()).toContainText('reddit.com');
 
     // ストレージに保存されたことを確認
-    const blockList = await page.evaluate(async () => {
-      const result = await chrome.storage.local.get('settings');
-      return result.settings?.blockList || [];
-    });
+    const settings = await getStorageData<{ blockList?: unknown[] }>(
+      page,
+      'settings'
+    );
+    const blockList = settings?.blockList ?? [];
 
     expect(blockList).toEqual(
       expect.arrayContaining([
@@ -144,28 +138,18 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     const page = await openOptions(context, extensionId, 'blocklist');
 
     // example.com が表示されることを確認
-    const domainItem = page.locator('text=/example.com/i').first();
-    await expect(domainItem).toBeVisible();
+    const domainItem = page.locator(SELECTORS.options.itemDomain).first();
+    await expect(domainItem).toContainText('example.com');
 
-    // 削除ボタンを探してクリック
-    const deleteButton = page
-      .locator(
-        'button[title*="削除"], button[title*="Delete"], button[title*="Remove"]'
-      )
-      .first();
-    await deleteButton.click();
+    // 削除ボタンをクリック
+    await page.locator(SELECTORS.options.deleteButton).first().click();
 
-    // Unblock 確認モーダルが表示される（パスワード未設定の場合）
-    const confirmModal = page.locator('text=/Are you sure|確認/i');
-    if (await confirmModal.isVisible()) {
-      const confirmButton = page
-        .locator('button')
-        .filter({ hasText: /Confirm|確定|Yes|はい/i });
-      await confirmButton.click();
-    }
+    // Unblock 確認モーダルで確定する（5 秒の長押しが必要）
+    await expect(page.locator(SELECTORS.modal.unblockConfirm)).toBeVisible();
+    await holdUnblockConfirm(page);
 
-    // example.com が削除されたことを確認
-    await expect(page.locator('text=/example.com/i').first()).not.toBeVisible();
+    // 項目が削除されたことを確認
+    await expect(page.locator(SELECTORS.options.listItem)).toHaveCount(0);
 
     await page.close();
   });
@@ -185,8 +169,8 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
 
     const page = await openOptions(context, extensionId, 'blocklist');
 
-    // トグルスイッチを探す
-    const toggle = page.locator('[role="switch"]').first();
+    // ブロックリスト項目のトグルを取得する
+    const toggle = page.locator(SELECTORS.options.itemToggle).first();
     await expect(toggle).toBeVisible();
 
     // 初期状態は有効（aria-checked="true"）
@@ -195,14 +179,9 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     // トグルをクリックして無効化
     await toggle.click();
 
-    // Unblock 確認モーダルが表示される（パスワード未設定の場合）
-    const confirmModal = page.locator('text=/Are you sure|確認/i');
-    if (await confirmModal.isVisible()) {
-      const confirmButton = page
-        .locator('button')
-        .filter({ hasText: /Confirm|確定|Yes|はい/i });
-      await confirmButton.click();
-    }
+    // Unblock 確認モーダルで確定する（5 秒の長押しが必要）
+    await expect(page.locator(SELECTORS.modal.unblockConfirm)).toBeVisible();
+    await holdUnblockConfirm(page);
 
     // トグルが無効になる
     await expect(toggle).toHaveAttribute('aria-checked', 'false');
@@ -308,18 +287,14 @@ test.describe('Options 画面（ブロックリストタブ）', () => {
     const page = await openOptions(context, extensionId, 'blocklist');
 
     // トグルスイッチをクリックして無効化を試みる
-    const toggle = page.locator('[role="switch"]').first();
+    const toggle = page.locator(SELECTORS.options.itemToggle).first();
     await toggle.click();
 
     // Unblock 確認モーダルが表示される
-    const confirmModal = page.locator('text=/Are you sure|本当に|確認/i');
-    await expect(confirmModal.first()).toBeVisible();
+    await expect(page.locator(SELECTORS.modal.unblockConfirm)).toBeVisible();
 
-    // Confirm ボタンをクリック
-    const confirmButton = page
-      .locator('button')
-      .filter({ hasText: /Confirm|確定|Yes|はい/i });
-    await confirmButton.click();
+    // 長押しで確定する（5 秒の長押しが必要な実装）
+    await holdUnblockConfirm(page);
 
     // トグルが無効になる
     await expect(toggle).toHaveAttribute('aria-checked', 'false');


### PR DESCRIPTION
## 概要

#327 の**第4弾**。`options-blocklist.spec.ts` を **13/13 全 pass** にした（実行 19.5秒）。

ベースラインは pass 7 / fail 6。

## 最大の発見: 確認モーダルは「5秒の長押し」で確定する

`UnblockConfirmModal` の確定操作は**ボタンのクリックではなく 5 秒間の長押し**だった（`HOLD_DURATION_MS = 5000`、`requestAnimationFrame` で進捗を加算し 100% で `onConfirm`）。ブロック解除を安易に行わせないための意図的な UX。

テストは「Confirm ボタンをクリック」を想定しており、しかも以下のように `if` で囲まれていた。

```ts
const confirmModal = page.locator('text=/Are you sure|確認/i');
if (await confirmModal.isVisible()) {
  const confirmButton = page.locator('button').filter({ hasText: /Confirm|確定/i });
  await confirmButton.click();
}
```

モーダルが見つからなければ**何も検証せず先へ進む**構造で、実質的に確認フローを一切テストできていなかった。

### `holdUnblockConfirm` ヘルパーを追加

```ts
await page.mouse.down();
try {
  // 確定するとモーダルが閉じるので、それを状態で待つ
  await button.waitFor({ state: 'detached', timeout: 8000 });
} finally {
  await page.mouse.up();
}
```

固定時間の待機（`waitForTimeout(5600)`）では成立しなかった。押下中は Playwright の待機と進捗更新のタイミングが噛み合わず、`mouse.up()` が早すぎて `handlePointerUp` がリセットしてしまう。**モーダルが閉じることを状態として待つ**方式にして解決した。

実機での実測（進捗 20% → 40% → 60% と進み、確定後に `aria-checked="false"` になる）で挙動を確認したうえで実装している。

## `data-testid` の付与

| コンポーネント | testid |
| --- | --- |
| `BlocklistTab` | `blocklist-domain-input` / `blocklist-add-button` |
| `DomainListItem` | `blocklist-item` / `blocklist-item-domain` / `blocklist-item-toggle` / `blocklist-item-remove` |
| `UnblockConfirmModal` | `unblock-confirm-hold-button` / `unblock-confirm-cancel` |

従来は `input[type="text"]` の最初の要素、`button` を文言でフィルタ、`button[title*="削除"]`（実装に `title` 属性が無く一致しない）といった脆いセレクタだった。

## その他の修正

- タブの活性判定を `toHaveClass(/border-primary-500/)` から `toHaveAttribute('aria-selected', 'true')` に変更
- ストレージ確認を `page.evaluate` の直接読み出しから `getStorageData` ヘルパー経由に変更（JSON 形式に対応）
- ワイルドカードの表示確認は `*.` が別要素で描画されるため、ドメイン部分の一致で検証する形に修正

## 検証

| | 変更前 | 変更後 |
| --- | --- | --- |
| pass | 7 | **13** |
| fail | 6 | **0** |

- ユニットテスト 808 件 全 pass（実装変更は testid の付与のみ）
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` / `pnpm build` 通過

## 残り

options の style 16 / schedule 11 / analytics 9 / help 7 / premium 3 と、block / youtube / time-limit / premium / analytics / interaction。

Refs #327