### PR TITLE
chore: セキュリティ CI の導入（サプライチェーン・シークレット・拡張権限）

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,12 +12,20 @@ on:
     # 毎週月曜 03:00 UTC（JST 正午）に実行し、新規 CVE を commit と無関係に検知する
     - cron: '0 3 * * 1'
 
+# デフォルトを最小権限にし、昇格が必要なジョブ（codeql）にのみ個別に権限を付与する
+permissions:
+  contents: read
+
 jobs:
   # ブロッキング: npm audit（high 以上のみ拾う。moderate まで含めると transitive 依存の
   # ノイズで形骸化するため、まずは high から開始する）
   audit-high:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    # 【暫定措置】develop に既存の脆弱性（1 critical / 40 high）があるため一時的に非ブロッキング化している。
+    # 脆弱性解消後にこの continue-on-error を削除し、ブロッキングへ戻すこと。
+    # 追従 Issue: #350
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,7 +45,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: npm audit (high 以上で fail)
+        # 【暫定措置】job 単位の continue-on-error だけではジョブ自身の conclusion が
+        # failure のままになり、必須ステータスチェックとして残っているとブロックされ得るため、
+        # step 単位でも continue-on-error を付与し、ジョブの conclusion を success 扱いにする。
         run: pnpm audit --audit-level high
+        continue-on-error: true
 
   # ブロッキング: gitleaks によるシークレット混入検出
   secret-scan:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,136 @@
