### PR TITLE
test: options スケジュールタブの E2E を data-testid ベースへ移行

### DIFF
--- a/src/components/options/SchedulesTab.tsx
+++ b/src/components/options/SchedulesTab.tsx
@@ -38,7 +38,7 @@ export function SchedulesTab({
           <h2 className="text-lg font-semibold text-gray-900">
             {getMessage('blockingSchedules')}
           </h2>
-          <Button onClick={onAddSchedule}>
+          <Button onClick={onAddSchedule} data-testid="schedule-add-button">
             <Plus className="w-4 h-4 mr-1" />
             {getMessage('addSchedule')}
           </Button>
@@ -65,12 +65,14 @@ export function SchedulesTab({
             {settings?.schedules.map((schedule) => (
               <div
                 key={schedule.id}
+                data-testid="schedule-item"
                 className="flex items-center justify-between p-4 bg-gray-50 rounded-lg"
               >
                 <div className="flex-1">
                   <div className="flex items-center gap-2">
                     <p className="font-medium text-gray-900">{schedule.name}</p>
                     <Toggle
+                      data-testid="schedule-item-toggle"
                       checked={schedule.enabled}
                       onChange={(enabled) =>
                         onToggleSchedule(schedule.id, enabled)
@@ -95,7 +97,10 @@ export function SchedulesTab({
                     ))}
                   </div>
                   {schedule.presetId && (
-                    <p className="text-xs text-primary-600 mt-1">
+                    <p
+                      className="text-xs text-primary-600 mt-1"
+                      data-testid="schedule-item-preset"
+                    >
                       {getMessage('presetLabel')}:{' '}
                       {vision?.presets?.find((p) => p.id === schedule.presetId)
                         ?.name || getMessage('unknownPreset')}
@@ -107,6 +112,7 @@ export function SchedulesTab({
                     variant="ghost"
                     size="sm"
                     onClick={() => onEditSchedule(schedule)}
+                    data-testid="schedule-item-edit"
                   >
                     {getMessage('edit')}
                   </Button>
@@ -114,6 +120,7 @@ export function SchedulesTab({
                     variant="ghost"
                     size="sm"
                     onClick={() => onDeleteSchedule(schedule.id)}
+                    data-testid="schedule-item-delete"
                   >
                     <Trash2 className="w-4 h-4 text-danger-500" />
                   </Button>

--- a/src/components/options/WeeklyCalendar.tsx
+++ b/src/components/options/WeeklyCalendar.tsx
@@ -146,7 +146,10 @@ export function WeeklyCalendar({
       </h2>
 
       {/* Calendar Grid */}
-      <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <div
+        className="border border-gray-200 rounded-lg overflow-hidden"
+        data-testid="weekly-calendar"
+      >
         {/* Header Row - Days */}
         <div className="grid grid-cols-8 bg-gray-50 border-b border-gray-200">
           <div className="p-2 text-center text-xs font-medium text-gray-500 border-r border-gray-200">
@@ -157,6 +160,7 @@ export function WeeklyCalendar({
             return (
               <div
                 key={day}
+                data-testid="weekly-calendar-day-header"
                 className={`p-2 text-center text-xs font-medium border-r border-gray-200 last:border-r-0 ${
                   isToday
                     ? 'text-danger-600 bg-danger-50 font-semibold'

--- a/src/components/options/modals/ScheduleModal.tsx
+++ b/src/components/options/modals/ScheduleModal.tsx
@@ -54,6 +54,7 @@ export function ScheduleModal({
             {getMessage('scheduleName')}
           </label>
           <Input
+            data-testid="schedule-name-input"
             value={scheduleForm.name}
             onChange={(value) => onFormChange({ ...scheduleForm, name: value })}
             placeholder=""
@@ -66,6 +67,7 @@ export function ScheduleModal({
               {getMessage('startTime')}
             </label>
             <input
+              data-testid="schedule-start-time"
               type="time"
               value={scheduleForm.startTime}
               onChange={(e) =>
@@ -79,6 +81,7 @@ export function ScheduleModal({
               {getMessage('endTime')}
             </label>
             <input
+              data-testid="schedule-end-time"
               type="time"
               value={
                 scheduleForm.endTime === '24:00'
@@ -101,6 +104,8 @@ export function ScheduleModal({
             {DAY_KEYS.map((day, idx) => (
               <button
                 key={day}
+                data-testid="schedule-day-button"
+                aria-pressed={scheduleForm.days.includes(idx)}
                 onClick={() => toggleDay(idx)}
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                   scheduleForm.days.includes(idx)
@@ -120,6 +125,7 @@ export function ScheduleModal({
             {getMessage('schedulePreset')}
           </label>
           <select
+            data-testid="schedule-preset-select"
             value={scheduleForm.presetId}
             onChange={(e) =>
               onFormChange({ ...scheduleForm, presetId: e.target.value })
@@ -153,10 +159,18 @@ export function ScheduleModal({
         </div>
 
         <div className="flex justify-end gap-2 pt-4">
-          <Button variant="secondary" onClick={onClose}>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            data-testid="schedule-cancel-button"
+          >
             {getMessage('cancel')}
           </Button>
-          <Button onClick={onSave} disabled={!scheduleForm.name.trim()}>
+          <Button
+            onClick={onSave}
+            disabled={!scheduleForm.name.trim()}
+            data-testid="schedule-save-button"
+          >
             {editingSchedule
               ? getMessage('saveChanges')
               : getMessage('addSchedule')}

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -160,21 +160,23 @@ export const SELECTORS = {
 
   // Options - Schedules Tab
   schedules: {
-    weeklyCalendar: '.grid.grid-cols-7',
-    addScheduleButton:
-      'button:has-text("スケジュールを追加"), button:has-text("Add Schedule")',
-    scheduleItem: '.flex.items-center.justify-between.p-4',
-    scheduleToggle: '[role="switch"]',
-    editButton: 'button:has-text("編集"), button:has-text("Edit")',
-    deleteButton: 'button:has(svg.lucide-trash-2)',
+    weeklyCalendar: '[data-testid="weekly-calendar"]',
+    weeklyCalendarDayHeader: '[data-testid="weekly-calendar-day-header"]',
+    addScheduleButton: '[data-testid="schedule-add-button"]',
+    scheduleItem: '[data-testid="schedule-item"]',
+    scheduleItemPreset: '[data-testid="schedule-item-preset"]',
+    scheduleToggle: '[data-testid="schedule-item-toggle"]',
+    editButton: '[data-testid="schedule-item-edit"]',
+    deleteButton: '[data-testid="schedule-item-delete"]',
     scheduleModal: '[role="dialog"]',
-    scheduleNameInput:
-      'input[placeholder*="スケジュール名"], input[placeholder*="Schedule name"]',
-    startTimeInput: 'input[type="time"]:first-of-type',
-    endTimeInput: 'input[type="time"]:last-of-type',
-    dayCheckbox: 'input[type="checkbox"]',
-    presetSelect: 'select',
-    saveScheduleButton: 'button:has-text("保存"), button:has-text("Save")',
+    scheduleNameInput: '[data-testid="schedule-name-input"]',
+    startTimeInput: '[data-testid="schedule-start-time"]',
+    endTimeInput: '[data-testid="schedule-end-time"]',
+    // 曜日は checkbox ではなくトグルボタン
+    dayCheckbox: '[data-testid="schedule-day-button"]',
+    presetSelect: '[data-testid="schedule-preset-select"]',
+    saveScheduleButton: '[data-testid="schedule-save-button"]',
+    cancelScheduleButton: '[data-testid="schedule-cancel-button"]',
     noSchedules: 'text=/スケジュールがありません|No schedules/i'
   },
 

--- a/tests/e2e/helpers/storage.ts
+++ b/tests/e2e/helpers/storage.ts
@@ -202,6 +202,38 @@ export function makePreset(
 }
 
 /**
+ * AppSettings の完全な形を作る
+ *
+ * 必須フィールドを欠くとアプリ側の参照が壊れる。また analyticsOptIn を
+ * 落とすと Opt-In モーダルが開いてしまい、他の要素のクリックを遮る。
+ * テストで settings を直接書く場合は必ずこれを使う。
+ *
+ * @param overrides - 上書きする値
+ */
+export function makeSettings(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    blockList: [],
+    schedules: [],
+    language: 'en',
+    paused: false,
+    notifications: { timeLimitEnabled: true, timeLimitMinutes: 5 },
+    youtube: {
+      enabled: false,
+      blockAccess: false,
+      hideShorts: false,
+      hideRecommendations: false,
+      hideComments: false,
+      timeLimit: null
+    },
+    password: { enabled: false, passwordHash: null },
+    analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
+    ...overrides
+  };
+}
+
+/**
  * テスト用の初期設定をセットする
  *
  * @param page - Playwright Page オブジェクト
@@ -215,6 +247,7 @@ export async function setupTestStorage(
     withPassword?: boolean;
     withPremium?: boolean;
     withAnalyticsOptIn?: boolean;
+    withSchedule?: boolean;
     language?: 'en' | 'ja';
   } = {}
 ): Promise<void> {
@@ -224,6 +257,7 @@ export async function setupTestStorage(
     withPassword = false,
     withPremium = false,
     withAnalyticsOptIn = true,
+    withSchedule = false,
     language = 'en'
   } = options;
 
@@ -264,6 +298,22 @@ export async function setupTestStorage(
       enabled: true,
       passwordHash: TEST_DATA.password.validHash
     };
+  }
+
+  // 週間カレンダーはスケジュールが 1 件以上ないと描画されない
+  // （WeeklyCalendar は schedules.length === 0 で null を返す）
+  if (withSchedule) {
+    defaultSettings['schedules'] = [
+      {
+        id: 'schedule-1',
+        name: 'Work Hours',
+        startTime: '09:00',
+        endTime: '18:00',
+        days: [1, 2, 3, 4, 5],
+        enabled: true,
+        presetId: null
+      }
+    ];
   }
 
   // ブロックリストは settings.blockList に保持される（トップレベルの

--- a/tests/e2e/options-schedule.spec.ts
+++ b/tests/e2e/options-schedule.spec.ts
@@ -4,6 +4,9 @@ import {
   setupTestStorage,
   clearStorage,
   setStorageData,
+  makeDisplaySettings,
+  makePreset,
+  makeSettings,
   SELECTORS
 } from './helpers';
 
@@ -20,7 +23,9 @@ test.describe('Options - Schedule Tab', () => {
     await clearStorage(page);
     await setupTestStorage(page, {
       withGoal: true,
-      withAnalyticsOptIn: true
+      withAnalyticsOptIn: true,
+      // 週間カレンダーはスケジュールが無いと描画されないため 1 件用意する
+      withSchedule: true
     });
     await page.close();
   });
@@ -57,10 +62,11 @@ test.describe('Options - Schedule Tab', () => {
     const calendar = page.locator(SELECTORS.schedules.weeklyCalendar);
     await expect(calendar).toBeVisible();
 
-    // 7日分の列が表示される（日曜〜土曜）
-    const dayColumns = calendar.locator('> div');
-    const count = await dayColumns.count();
-    expect(count).toBe(7);
+    // 7日分の曜日ヘッダーが表示される（日曜〜土曜）。
+    // カレンダーは時刻列を含む 8 列構成なので、曜日ヘッダーを数える
+    await expect(
+      page.locator(SELECTORS.schedules.weeklyCalendarDayHeader)
+    ).toHaveCount(7);
 
     await page.close();
   });
@@ -91,8 +97,9 @@ test.describe('Options - Schedule Tab', () => {
     await endTime.fill('12:00');
 
     // 曜日を選択（月曜）
+    // 曜日は checkbox ではなくトグルボタンなので click で切り替える
     const dayCheckboxes = modal.locator(SELECTORS.schedules.dayCheckbox);
-    await dayCheckboxes.nth(1).check();
+    await dayCheckboxes.nth(1).click();
 
     // 保存ボタンをクリック
     await modal.locator(SELECTORS.schedules.saveScheduleButton).click();
@@ -131,9 +138,7 @@ test.describe('Options - Schedule Tab', () => {
     await expect(endTime).toHaveValue('18:00');
 
     // モーダルを閉じる
-    await modal
-      .locator('button:has-text("キャンセル"), button:has-text("Cancel")')
-      .click();
+    await page.locator(SELECTORS.schedules.cancelScheduleButton).click();
 
     await page.close();
   });
@@ -147,22 +152,25 @@ test.describe('Options - Schedule Tab', () => {
     const modal = page.locator(SELECTORS.schedules.scheduleModal);
 
     // 曜日チェックボックスが7つ表示される
+    // 曜日は checkbox ではなくトグルボタンなので click で切り替える
     const dayCheckboxes = modal.locator(SELECTORS.schedules.dayCheckbox);
     const count = await dayCheckboxes.count();
     expect(count).toBeGreaterThanOrEqual(7);
 
-    // 月曜と水曜を選択
-    await dayCheckboxes.nth(1).check();
-    await dayCheckboxes.nth(3).check();
-
-    // 選択された状態を確認
-    await expect(dayCheckboxes.nth(1)).toBeChecked();
-    await expect(dayCheckboxes.nth(3)).toBeChecked();
+    // 曜日ボタンは初期状態で一部が選択済みのため、クリックで状態が
+    // 反転することを検証する
+    for (const index of [1, 3]) {
+      const day = dayCheckboxes.nth(index);
+      const before = await day.getAttribute('aria-pressed');
+      await day.click();
+      await expect(day).toHaveAttribute(
+        'aria-pressed',
+        before === 'true' ? 'false' : 'true'
+      );
+    }
 
     // モーダルを閉じる
-    await modal
-      .locator('button:has-text("キャンセル"), button:has-text("Cancel")')
-      .click();
+    await page.locator(SELECTORS.schedules.cancelScheduleButton).click();
 
     await page.close();
   });
@@ -186,9 +194,7 @@ test.describe('Options - Schedule Tab', () => {
     await presetSelect.selectOption({ index: 0 });
 
     // モーダルを閉じる
-    await modal
-      .locator('button:has-text("キャンセル"), button:has-text("Cancel")')
-      .click();
+    await page.locator(SELECTORS.schedules.cancelScheduleButton).click();
 
     await page.close();
   });
@@ -199,21 +205,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // テスト用スケジュールを追加
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Test Schedule',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1, 3, 5],
-          presetId: 'default',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Test Schedule',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1, 3, 5],
+            presetId: 'default',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -245,7 +253,11 @@ test.describe('Options - Schedule Tab', () => {
     await expect(modal).not.toBeVisible();
 
     // 更新されたスケジュールが表示される
-    await expect(page.locator('text=/Updated Schedule/i')).toBeVisible();
+    await expect(
+      page
+        .locator(SELECTORS.schedules.scheduleItem)
+        .filter({ hasText: 'Updated Schedule' })
+    ).toBeVisible();
 
     await page.close();
   });
@@ -256,21 +268,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // テスト用スケジュールを追加
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Delete Me',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1],
-          presetId: 'default',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Delete Me',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1],
+            presetId: 'default',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -297,21 +311,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // テスト用スケジュールを追加
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Toggle Schedule',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1],
-          presetId: 'default',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Toggle Schedule',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1],
+            presetId: 'default',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -346,21 +362,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // このテストは実際の時刻判定が必要なため、スケジュール設定の保存を確認するのみ
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Auto Apply',
-          startTime: '09:00',
-          endTime: '17:00',
-          days: [1, 2, 3, 4, 5], // 平日
-          presetId: 'default',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Auto Apply',
+            startTime: '09:00',
+            endTime: '17:00',
+            days: [1, 2, 3, 4, 5], // 平日
+            presetId: 'default',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -372,7 +390,9 @@ test.describe('Options - Schedule Tab', () => {
     await expect(scheduleItem).toBeVisible();
 
     // プリセット情報が表示される
-    const presetLabel = scheduleItem.locator('text=/Preset|プリセット/i');
+    const presetLabel = scheduleItem.locator(
+      SELECTORS.schedules.scheduleItemPreset
+    );
     await expect(presetLabel).toBeVisible();
 
     await page.close();
@@ -384,21 +404,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // 無効なスケジュールを追加
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Disabled Schedule',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1],
-          presetId: 'default',
-          enabled: false
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Disabled Schedule',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1],
+            presetId: 'default',
+            enabled: false
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -426,13 +448,10 @@ test.describe('Options - Schedule Tab', () => {
     // Freeユーザーで複数プリセットを作成
     const setupPage = await openOptions(context, extensionId);
     await setStorageData(setupPage, 'vision', {
-      defaultSettings: {
-        goalText: 'Focus',
-        subText: 'Stay productive'
-      },
+      defaultSettings: makeDisplaySettings({ goalText: 'Focus' }),
       presets: [
-        { id: 'default', name: 'Default', goalText: 'Default' },
-        { id: 'locked', name: 'Locked Preset', goalText: 'Locked' }
+        makePreset('default', 'Default', { goalText: 'Default Goal' }),
+        makePreset('to-delete', 'To Delete', { goalText: 'To Delete Goal' })
       ],
       activePresetId: 'default'
     });
@@ -455,9 +474,7 @@ test.describe('Options - Schedule Tab', () => {
     expect(options.length).toBeGreaterThan(0);
 
     // モーダルを閉じる
-    await modal
-      .locator('button:has-text("キャンセル"), button:has-text("Cancel")')
-      .click();
+    await page.locator(SELECTORS.schedules.cancelScheduleButton).click();
 
     await page.close();
   });
@@ -468,21 +485,23 @@ test.describe('Options - Schedule Tab', () => {
   }) => {
     // 既存のスケジュールを追加
     const setupPage = await openOptions(context, extensionId);
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Existing Schedule',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1], // 月曜
-          presetId: 'default',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Existing Schedule',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1], // 月曜
+            presetId: 'default',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     const page = await openOptions(context, extensionId, 'schedules');
@@ -503,8 +522,9 @@ test.describe('Options - Schedule Tab', () => {
     await endTime.fill('12:00');
 
     // 同じ曜日（月曜）を選択
+    // 曜日は checkbox ではなくトグルボタンなので click で切り替える
     const dayCheckboxes = modal.locator(SELECTORS.schedules.dayCheckbox);
-    await dayCheckboxes.nth(1).check();
+    await dayCheckboxes.nth(1).click();
 
     // 保存ボタンをクリック
     const saveButton = modal.locator(SELECTORS.schedules.saveScheduleButton);
@@ -523,52 +543,43 @@ test.describe('Options - Schedule Tab', () => {
     await page.close();
   });
 
-  test('OPT-S14: プリセット削除時、該当スケジュールが無効化される', async ({
+  // 実装が未対応のため保留（#333）。
+  // handleDeletePreset は vision のみ更新し、settings.schedules を触らないため、
+  // スタイルを削除してもスケジュールは有効なまま「不明なスタイル」を指し続ける。
+  // 実行時は defaultSettings にフォールバックするためクラッシュはしないが、
+  // ユーザーからは「設定したのに切り替わらない」状態になる。
+  // 仕様を確定させてから有効化する。
+  test.fixme('OPT-S14: プリセット削除時、該当スケジュールが無効化される', async ({
     context,
     extensionId
   }) => {
     // プリセットとスケジュールを設定
     const setupPage = await openOptions(context, extensionId);
     await setStorageData(setupPage, 'vision', {
-      defaultSettings: {
-        goalText: 'Focus',
-        subText: 'Stay productive'
-      },
+      defaultSettings: makeDisplaySettings({ goalText: 'Focus' }),
       presets: [
-        {
-          id: 'default',
-          name: 'Default',
-          goalText: 'Default Goal',
-          textColor: '#ffffff',
-          backgroundColor: '#1a1a2e',
-          backgroundType: 'color'
-        },
-        {
-          id: 'to-delete',
-          name: 'To Delete',
-          goalText: 'Delete This',
-          textColor: '#000000',
-          backgroundColor: '#ffffff',
-          backgroundType: 'color'
-        }
+        makePreset('default', 'Default', { goalText: 'Default Goal' }),
+        makePreset('to-delete', 'To Delete', { goalText: 'To Delete Goal' })
       ],
       activePresetId: 'default'
     });
-    await setStorageData(setupPage, 'settings', {
-      language: 'en',
-      paused: false,
-      schedules: [
-        {
-          id: 'schedule1',
-          name: 'Linked Schedule',
-          startTime: '09:00',
-          endTime: '12:00',
-          days: [1],
-          presetId: 'to-delete',
-          enabled: true
-        }
-      ]
-    });
+    await setStorageData(
+      setupPage,
+      'settings',
+      makeSettings({
+        schedules: [
+          {
+            id: 'schedule1',
+            name: 'Linked Schedule',
+            startTime: '09:00',
+            endTime: '12:00',
+            days: [1],
+            presetId: 'to-delete',
+            enabled: true
+          }
+        ]
+      })
+    );
     await setupPage.close();
 
     // スタイルタブでプリセットを削除


### PR DESCRIPTION
## 概要

#327 の**第6弾**。`options-schedule.spec.ts` を **13 pass / 1 skip** にした（実行時間 1.7分 → **9.9秒**）。

ベースラインは pass 3 / fail 11。

## 30秒タイムアウトの主因は Analytics Opt-In モーダルだった

複数のテストが 30 秒タイムアウトしていた原因は、**モーダルがクリックを遮っていた**こと。

```
<div class="absolute inset-0 bg-black/50 backdrop-blur-sm"></div>
from <div data-testid="analytics-optin-modal"> subtree intercepts pointer events
```

テストが `setStorageData(page, 'settings', { language, paused, schedules })` と**部分的な settings を書いて `analyticsOptIn` を落としていた**ため、Opt-In モーダルが開いていた。

### `makeSettings` ファクトリを追加

```ts
makeSettings({ schedules: [...] })  // AppSettings の完全な形 + 上書き
```

必須フィールドと `analyticsOptIn` を保ちつつ、必要な部分だけ上書きできる。7 箇所に適用した。同じ問題は他の spec にもあるため、共通化しておく価値が高い。

## `data-testid` の付与

| コンポーネント | testid |
| --- | --- |
| `SchedulesTab` | `schedule-add-button` / `schedule-item` / `schedule-item-toggle` / `schedule-item-edit` / `schedule-item-delete` / `schedule-item-preset` |
| `ScheduleModal` | `schedule-name-input` / `schedule-start-time` / `schedule-end-time` / `schedule-day-button` / `schedule-preset-select` / `schedule-save-button` / `schedule-cancel-button` |
| `WeeklyCalendar` | `weekly-calendar` / `weekly-calendar-day-header` |

### 曜日ボタンに `aria-pressed` を追加

曜日選択は `<input type="checkbox">` ではなく**トグルボタン**。テストは `.check()` と `toBeChecked()` を使っていたが、Playwright は「Not a checkbox or radio button」で失敗する。

`aria-pressed` を実装に追加し、選択状態を属性で判定できるようにした。スクリーンリーダーがトグルの状態を認識できるようになるアクセシビリティ改善でもある。

## テストが実装と合っていなかった箇所

| テスト | 問題 |
| --- | --- |
| OPT-S01/S02 | 週間カレンダーは**スケジュールが 1 件以上ないと描画されない**（`schedules.length === 0` で `null`）。`setupTestStorage` に `withSchedule` を追加して対応 |
| OPT-S02 | カレンダーは**時刻列を含む 8 列構成**だが 7 列を期待していた。曜日ヘッダーを数える形に修正 |
| OPT-S05 | 曜日ボタンは初期状態で一部が選択済み。クリックで「必ず true になる」前提が誤り。**状態が反転すること**を検証する形にした |
| OPT-S07 | `text=/Updated Schedule/i` が 5 要素に一致し strict mode 違反。`scheduleItem` で絞り込む形に修正 |
| OPT-S10 | スケジュール項目のスタイル表示が「プリセット」→「スタイル」に改称されており文言が一致しなかった |

## ⚠️ 実装バグを検出: OPT-S14 は `test.fixme`（#333）

**スタイル削除時に、それを参照しているスケジュールが更新されない。**

`src/hooks/usePresets.ts` の `handleDeletePreset` は `vision`（`presets` / `activePresetId`）のみ更新し、`settings.schedules` に触れない。結果:

- スケジュールは**有効なまま**、存在しないスタイルを指し続ける
- 一覧に「スタイル: 不明なスタイル」と表示される
- 時間帯になっても何も切り替わらない（実行時は `defaultSettings` にフォールバックするためクラッシュはしない）

`docs/TEST_CASES.md` の OPT-S14 は「該当スケジュールが無効化される」と定義しており、**仕様として意図されていたが実装されていない**。

方針判断（無効化する / `presetId` を null にする / 削除時に警告する）が必要なため #333 を起票し、テストは理由をコメントに明記して保留した。

## 検証

| | 変更前 | 変更後 |
| --- | --- | --- |
| pass | 3 | **13** |
| fail | 11 | **0** |
| skip | 0 | 1（#333） |
| 実行時間 | 1.7分 | **9.9秒** |

- ユニットテスト 808 件 全 pass（実装変更は testid と `aria-pressed` の付与のみ）
- `pnpm type-check` / `pnpm lint`（エラー 0）/ `pnpm format:check` / `pnpm build` 通過

## 残り

options の analytics 9 / help 7 / premium 3 と、block / youtube / time-limit / premium / analytics / interaction。

Refs #327