### PR TITLE
test: options スタイルタブの E2E を data-testid ベースへ移行

### DIFF
--- a/src/components/features/FontPicker/FontPicker.tsx
+++ b/src/components/features/FontPicker/FontPicker.tsx
@@ -141,6 +141,7 @@ export function FontPicker({
             return (
               <button
                 key={categoryKey}
+                data-testid="font-category-button"
                 onClick={() => handleCategoryChange(categoryKey)}
                 className={`
                   px-3 py-1.5 text-sm rounded-lg border transition-colors
@@ -167,6 +168,7 @@ export function FontPicker({
           {FONT_CATEGORIES[selectedCategory].fonts.map((font) => (
             <button
               key={font.family}
+              data-testid="font-family-button"
               onClick={() => handleChange({ family: font.family })}
               className={`
                 px-3 py-2 text-sm rounded-lg border transition-colors text-left
@@ -193,6 +195,7 @@ export function FontPicker({
           {FONT_SIZES.map((size) => (
             <button
               key={size.value}
+              data-testid="font-size-button"
               onClick={() => handleChange({ size: size.value })}
               className={`
                 flex-1 px-3 py-2 text-sm rounded-lg border transition-colors
@@ -218,6 +221,7 @@ export function FontPicker({
           {FONT_WEIGHTS.map((weight) => (
             <button
               key={weight.value}
+              data-testid="font-weight-button"
               onClick={() => handleChange({ weight: weight.value })}
               className={`
                 flex-1 px-3 py-2 text-sm rounded-lg border transition-colors

--- a/src/components/features/ImageUploader/ImageUploader.tsx
+++ b/src/components/features/ImageUploader/ImageUploader.tsx
@@ -137,6 +137,7 @@ export function ImageUploader({
     <div className="space-y-2">
       <input
         ref={fileInputRef}
+        data-testid="style-bg-upload"
         type="file"
         accept="image/jpeg,image/png,image/webp"
         onChange={handleFileSelect}
@@ -145,6 +146,7 @@ export function ImageUploader({
       />
 
       <div
+        data-testid="style-bg-upload-dropzone"
         onClick={handleClick}
         onDragEnter={handleDragEnter}
         onDragLeave={handleDragLeave}

--- a/src/components/options/StylesTab.tsx
+++ b/src/components/options/StylesTab.tsx
@@ -57,6 +57,7 @@ export function StylesTab({ isPremium, featureLimits }: StylesTabProps) {
               </h2>
               <div
                 className="relative aspect-video rounded-lg overflow-hidden"
+                data-testid="style-preview"
                 style={
                   draftDisplaySettings.backgroundType === 'color'
                     ? {

--- a/src/components/options/modals/NewPresetModal.tsx
+++ b/src/components/options/modals/NewPresetModal.tsx
@@ -33,15 +33,24 @@ export function NewPresetModal({
     >
       <div className="space-y-4">
         <Input
+          data-testid="new-preset-name-input"
           value={presetName}
           onChange={onPresetNameChange}
           placeholder={getMessage('presetNamePlaceholder')}
         />
         <div className="flex justify-end gap-2">
-          <Button variant="secondary" onClick={handleClose}>
+          <Button
+            variant="secondary"
+            onClick={handleClose}
+            data-testid="new-preset-cancel"
+          >
             {getMessage('cancel')}
           </Button>
-          <Button onClick={onCreate} disabled={!presetName.trim()}>
+          <Button
+            onClick={onCreate}
+            disabled={!presetName.trim()}
+            data-testid="new-preset-confirm"
+          >
             <Plus className="w-4 h-4" />
             {getMessage('add')}
           </Button>

--- a/src/components/options/styles/DisplaySettingsForm.tsx
+++ b/src/components/options/styles/DisplaySettingsForm.tsx
@@ -64,6 +64,7 @@ export function DisplaySettingsForm({
                 {getMessage('presetName')}
               </label>
               <Input
+                data-testid="style-preset-name-input"
                 value={editingPresetName}
                 onChange={handlePresetNameChange}
                 placeholder={getMessage('presetNamePlaceholder')}
@@ -77,6 +78,7 @@ export function DisplaySettingsForm({
               {getMessage('yourGoal')}
             </label>
             <Input
+              data-testid="style-goal-input"
               value={draftDisplaySettings.goalText}
               onChange={handleGoalTextChange}
               placeholder={getMessage('goalPlaceholder')}
@@ -89,6 +91,7 @@ export function DisplaySettingsForm({
               {getMessage('goalSubText')}
             </label>
             <textarea
+              data-testid="style-goal-subtext"
               value={draftDisplaySettings.goalSubText}
               onChange={(e) => handleGoalSubTextChange(e.target.value)}
               placeholder={getMessage('goalSubTextPlaceholder')}
@@ -108,6 +111,7 @@ export function DisplaySettingsForm({
             </label>
             <div className="flex items-center gap-4">
               <input
+                data-testid="style-text-color-picker"
                 type="color"
                 value={draftDisplaySettings.textColor}
                 onChange={(e) => handleTextColorChange(e.target.value)}
@@ -138,6 +142,7 @@ export function DisplaySettingsForm({
           </label>
           <div className="flex gap-2">
             <button
+              data-testid="style-bg-type-image"
               onClick={() => handleBackgroundTypeChange('image')}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 (draftDisplaySettings.backgroundType || 'image') === 'image'
@@ -148,6 +153,7 @@ export function DisplaySettingsForm({
               {getMessage('backgroundTypeImage')}
             </button>
             <button
+              data-testid="style-bg-type-color"
               onClick={() => handleBackgroundTypeChange('color')}
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
                 draftDisplaySettings.backgroundType === 'color'
@@ -166,6 +172,7 @@ export function DisplaySettingsForm({
             {BACKGROUND_OPTIONS.map((bg) => (
               <button
                 key={bg.id}
+                data-testid="style-bg-option"
                 onClick={() => handleBackgroundChange(bg.id)}
                 className={`relative aspect-video rounded-lg overflow-hidden border-2 transition-colors ${
                   draftDisplaySettings.backgroundImage === bg.id

--- a/src/components/options/styles/PresetSelector.tsx
+++ b/src/components/options/styles/PresetSelector.tsx
@@ -41,7 +41,10 @@ export function PresetSelector({
       {/* Preset Selector */}
       <Card>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold text-gray-900">
+          <h2
+            className="text-lg font-semibold text-gray-900"
+            data-testid="styles-section-heading"
+          >
             {getMessage('dashboardPresets')}
           </h2>
           {!isPremium && (
@@ -122,7 +125,11 @@ function EmptyState({ onCreateClick }: { onCreateClick: () => void }) {
       <p className="text-xs text-gray-500 mb-4">
         {getMessage('noPresetsDescription')}
       </p>
-      <Button onClick={onCreateClick} size="sm">
+      <Button
+        onClick={onCreateClick}
+        size="sm"
+        data-testid="style-create-first-button"
+      >
         <Plus className="w-4 h-4" />
         {getMessage('createFirstPreset')}
       </Button>
@@ -158,6 +165,7 @@ function PresetButtons({
         return (
           <button
             key={preset.id}
+            data-testid="style-preset-button"
             onClick={() => !isLocked && onSelectPreset(preset.id)}
             disabled={isLocked}
             title={isLocked ? getMessage('upgradeToUsePreset') : undefined}
@@ -185,6 +193,7 @@ function PresetButtons({
       {/* New preset button */}
       {draftPresets.length < featureLimits.maxPresets && (
         <button
+          data-testid="style-new-preset-button"
           onClick={onCreateClick}
           className="px-4 py-2 rounded-lg text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors flex items-center gap-1"
         >
@@ -239,6 +248,7 @@ function EditingIndicator({
           variant="ghost"
           size="sm"
           onClick={() => onDeletePreset(selectedPreset.id)}
+          data-testid="style-delete-button"
         >
           <Trash2 className="w-4 h-4 text-danger-500" />
         </Button>
@@ -248,7 +258,12 @@ function EditingIndicator({
             {getMessage('activePreset')}
           </span>
         ) : (
-          <Button variant="secondary" onClick={onApplyPreset} size="sm">
+          <Button
+            variant="secondary"
+            onClick={onApplyPreset}
+            size="sm"
+            data-testid="style-apply-button"
+          >
             <Check className="w-4 h-4" />
             {getMessage('applyPreset')}
           </Button>
@@ -261,6 +276,7 @@ function EditingIndicator({
             !isDirty
           }
           size="sm"
+          data-testid="style-save-button"
         >
           <Save className="w-4 h-4" />
           {visionSaved ? getMessage('saved') : getMessage('save')}

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -129,29 +129,33 @@ export const SELECTORS = {
 
   // Options - Styles Tab
   styles: {
-    presetSelector: 'h2:has-text("Preset"), h2:has-text("プリセット")',
-    createPresetButton:
-      'button:has-text("新規プリセット"), button:has-text("New Preset")',
-    createFirstPresetButton:
-      'button:has-text("最初のプリセット"), button:has-text("Create First Preset")',
-    presetButton: '.flex.flex-wrap.gap-2 > button',
-    presetNameInput:
-      'input[placeholder*="プリセット名"], input[placeholder*="Preset name"]',
-    goalTextInput:
-      'input[placeholder*="目標"], input[placeholder*="your goal"]',
-    goalSubTextArea: 'textarea[maxLength="100"]',
-    textColorPicker: 'input[type="color"]',
-    backgroundTypeImage: 'button:has-text("画像"), button:has-text("Image")',
-    backgroundTypeColor: 'button:has-text("単色"), button:has-text("Color")',
-    backgroundImageOption: '.grid.grid-cols-3 > button',
-    backgroundColorPicker: 'input[type="color"]',
-    customBackgroundUpload: 'input[type="file"]',
-    fontFamilySelect: 'select',
-    saveButton: 'button:has-text("保存"), button:has-text("Save")',
-    applyButton: 'button:has-text("適用"), button:has-text("Apply")',
-    deleteButton:
-      'button:has-text("削除"), button:has-text("Delete"), button:has(svg.lucide-trash-2)',
-    preview: '.relative.aspect-video'
+    presetSelector: '[data-testid="styles-section-heading"]',
+    createPresetButton: '[data-testid="style-new-preset-button"]',
+    createFirstPresetButton: '[data-testid="style-create-first-button"]',
+    presetButton: '[data-testid="style-preset-button"]',
+    presetNameInput: '[data-testid="style-preset-name-input"]',
+    goalTextInput: '[data-testid="style-goal-input"]',
+    goalSubTextArea: '[data-testid="style-goal-subtext"]',
+    textColorPicker: '[data-testid="style-text-color-picker"]',
+    backgroundTypeImage: '[data-testid="style-bg-type-image"]',
+    backgroundTypeColor: '[data-testid="style-bg-type-color"]',
+    backgroundImageOption: '[data-testid="style-bg-option"]',
+    backgroundColorPicker: '[data-testid="style-text-color-picker"]',
+    // ファイル入力は hidden。可視要素はドロップゾーン
+    customBackgroundUpload: '[data-testid="style-bg-upload"]',
+    customBackgroundDropzone: '[data-testid="style-bg-upload-dropzone"]',
+    // フォントは select ではなくボタン群で選択する
+    fontCategoryButton: '[data-testid="font-category-button"]',
+    fontFamilySelect: '[data-testid="font-family-button"]',
+    fontSizeButton: '[data-testid="font-size-button"]',
+    fontWeightButton: '[data-testid="font-weight-button"]',
+    saveButton: '[data-testid="style-save-button"]',
+    applyButton: '[data-testid="style-apply-button"]',
+    deleteButton: '[data-testid="style-delete-button"]',
+    preview: '[data-testid="style-preview"]',
+    newPresetNameInput: '[data-testid="new-preset-name-input"]',
+    newPresetConfirm: '[data-testid="new-preset-confirm"]',
+    newPresetCancel: '[data-testid="new-preset-cancel"]'
   },
 
   // Options - Schedules Tab

--- a/tests/e2e/helpers/storage.ts
+++ b/tests/e2e/helpers/storage.ts
@@ -158,6 +158,50 @@ export async function getStorageDataFromExtension<T = unknown>(
 }
 
 /**
+ * DashboardDisplaySettings の完全な形を作る
+ *
+ * 必須フィールドを欠くとアプリ側の参照が壊れるため、テストで vision を
+ * 直接組み立てる場合は必ずこれを使う。
+ *
+ * @param overrides - 上書きする値
+ */
+export function makeDisplaySettings(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    goalText: 'Focus on what matters',
+    goalSubText: 'Stay productive',
+    textColor: '#ffffff',
+    backgroundType: 'color',
+    backgroundImage: 'default-1',
+    backgroundColor: '#1a1a2e',
+    customBackgroundData: null,
+    fontSettings: { family: 'system', size: 'lg', weight: 'bold' },
+    ...overrides
+  };
+}
+
+/**
+ * DashboardPreset の完全な形を作る
+ *
+ * @param id - プリセットID
+ * @param name - プリセット名
+ * @param overrides - 表示設定の上書き
+ */
+export function makePreset(
+  id: string,
+  name: string,
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    ...makeDisplaySettings(overrides),
+    id,
+    name,
+    createdAt: new Date().toISOString()
+  };
+}
+
+/**
  * テスト用の初期設定をセットする
  *
  * @param page - Playwright Page オブジェクト

--- a/tests/e2e/options-style.spec.ts
+++ b/tests/e2e/options-style.spec.ts
@@ -4,6 +4,8 @@ import {
   setupTestStorage,
   clearStorage,
   setStorageData,
+  makeDisplaySettings,
+  makePreset,
   SELECTORS
 } from './helpers';
 
@@ -95,14 +97,10 @@ test.describe('Options - Style Tab', () => {
     await expect(modal).toBeVisible();
 
     // プリセット名を入力
-    const nameInput = modal.locator('input[type="text"]');
-    await nameInput.fill('Test Preset');
+    await page.locator(SELECTORS.styles.newPresetNameInput).fill('Test Preset');
 
     // 作成ボタンをクリック
-    const confirmButton = modal.locator(
-      'button:has-text("作成"), button:has-text("Create")'
-    );
-    await confirmButton.click();
+    await page.locator(SELECTORS.styles.newPresetConfirm).click();
 
     // モーダルが閉じる
     await expect(modal).not.toBeVisible();
@@ -120,29 +118,15 @@ test.describe('Options - Style Tab', () => {
     // テスト用プリセットを追加
     const setupPage = await openOptions(context, extensionId);
     await setStorageData(setupPage, 'vision', {
-      defaultSettings: {
-        goalText: 'Focus on what matters',
-        subText: 'Stay productive'
-      },
+      defaultSettings: makeDisplaySettings(),
       presets: [
-        {
-          id: 'default',
-          name: 'Default',
-          goalText: 'Focus on what matters',
-          subText: 'Stay productive',
-          textColor: '#ffffff',
-          backgroundColor: '#1a1a2e',
-          backgroundType: 'color'
-        },
-        {
-          id: 'test-preset',
-          name: 'Test Preset',
+        makePreset('default', 'Default'),
+        makePreset('test-preset', 'Test Preset', {
           goalText: 'Test Goal',
-          subText: 'Test Sub',
+          goalSubText: 'Test Sub',
           textColor: '#000000',
-          backgroundColor: '#ffffff',
-          backgroundType: 'color'
-        }
+          backgroundColor: '#ffffff'
+        })
       ],
       activePresetId: 'default'
     });
@@ -289,9 +273,14 @@ test.describe('Options - Style Tab', () => {
       .filter({ hasText: 'Default' });
     await presetButton.click();
 
-    // カスタム背景アップロードフィールドが表示される
-    const uploadInput = page.locator(SELECTORS.styles.customBackgroundUpload);
-    await expect(uploadInput).toBeVisible();
+    // カスタム背景アップロードのドロップゾーンが表示される
+    // （ファイル入力自体は hidden なので可視要素で確認する）
+    await expect(
+      page.locator(SELECTORS.styles.customBackgroundDropzone)
+    ).toBeVisible();
+    await expect(
+      page.locator(SELECTORS.styles.customBackgroundUpload)
+    ).toBeAttached();
 
     await page.close();
   });
@@ -342,14 +331,19 @@ test.describe('Options - Style Tab', () => {
       .filter({ hasText: 'Default' });
     await presetButton.click();
 
-    // フォント選択セレクトでGoogle Fontsが選択可能
-    const fontSelect = page.locator(SELECTORS.styles.fontFamilySelect).first();
-    await expect(fontSelect).toBeVisible();
+    // フォントはカテゴリ選択 + ファミリ選択のボタン群で構成される
+    const categoryButtons = page.locator(SELECTORS.styles.fontCategoryButton);
+    await expect(categoryButtons.first()).toBeVisible();
 
-    // Google Fontsのオプションが含まれている（Premiumユーザーのみ）
-    const options = await fontSelect.locator('option').allTextContents();
-    // System fonts以外にGoogle Fontsが含まれることを確認
-    expect(options.length).toBeGreaterThan(3);
+    // System 以外のカテゴリ（Google Fonts 系）が選択できる
+    const categoryCount = await categoryButtons.count();
+    expect(categoryCount).toBeGreaterThan(1);
+
+    // 2 番目のカテゴリを選ぶとファミリ候補が表示される
+    await categoryButtons.nth(1).click();
+    const familyButtons = page.locator(SELECTORS.styles.fontFamilySelect);
+    await expect(familyButtons.first()).toBeVisible();
+    expect(await familyButtons.count()).toBeGreaterThan(1);
 
     await page.close();
   });
@@ -457,19 +451,13 @@ test.describe('Options - Style Tab', () => {
     // 無料版の上限（FEATURE_LIMITS.free.maxPresets = 3）を 1 件超える 4 件を用意する
     const setupPage = await openOptions(context, extensionId);
     await setStorageData(setupPage, 'vision', {
-      defaultSettings: {
-        goalText: 'Focus on what matters',
-        subText: 'Stay productive'
-      },
-      presets: [1, 2, 3, 4].map((n) => ({
-        id: `preset${n}`,
-        name: `Preset ${n}`,
-        goalText: `Goal ${n}`,
-        subText: `Sub ${n}`,
-        textColor: '#ffffff',
-        backgroundColor: '#1a1a2e',
-        backgroundType: 'color'
-      })),
+      defaultSettings: makeDisplaySettings(),
+      presets: [1, 2, 3, 4].map((n) =>
+        makePreset(`preset${n}`, `Preset ${n}`, {
+          goalText: `Goal ${n}`,
+          goalSubText: `Sub ${n}`
+        })
+      ),
       activePresetId: 'preset1'
     });
     // Freeユーザー（Premiumなし）


### PR DESCRIPTION
## 概要

#327 の**第5弾**。`options-style.spec.ts` を **16/16 全 pass** にした（実行 10.9秒）。

ベースラインは pass 7 / fail 9。この spec は**セレクタ腐敗の中心**だった箇所で、調査当初（#323）は 16 件全滅していた。

## 腐敗の原因

UI 用語が「プリセット」→「**スタイル**」に改称された際、E2E が追従していなかった。

| 旧セレクタ | 実態 |
| --- | --- |
| `h2:has-text("Preset"), h2:has-text("プリセット")` | 見出しは「スタイル」 |
| `button:has-text("新規プリセット")` | 「新規スタイル」 |
| `button:has-text("最初のプリセット")` | 「最初のスタイルを作成」 |
| `.flex.flex-wrap.gap-2 > button` | Tailwind クラス依存 |
| `select`（フォント選択） | **select ではなくボタン群** |

## `data-testid` の付与

| コンポーネント | testid |
| --- | --- |
| `PresetSelector` | `styles-section-heading` / `style-preset-button` / `style-new-preset-button` / `style-create-first-button` / `style-apply-button` / `style-save-button` / `style-delete-button` |
| `DisplaySettingsForm` | `style-preset-name-input` / `style-goal-input` / `style-goal-subtext` / `style-text-color-picker` / `style-bg-type-image` / `style-bg-type-color` / `style-bg-option` |
| `StylesTab` | `style-preview` |
| `NewPresetModal` | `new-preset-name-input` / `new-preset-confirm` / `new-preset-cancel` |
| `FontPicker` | `font-category-button` / `font-family-button` / `font-size-button` / `font-weight-button` |
| `ImageUploader` | `style-bg-upload` / `style-bg-upload-dropzone` |

## テストが実装の実態と合っていなかった箇所

### フォント選択は select ではない

`FontPicker` はカテゴリ選択とファミリ選択の**ボタン群**で構成されている。テストは `select` の `option` を数えて「3個より多い」ことを確認しようとしていたため、そもそも成立しなかった。

カテゴリが複数あること → 2番目のカテゴリを選ぶ → ファミリ候補が複数表示されることを確認する形に書き換えた。Google Fonts が Premium 向けに提供されるという検証意図は保っている。

### カスタム背景のファイル入力は hidden

`ImageUploader` の `<input type="file">` は `className="hidden"` で、可視要素はクリック/ドラッグ用のドロップゾーン。`toBeVisible()` は原理的に成功しない。

**可視性はドロップゾーンで、要素の存在は `toBeAttached()` で**確認する形にした。

### 新規プリセット作成の確定ボタン

ラベルは「作成」ではなく i18n キー `add`（追加 / Add）だった。`button:has-text("作成")` は一致しない。

## フィクスチャの共通化

spec 内に不完全な `vision` データが散在していた（`goalSubText` が `subText` になっている、`fontSettings` が無い等）。ヘルパーにファクトリを追加して一掃した。

```ts
makeDisplaySettings(overrides?)  // DashboardDisplaySettings の完全な形
makePreset(id, name, overrides?) // DashboardPreset の完全な形
```

以降の spec でも同じ問題が出るため、共通化しておく価値が高い。

## 検証

| | 変更前 | 変更後 |
| --- | --- | --- |
| pass | 7 | **16** |
| fail | 9 | **0** |

- ユニットテスト 808 件 全 pass（実装変更は testid の付与のみ）
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` / `pnpm build` 通過

## 残り

options の schedule 11 / analytics 9 / help 7 / premium 3 と、block / youtube / time-limit / premium / analytics / interaction。

Refs #327