+name: Security
+
+# セキュリティ専用の CI ワークフロー。既存の ci.yml とは分離する。
+# ブロッキングジョブ（audit / secret scan / manifest 権限差分）は PR を止める。
+# 非ブロッキングジョブ（CodeQL / 週次 audit）は informational のみで PR をブロックしない。
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # 毎週月曜 03:00 UTC（JST 正午）に実行し、新規 CVE を commit と無関係に検知する
+    - cron: '0 3 * * 1'
+
+jobs:
+  # ブロッキング: npm audit（high 以上のみ拾う。moderate まで含めると transitive 依存の
+  # ノイズで形骸化するため、まずは high から開始する）
+  audit-high:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: npm audit (high 以上で fail)
+        run: pnpm audit --audit-level high
+
+  # ブロッキング: gitleaks によるシークレット混入検出
+  secret-scan:
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ブロッキング: manifest 権限の差分検知
+  # package.json の manifest.permissions / manifest.host_permissions が
+  # base ブランチと比較して増えている場合に fail させ、人間のレビューを強制する
+  manifest-permission-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: base ブランチの package.json を取得
+        run: git show origin/${{ github.base_ref }}:package.json > /tmp/base-package.json
+
+      - name: manifest 権限の差分を検査
+        run: pnpm exec tsx scripts/check-manifest-permissions.ts /tmp/base-package.json package.json
+
+  # 非ブロッキング: CodeQL（javascript-typescript）。結果は informational のみ
+  codeql:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        continue-on-error: true
+
+  # 非ブロッキング: npm audit の週次実行。新規 CVE を informational に検知する
+  audit-weekly:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: npm audit (週次・informational)
+        run: pnpm audit --audit-level high
+        continue-on-error: true

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+import security from 'eslint-plugin-security';
 import prettier from 'eslint-config-prettier';
 
 export default tseslint.config(
@@ -12,7 +13,8 @@ export default tseslint.config(
     files: ['**/*.{ts,tsx}'],
     plugins: {
       react,
-      'react-hooks': reactHooks
+      'react-hooks': reactHooks,
+      security
     },
     languageOptions: {
       parserOptions: {
@@ -32,6 +34,8 @@ export default tseslint.config(
       'react/prop-types': 'off',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
+      // dangerouslySetInnerHTML の使用を禁止する（XSS 対策）
+      'react/no-danger': 'error',
 
       // TypeScript
       '@typescript-eslint/no-unused-vars': [
@@ -45,7 +49,26 @@ export default tseslint.config(
       // General
       'no-console': ['warn', { allow: ['warn', 'error'] }],
       'prefer-const': 'error',
-      'no-var': 'error'
+      'no-var': 'error',
+
+      // セキュリティ（eslint-plugin-security の推奨ルールのうち誤検知が多いものはオフにし、
+      // XSS / コードインジェクションに直結するルールのみを有効化する）
+      'security/detect-eval-with-expression': 'error',
+      'security/detect-object-injection': 'off',
+      'security/detect-non-literal-fs-filename': 'off',
+      'security/detect-non-literal-regexp': 'off',
+      'security/detect-unsafe-regex': 'warn',
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      // 生の innerHTML への代入を禁止する（XSS 対策。DOM 操作は React の標準レンダリングを使う）
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "AssignmentExpression[left.property.name='innerHTML']",
+          message:
+            '生の innerHTML への代入は禁止されています。XSS のリスクがあるため、React の標準的なレンダリングを使用してください。'
+        }
+      ]
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,13 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-security": "^4.0.1",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "storybook": "^8.5.0",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.23.12",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.53.1",
     "vitest": "^2.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.2(jiti@1.21.7))
+      eslint-plugin-security:
+        specifier: ^4.0.1
+        version: 4.0.1
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -119,7 +122,10 @@ importers:
         version: 8.6.15(prettier@3.8.0)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19(yaml@2.8.2)
+        version: 3.4.19(tsx@4.23.12)(yaml@2.8.2)
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -285,6 +291,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -299,6 +311,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -321,6 +339,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -335,6 +359,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -357,6 +387,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -371,6 +407,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -393,6 +435,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -407,6 +455,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -429,6 +483,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -443,6 +503,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -465,6 +531,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -479,6 +551,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -501,6 +579,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -515,6 +599,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -537,6 +627,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -551,6 +647,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -573,8 +675,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -597,8 +711,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -621,8 +747,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -645,6 +783,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
@@ -659,6 +803,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -681,6 +831,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -695,6 +851,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3366,6 +3528,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3391,6 +3558,10 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-security@4.0.1:
+    resolution: {integrity: sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -4829,6 +5000,10 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
+  regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4909,6 +5084,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safe-regex@2.1.1:
+    resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -5252,6 +5430,11 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tween-functions@1.2.0:
     resolution: {integrity: sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==}
@@ -5743,6 +5926,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -5750,6 +5936,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -5761,6 +5950,9 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -5768,6 +5960,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -5779,6 +5974,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -5786,6 +5984,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -5797,6 +5998,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -5804,6 +6008,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -5815,6 +6022,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -5822,6 +6032,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -5833,6 +6046,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -5840,6 +6056,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -5851,6 +6070,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -5858,6 +6080,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -5869,6 +6094,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -5876,6 +6104,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -5887,7 +6118,13 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.18.20':
@@ -5899,7 +6136,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -5911,7 +6154,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
     optional: true
 
   '@esbuild/sunos-x64@0.18.20':
@@ -5923,6 +6172,9 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
   '@esbuild/win32-arm64@0.18.20':
     optional: true
 
@@ -5930,6 +6182,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
     optional: true
 
   '@esbuild/win32-ia32@0.18.20':
@@ -5941,6 +6196,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
@@ -5948,6 +6206,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@1.21.7))':
@@ -9098,6 +9359,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -9138,6 +9428,10 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-security@4.0.1:
+    dependencies:
+      safe-regex: 2.1.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -10437,12 +10731,13 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.23.12)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.6
+      tsx: 4.23.12
       yaml: 2.8.2
 
   postcss-nested@6.2.0(postcss@8.5.6):
@@ -10633,6 +10928,8 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
+  regexp-tree@0.1.27: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -10743,6 +11040,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safe-regex@2.1.1:
+    dependencies:
+      regexp-tree: 0.1.27
 
   safer-buffer@2.1.2: {}
 
@@ -11026,7 +11327,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailwindcss@3.4.19(yaml@2.8.2):
+  tailwindcss@3.4.19(tsx@4.23.12)(yaml@2.8.2):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -11045,7 +11346,7 @@ snapshots:
       postcss: 8.5.6
       postcss-import: 15.1.0(postcss@8.5.6)
       postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.23.12)(yaml@2.8.2)
       postcss-nested: 6.2.0(postcss@8.5.6)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -11163,6 +11464,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tween-functions@1.2.0: {}
 

--- a/scripts/__tests__/check-manifest-permissions.test.ts
+++ b/scripts/__tests__/check-manifest-permissions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  diffPermissions,
+  extractPermissions,
+  formatDiffReport,
+  hasAddedPermissions
+} from '../check-manifest-permissions';
+
+describe('extractPermissions', () => {
+  it('package.json から manifest の権限を抽出できる', () => {
+    const pkg = {
+      manifest: {
+        permissions: ['storage', 'tabs'],
+        host_permissions: ['<all_urls>']
+      }
+    };
+
+    expect(extractPermissions(pkg)).toEqual({
+      permissions: ['storage', 'tabs'],
+      hostPermissions: ['<all_urls>']
+    });
+  });
+
+  it('manifest が存在しない場合は空配列を返す', () => {
+    expect(extractPermissions({})).toEqual({
+      permissions: [],
+      hostPermissions: []
+    });
+  });
+});
+
+describe('diffPermissions', () => {
+  it('permissions が増えたケースを検出する', () => {
+    const base = { permissions: ['storage'], hostPermissions: [] };
+    const head = { permissions: ['storage', 'tabs'], hostPermissions: [] };
+
+    const diff = diffPermissions(base, head);
+
+    expect(diff.addedPermissions).toEqual(['tabs']);
+    expect(diff.removedPermissions).toEqual([]);
+    expect(hasAddedPermissions(diff)).toBe(true);
+  });
+
+  it('permissions が減ったケースは増加なしと判定する', () => {
+    const base = { permissions: ['storage', 'tabs'], hostPermissions: [] };
+    const head = { permissions: ['storage'], hostPermissions: [] };
+
+    const diff = diffPermissions(base, head);
+
+    expect(diff.addedPermissions).toEqual([]);
+    expect(diff.removedPermissions).toEqual(['tabs']);
+    expect(hasAddedPermissions(diff)).toBe(false);
+  });
+
+  it('変化なしのケースは増加なしと判定する', () => {
+    const base = {
+      permissions: ['storage', 'tabs'],
+      hostPermissions: ['<all_urls>']
+    };
+    const head = {
+      permissions: ['tabs', 'storage'],
+      hostPermissions: ['<all_urls>']
+    };
+
+    const diff = diffPermissions(base, head);
+
+    expect(hasAddedPermissions(diff)).toBe(false);
+    expect(diff.addedPermissions).toEqual([]);
+    expect(diff.addedHostPermissions).toEqual([]);
+  });
+
+  it('host_permissions のみが増えたケースを検出する', () => {
+    const base = {
+      permissions: ['storage'],
+      hostPermissions: ['https://example.com/*']
+    };
+    const head = {
+      permissions: ['storage'],
+      hostPermissions: ['https://example.com/*', '<all_urls>']
+    };
+
+    const diff = diffPermissions(base, head);
+
+    expect(diff.addedPermissions).toEqual([]);
+    expect(diff.addedHostPermissions).toEqual(['<all_urls>']);
+    expect(hasAddedPermissions(diff)).toBe(true);
+  });
+});
+
+describe('formatDiffReport', () => {
+  it('増加した権限を明示するメッセージを組み立てる', () => {
+    const diff = diffPermissions(
+      { permissions: [], hostPermissions: [] },
+      { permissions: ['tabs'], hostPermissions: ['<all_urls>'] }
+    );
+
+    const report = formatDiffReport(diff);
+
+    expect(report).toContain('tabs');
+    expect(report).toContain('<all_urls>');
+  });
+});

--- a/scripts/check-manifest-permissions.ts
+++ b/scripts/check-manifest-permissions.ts
@@ -1,0 +1,161 @@
+/**
+ * manifest 権限の差分検知スクリプト。
+ *
+ * package.json の manifest.permissions / manifest.host_permissions を
+ * base ブランチ（比較元）と比較し、エントリが増えている場合に fail する。
+ * Chrome 拡張は権限が広がるほど攻撃面（1 つの XSS/サプライチェーン汚染からの
+ * 被害範囲）が広がるため、権限の追加は必ず人間のレビューを通す。
+ *
+ * 使い方:
+ *   tsx scripts/check-manifest-permissions.ts <base-package-json-path> <head-package-json-path>
+ *
+ * CI からは base ブランチの package.json を一時ファイルに書き出して渡す
+ * （.github/workflows/security.yml 参照）。
+ */
+import { readFileSync } from 'node:fs';
+
+/** package.json の manifest.permissions / manifest.host_permissions を表す型 */
+export interface ManifestPermissions {
+  permissions: string[];
+  hostPermissions: string[];
+}
+
+/** 差分検知の結果 */
+export interface PermissionDiff {
+  addedPermissions: string[];
+  removedPermissions: string[];
+  addedHostPermissions: string[];
+  removedHostPermissions: string[];
+}
+
+/**
+ * package.json の JSON オブジェクトから manifest 権限を抽出する。
+ * manifest / permissions / host_permissions が存在しない場合は空配列扱いにする。
+ */
+export function extractPermissions(pkg: unknown): ManifestPermissions {
+  const manifest =
+    typeof pkg === 'object' && pkg !== null && 'manifest' in pkg
+      ? (pkg as { manifest?: unknown }).manifest
+      : undefined;
+
+  const permissions =
+    typeof manifest === 'object' &&
+    manifest !== null &&
+    'permissions' in manifest
+      ? (manifest as { permissions?: unknown }).permissions
+      : undefined;
+
+  const hostPermissions =
+    typeof manifest === 'object' &&
+    manifest !== null &&
+    'host_permissions' in manifest
+      ? (manifest as { host_permissions?: unknown }).host_permissions
+      : undefined;
+
+  return {
+    permissions: Array.isArray(permissions)
+      ? permissions.filter((p) => typeof p === 'string')
+      : [],
+    hostPermissions: Array.isArray(hostPermissions)
+      ? hostPermissions.filter((p) => typeof p === 'string')
+      : []
+  };
+}
+
+/**
+ * base（比較元）と head（比較先）の権限セットを比較し、増減した権限を返す。
+ * 集合比較のため、並び順の変化は差分として扱わない。
+ */
+export function diffPermissions(
+  base: ManifestPermissions,
+  head: ManifestPermissions
+): PermissionDiff {
+  const baseSet = new Set(base.permissions);
+  const headSet = new Set(head.permissions);
+  const baseHostSet = new Set(base.hostPermissions);
+  const headHostSet = new Set(head.hostPermissions);
+
+  return {
+    addedPermissions: [...headSet].filter((p) => !baseSet.has(p)),
+    removedPermissions: [...baseSet].filter((p) => !headSet.has(p)),
+    addedHostPermissions: [...headHostSet].filter((p) => !baseHostSet.has(p)),
+    removedHostPermissions: [...baseHostSet].filter((p) => !headHostSet.has(p))
+  };
+}
+
+/** 増えた権限が 1 つでもあるかどうか */
+export function hasAddedPermissions(diff: PermissionDiff): boolean {
+  return (
+    diff.addedPermissions.length > 0 || diff.addedHostPermissions.length > 0
+  );
+}
+
+/** fail 時に「どの権限が増えたか」を明示するメッセージを組み立てる */
+export function formatDiffReport(diff: PermissionDiff): string {
+  const lines: string[] = [];
+
+  if (diff.addedPermissions.length > 0) {
+    lines.push(`  permissions が増加: ${diff.addedPermissions.join(', ')}`);
+  }
+  if (diff.addedHostPermissions.length > 0) {
+    lines.push(
+      `  host_permissions が増加: ${diff.addedHostPermissions.join(', ')}`
+    );
+  }
+  if (diff.removedPermissions.length > 0) {
+    lines.push(
+      `  (参考) permissions が減少: ${diff.removedPermissions.join(', ')}`
+    );
+  }
+  if (diff.removedHostPermissions.length > 0) {
+    lines.push(
+      `  (参考) host_permissions が減少: ${diff.removedHostPermissions.join(', ')}`
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function readPackageJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+function main(): void {
+  const [baseArg, headArg] = process.argv.slice(2);
+
+  if (!baseArg || !headArg) {
+    // CLI ツールとしての使用方法エラーを表示する目的の標準出力
+    console.error(
+      'Usage: tsx scripts/check-manifest-permissions.ts <base-package-json-path> <head-package-json-path>'
+    );
+    process.exit(2);
+  }
+
+  const base = extractPermissions(readPackageJson(baseArg));
+  const head = extractPermissions(readPackageJson(headArg));
+  const diff = diffPermissions(base, head);
+
+  if (hasAddedPermissions(diff)) {
+    // CI 上でどの権限が増えたかを明示するための標準出力
+    console.error('❌ manifest の権限が増加しています。レビューが必要です:');
+    console.error(formatDiffReport(diff));
+    process.exit(1);
+  }
+
+  // CI 上で正常終了を明示するための標準出力
+  console.log('✅ manifest の権限に増加はありません。');
+  if (
+    diff.removedPermissions.length > 0 ||
+    diff.removedHostPermissions.length > 0
+  ) {
+    console.log(formatDiffReport(diff));
+  }
+}
+
+// vitest から import された際は実行しない（テストは純粋関数のみを対象にする）
+if (
+  process.argv[1] &&
+  process.argv[1].endsWith('check-manifest-permissions.ts')
+) {
+  main();
+}


### PR DESCRIPTION
## 概要

Closes #347

セキュリティ専用の CI ワークフロー `.github/workflows/security.yml` を新規追加した（既存 `ci.yml` には混ぜていない）。

## 実装内容

### ブロッキング（PR を止める）
1. `npm audit --audit-level=high`（実際には pnpm を使用しているプロジェクトのため `pnpm audit --audit-level high` を使用。moderate は拾わない）
2. gitleaks によるシークレット検出（`gitleaks/gitleaks-action@v2`、公式アクション）
3. manifest 権限の差分検知（`scripts/check-manifest-permissions.ts`）
   - `package.json` の `manifest.permissions` / `manifest.host_permissions` を base ブランチと比較し、エントリが増えた場合に fail
   - fail 時は「どの権限が増えたか」を標準出力に明示（`formatDiffReport`）
   - 減った場合・変化なしの場合は pass

### 非ブロッキング（informational）
4. CodeQL（javascript-typescript）を PR + 週次で実行（`continue-on-error: true` で informational 化）
5. `npm audit` の週次 schedule 実行（`continue-on-error: true`）

### 実現方法（ブロッキング/非ブロッキングの切り分け）
- ブロッキングジョブ（`secret-scan` / `manifest-permission-diff`）は通常どおり fail させて PR をブロックする
- `audit-high` は本来ブロッキング設計だが、下記の理由により暫定的に `continue-on-error: true` を付与している（詳細は後述）
- 非ブロッキングジョブ（`codeql` / `audit-weekly`）はジョブ・ステップに `continue-on-error: true` を付与し、fail してもワークフロー全体は成功扱いになるようにした
- トリガーは `pull_request` / `push`（develop）/ `schedule`（週次 月曜 03:00 UTC）
- ワークフロー全体のデフォルト権限を `permissions: contents: read` に絞り、昇格が必要な `codeql` ジョブにのみ個別に `security-events: write` 等を付与（Architect レビュー nit 対応）

### ESLint への追加
- `eslint-plugin-security` を devDependencies に追加
- `eslint.config.mjs` に組み込み、`security/detect-eval-with-expression` を error に設定
- `dangerouslySetInnerHTML`（`react/no-danger`）/ 生 `innerHTML` への代入（`no-restricted-syntax`）/ `eval`（`no-eval` / `no-implied-eval`）を error として禁止

### テスト
- `scripts/__tests__/check-manifest-permissions.test.ts` に vitest でユニットテストを追加
  - permissions が増えた / 減った / 変化なし / host_permissions のみ増えた の 4 ケースを含む計 7 テスト

## 変更ファイル

- 新規: `.github/workflows/security.yml`
- 新規: `scripts/check-manifest-permissions.ts`
- 新規: `scripts/__tests__/check-manifest-permissions.test.ts`
- 変更: `eslint.config.mjs`（`eslint-plugin-security` 追加、ルール追加）
- 変更: `package.json` / `pnpm-lock.yaml`（`tsx` / `eslint-plugin-security` を devDependencies に追加）

## ローカル確認結果

- `pnpm lint`: 0 errors / 43 warnings（既存の warning のみ。詳細は下記）
- `pnpm type-check`: pass
- `pnpm format:check`: pass
- `pnpm test --run`: 788 tests pass（新規 7 テスト含む）
- `check-manifest-permissions.ts` を手動で実行し、権限追加時に exit 1・「どの権限が増えたか」の出力・権限未追加時に exit 0 を確認済み

## eslint-plugin-security 導入で検出された既存コードの問題

- `src/lib/domain.ts:67` の正規表現に対して `security/detect-unsafe-regex` の warning が 1 件検出された（error ではないため lint は通過）。ReDoS の可能性がある正規表現だが、ラベル長を事前に 63 文字以下に制限してから適用しているため実害は限定的と判断し、今回は警告のまま残した。本質的な修正（正規表現の書き換え）が必要な場合は別 Issue 化を検討してほしい。
- `dangerouslySetInnerHTML` / 生 `innerHTML` / `eval` の使用は `src/` 配下に存在しなかったため、`// eslint-disable-next-line` での回避は発生していない。

## ⚠️ 既存の依存関係に high/critical 脆弱性あり（追従 Issue #350 で対応予定）

`pnpm audit --audit-level high` をこのブランチ（= develop 相当）で実行したところ、**1 critical / 40 high** の脆弱性が既存の依存関係ツリー（主に `storybook` / `postcss` 系の transitive 依存）から検出された。これは本 PR の変更が原因ではなく、マージ前から存在する状態。

Architect レビューを受け、以下の対応を実施した:

- **`audit-high` ジョブは暫定的に非ブロッキング化した**（`continue-on-error: true` を付与。ワークフロー内に暫定措置である旨と追従 Issue 番号をコメントで明記済み）
- 追従 Issue **#350** で既存の脆弱性解消を行い、解消後に `audit-high` の `continue-on-error: true` を削除してブロッキングへ戻す（#350 の DoD に明記済み）

これにより、Issue 本文が懸念していた「新規 CVE で無関係な PR が全停止し CI が無視される文化になる」状態を回避しつつ、脆弱性解消のトラッキングを継続する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
