### PR TITLE
test: E2E をローカルサーバ化し、外部サイトへの実アクセスを不要にする

### DIFF
--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -260,6 +260,14 @@ Chrome拡張機能のE2Eテストには以下の特殊な設定が必要：
 | PR-006 | Analytics 全期間表示が使える             | P2     | E2E        |
 | PR-007 | Unblock History CSV エクスポートが使える | P2     | E2E        |
 
+### E2E の外部サイトについて
+
+ブロック機能のテストは実際のサイトへ遷移して確認する必要があるが、外部への実アクセスは行わない。Chromium の `--host-resolver-rules` で全ホストをローカルの HTTPS サーバ（`tests/e2e/fixtures/testServer.ts`）へ向け、`example.com` や `youtube.com` をローカルで再現する。
+
+- 拡張機能側は `declarativeNetRequest` の `||domain` でスキーム非依存に判定するため、実サイトと同じ経路を通る
+- HTTPS で待ち受けるのは、`youtube.com` が HSTS プリロード済みで http:// が内部昇格されるため。証明書は実行時に自己署名で生成する（リポジトリには含めない）
+- fixture の settings は必ず `makeSettings()` / `makeYouTubeSettings()` / `makeTimeLimitUsage()` 経由で作る。フィールドが欠けると実装側のスキーマ検証に落ちて既定値へフォールバックし、「設定したのに効かない」という分かりにくい失敗になる
+
 ### 開発支援（投げ銭）
 
 | ID      | シナリオ                                                 | 優先度 | ステータス |

--- a/src/lib/__tests__/blockService.test.ts
+++ b/src/lib/__tests__/blockService.test.ts
@@ -61,6 +61,12 @@ function createSettings(overrides: Partial<AppSettings> = {}): AppSettings {
 }
 
 describe('isAnyScheduleActive', () => {
+  it('schedules が未設定でも例外を投げず true を返す', () => {
+    // 設定が欠けているとブロックルールの再計算が丸ごと止まるため、
+    // ここで落ちないことを保証する
+    expect(isAnyScheduleActive(undefined)).toBe(true);
+  });
+
   it('スケジュールが空の場合はtrueを返す', () => {
     expect(isAnyScheduleActive([])).toBe(true);
   });

--- a/src/lib/blockService.ts
+++ b/src/lib/blockService.ts
@@ -58,8 +58,13 @@ export async function findEnabledBlockItemForDomain(
  * Check if any schedule is currently active
  * No schedules = always active (return true)
  */
-export function isAnyScheduleActive(schedules: Schedule[]): boolean {
-  if (schedules.length === 0) return true;
+export function isAnyScheduleActive(
+  schedules: Schedule[] | undefined
+): boolean {
+  // 旧バージョンの設定や部分的なインポートで schedules が欠けている場合がある。
+  // ここで例外を投げるとブロックルールの再計算が丸ごと止まり、
+  // ブロックが一切効かなくなるため、未設定は「常時有効」として扱う
+  if (!schedules || schedules.length === 0) return true;
   return schedules.some(
     (schedule) =>
       schedule.enabled &&

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -1,11 +1,17 @@
 import { test, expect } from './fixtures/extension';
-import { openOptions, openExternalSite } from './helpers/pages';
+import {
+  openOptions,
+  openExternalSite,
+  holdUnblockConfirm
+} from './helpers/pages';
 import {
   clearStorageFromExtension,
   setStorageDataFromExtension,
-  getStorageDataFromExtension
+  setSettingsFromExtension,
+  getStorageDataFromExtension,
+  getStorageData
 } from './helpers/storage';
-import { TEST_DOMAINS } from './helpers/constants';
+import { TEST_DOMAINS, SELECTORS } from './helpers/constants';
 
 /**
  * E2E Tests: アナリティクス機能
@@ -22,7 +28,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
@@ -62,9 +68,10 @@ test.describe('Analytics - アナリティクス機能', () => {
       'analytics'
     )) as any;
 
-    expect(analytics.siteStats[TEST_DOMAINS.example]).toBeDefined();
+    // サイト別の回数は siteBlockCounts[domain].count に入る
+    expect(analytics.siteBlockCounts[TEST_DOMAINS.example]).toBeDefined();
     expect(
-      analytics.siteStats[TEST_DOMAINS.example].blockCount
+      analytics.siteBlockCounts[TEST_DOMAINS.example].count
     ).toBeGreaterThanOrEqual(3);
   });
 
@@ -72,7 +79,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
@@ -87,31 +94,35 @@ test.describe('Analytics - アナリティクス機能', () => {
       ]
     });
 
+    // 解除履歴はドメインをキーにした sites に入る
     await setStorageDataFromExtension(context, extensionId, 'unblockHistory', {
-      entries: []
+      sites: {}
     });
 
-    // Options ページでブロックを一時解除
     const optionsPage = await openOptions(context, extensionId, 'blocklist');
-    await optionsPage.waitForLoadState('domcontentloaded');
 
-    // ブロック解除ボタンをクリック（実装に応じてセレクタを調整）
-    const unblockButton = optionsPage
-      .locator('button:has-text("Unblock"), button:has-text("解除")')
-      .first();
-    if (await unblockButton.isVisible()) {
-      await unblockButton.click();
-      await new Promise((resolve) => setTimeout(resolve, 300));
-    }
+    // ブロックリストから削除する = ブロック解除。5 秒の長押しで確定する
+    await optionsPage.locator(SELECTORS.options.deleteButton).first().click();
+    await expect(
+      optionsPage.locator(SELECTORS.modal.unblockConfirm)
+    ).toBeVisible();
+    await holdUnblockConfirm(optionsPage);
+    await expect(optionsPage.locator(SELECTORS.options.listItem)).toHaveCount(
+      0
+    );
 
-    // Unblock History を確認
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    const unblockHistory = (await getStorageDataFromExtension(
-      context,
-      extensionId,
-      'unblockHistory'
-    )) as any;
-    expect(unblockHistory.entries.length).toBeGreaterThan(0);
+    // 解除したドメインが履歴に記録される
+    await expect
+      .poll(async () => {
+        const history = (await getStorageData(
+          optionsPage,
+          'unblockHistory'
+        )) as {
+          sites?: Record<string, unknown>;
+        } | null;
+        return Object.keys(history?.sites ?? {});
+      })
+      .toContain(TEST_DOMAINS.example);
 
     await optionsPage.close();
   });
@@ -120,7 +131,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -163,7 +174,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -204,7 +215,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     extensionId
   }) => {
     // Opt-In が未決定の状態
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: null
@@ -241,7 +252,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     extensionId
   }) => {
     // Opt-Out 状態
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
@@ -276,7 +287,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -331,7 +342,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -367,7 +378,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     context,
     extensionId
   }) => {
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -410,7 +421,7 @@ test.describe('Analytics - アナリティクス機能', () => {
     extensionId
   }) => {
     // Opt-Out 状態
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() },

--- a/tests/e2e/block.spec.ts
+++ b/tests/e2e/block.spec.ts
@@ -1,8 +1,14 @@
 import { test, expect } from './fixtures/extension';
-import { openNewTab, openOptions, openExternalSite } from './helpers/pages';
+import {
+  openNewTab,
+  openOptions,
+  openExternalSite,
+  waitForBlockRules
+} from './helpers/pages';
 import {
   clearStorageFromExtension,
   setStorageDataFromExtension,
+  setSettingsFromExtension,
   getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS, SELECTORS } from './helpers/constants';
@@ -23,7 +29,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストにexample.comを追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -37,8 +43,12 @@ test.describe('Block - ブロック機能', () => {
       ]
     });
 
-    // ブロックルールが適用されるまで待機
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // ブロックルールが反映されるまで待つ（固定時間では足りないことがある）
+    {
+      const rulePage = await openOptions(context, extensionId);
+      await waitForBlockRules(rulePage, [TEST_DOMAINS.example]);
+      await rulePage.close();
+    }
 
     // ブロック対象サイトにアクセス
     const blockedPage = await openExternalSite(
@@ -58,7 +68,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ワイルドカードでブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -92,7 +102,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // 最初はブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -109,7 +119,7 @@ test.describe('Block - ブロック機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // ブロックリストから削除
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: []
@@ -136,7 +146,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -153,7 +163,7 @@ test.describe('Block - ブロック機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Pauseを有効化
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: true,
       blockList: [
@@ -187,7 +197,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // Pauseを有効化した状態で開始
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: true,
       blockList: [
@@ -204,7 +214,7 @@ test.describe('Block - ブロック機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // Pauseを解除
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -237,7 +247,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // enabled: false でブロックアイテムを追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -271,7 +281,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // 最初は無効化
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -288,7 +298,7 @@ test.describe('Block - ブロック機能', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
 
     // 有効化
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -321,7 +331,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -353,12 +363,16 @@ test.describe('Block - ブロック機能', () => {
     await rulesPage.close();
   });
 
-  test('BLOCK-009: ブロック時に lastBlockedDomain がポップアップ用に記録される', async ({
+  // 実装が動いていないため保留（#351）。
+  // DNR のリダイレクトとブロック回数の加算は動くが、
+  // chrome.storage.session の lastBlockedDomain が空のままで、
+  // 情報バナー（newtab-block-info）が一度も表示されない。
+  test.fixme('BLOCK-009: ブロック時にリダイレクト先でブロック元ドメインが表示される', async ({
     context,
     extensionId
   }) => {
     // ブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -382,15 +396,12 @@ test.describe('Block - ブロック機能', () => {
 
     await blockedPage.waitForURL(`**newtab.html**`, { timeout: 5000 });
 
-    // lastBlockedDomain が記録されたことを確認
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    const lastBlocked = (await getStorageDataFromExtension(
-      context,
-      extensionId,
-      'lastBlockedDomain'
-    )) as any;
-
-    expect(lastBlocked).toBe(TEST_DOMAINS.example);
+    // ブロック元のドメインが情報バナーに表示される。
+    // 実装は chrome.storage.session の lastBlockedDomain を経由するが、
+    // 表示と同時に消すため、storage を後から読んでも取れない（src/newtab.tsx）
+    const blockInfo = blockedPage.locator(SELECTORS.newtab.blockInfo);
+    await expect(blockInfo).toBeVisible();
+    await expect(blockInfo).toContainText(TEST_DOMAINS.example);
 
     await blockedPage.close();
   });
@@ -400,7 +411,7 @@ test.describe('Block - ブロック機能', () => {
     extensionId
   }) => {
     // ブロックリストに追加
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -417,7 +428,7 @@ test.describe('Block - ブロック機能', () => {
     // Analytics データ初期化
     await setStorageDataFromExtension(context, extensionId, 'analytics', {
       dailyStats: {},
-      siteStats: {}
+      siteBlockCounts: {}
     });
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -448,8 +459,9 @@ test.describe('Block - ブロック機能', () => {
 
     const today = new Date().toISOString().slice(0, 10);
     expect(analytics.dailyStats[today].blockCount).toBeGreaterThanOrEqual(2);
+    // サイト別の回数は siteBlockCounts[domain].count に入る
     expect(
-      analytics.siteStats[TEST_DOMAINS.example].blockCount
+      analytics.siteBlockCounts[TEST_DOMAINS.example].count
     ).toBeGreaterThanOrEqual(2);
 
     await blockedPage2.close();

--- a/tests/e2e/fixtures/extension.ts
+++ b/tests/e2e/fixtures/extension.ts
@@ -1,6 +1,8 @@
 import { test as base, chromium, type BrowserContext } from '@playwright/test';
 import path from 'path';
 
+import { startTestServer, type TestServer } from './testServer';
+
 /**
  * Chrome拡張機能テスト用のカスタムフィクスチャ
  *
@@ -20,22 +22,44 @@ export type ExtensionFixtures = {
   extensionId: string;
 };
 
+/** ワーカー単位で共有するフィクスチャ */
+export type ExtensionWorkerFixtures = {
+  /** テスト用のローカルサーバ（ワーカー単位で 1 台） */
+  testServer: TestServer;
+};
+
 /**
  * test.extend でカスタムフィクスチャを定義
  *
  * - context: 拡張機能をロードした BrowserContext
  * - extensionId: ロードされた拡張機能のID
  */
-export const test = base.extend<ExtensionFixtures>({
+export const test = base.extend<ExtensionFixtures, { testServer: TestServer }>({
+  // ローカルサーバはワーカー単位で使い回す（テストごとの起動は無駄）
+  testServer: [
+    async ({}, use) => {
+      const server = await startTestServer();
+      await use(server);
+      await server.close();
+    },
+    { scope: 'worker' }
+  ],
+
   // BrowserContextのカスタマイズ
-  context: async ({}, use) => {
+  context: async ({ testServer }, use) => {
     // Chrome拡張機能をロードした状態で BrowserContext を起動
     const context = await chromium.launchPersistentContext('', {
       headless: false, // Chrome拡張は headless 非対応
+      ignoreHTTPSErrors: true,
       args: [
         `--disable-extensions-except=${EXTENSION_PATH}`,
         `--load-extension=${EXTENSION_PATH}`,
-        '--no-sandbox'
+        '--no-sandbox',
+        // 全ホストをローカルのテストサーバへ向ける。
+        // localhost / 127.0.0.1 は拡張機能の内部通信に使うため除外する
+        `--host-resolver-rules=MAP * 127.0.0.1:${testServer.port}, EXCLUDE localhost`,
+        // テストサーバは自己署名証明書を使うため、警告を無視させる
+        '--ignore-certificate-errors'
       ]
     });
 

--- a/tests/e2e/fixtures/testServer.ts
+++ b/tests/e2e/fixtures/testServer.ts
@@ -58,9 +58,27 @@ function createSelfSignedCert(): { key: string; cert: string } {
   return { key, cert };
 }
 
+/**
+ * HTML に埋め込む値をエスケープする
+ *
+ * ホスト名とパスはリクエスト由来の値なので、そのまま埋めると
+ * リフレクト型 XSS になる。ローカル専用のテストサーバであっても、
+ * 壊れた入力でページが崩れると原因の切り分けが難しくなるため必ず通す。
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /** ホスト名からテスト用のページを組み立てる */
-function renderPage(host: string, pathname: string): string {
-  const isYouTube = /(^|\.)youtube\.com$/.test(host);
+function renderPage(rawHost: string, rawPathname: string): string {
+  const host = escapeHtml(rawHost);
+  const pathname = escapeHtml(rawPathname);
+  const isYouTube = /(^|\.)youtube\.com$/.test(rawHost);
 
   // YouTube のコンテンツスクリプトは実 DOM を前提に CSS を注入するため、
   // 隠す対象の要素だけを最小限に再現する

--- a/tests/e2e/fixtures/testServer.ts
+++ b/tests/e2e/fixtures/testServer.ts
@@ -1,0 +1,133 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import https from 'https';
+import os from 'os';
+import path from 'path';
+import type { AddressInfo } from 'net';
+
+/**
+ * E2E 用のローカル Web サーバ
+ *
+ * ブロック機能のテストは「実際のサイトに遷移して拡張機能が止めるか」を見るため、
+ * 従来は youtube.com や example.com へ実アクセスしていた。ネットワークが無い環境
+ * （CI のサンドボックス、オフライン開発）では ERR_NAME_NOT_RESOLVED で落ちるうえ、
+ * 外部サイトの都合でテストが壊れる。
+ *
+ * そこで、Chromium の --host-resolver-rules で全ホストをこのサーバへ向け、
+ * テスト対象のドメインをローカルで再現する。拡張機能側は declarativeNetRequest の
+ * `||domain` でスキーム非依存に判定しているため、実サイトと同じ経路を通る。
+ *
+ * HTTPS で待ち受ける理由: youtube.com は HSTS プリロード済みで、http:// でアクセス
+ * しても Chromium が https:// に内部昇格させる。平文 HTTP では接続が成立しない。
+ * 証明書は起動時に自己署名で生成し（リポジトリには含めない）、ブラウザ側は
+ * --ignore-certificate-errors で受け入れる。
+ */
+
+export interface TestServer {
+  /** 待ち受けポート。--host-resolver-rules に渡す */
+  port: number;
+  close: () => Promise<void>;
+}
+
+/** 自己署名証明書を一時ディレクトリに生成する */
+function createSelfSignedCert(): { key: string; cert: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vf-e2e-cert-'));
+  const keyPath = path.join(dir, 'key.pem');
+  const certPath = path.join(dir, 'cert.pem');
+
+  execFileSync('openssl', [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-keyout',
+    keyPath,
+    '-out',
+    certPath,
+    '-days',
+    '365',
+    '-subj',
+    '/CN=vision-focus-e2e'
+  ]);
+
+  const key = fs.readFileSync(keyPath, 'utf8');
+  const cert = fs.readFileSync(certPath, 'utf8');
+  fs.rmSync(dir, { recursive: true, force: true });
+
+  return { key, cert };
+}
+
+/** ホスト名からテスト用のページを組み立てる */
+function renderPage(host: string, pathname: string): string {
+  const isYouTube = /(^|\.)youtube\.com$/.test(host);
+
+  // YouTube のコンテンツスクリプトは実 DOM を前提に CSS を注入するため、
+  // 隠す対象の要素だけを最小限に再現する
+  const youtubeBody = `
+    <ytd-app>
+      <div id="content">
+        <ytd-browse page-subtype="home">
+          <ytd-rich-grid-renderer>
+            <div id="contents">
+              <ytd-rich-shelf-renderer is-shorts>Shorts shelf</ytd-rich-shelf-renderer>
+              <ytd-reel-shelf-renderer>Reel shelf</ytd-reel-shelf-renderer>
+            </div>
+          </ytd-rich-grid-renderer>
+        </ytd-browse>
+        <ytd-watch-flexy>
+          <div id="secondary"><div id="secondary-inner"><div id="related">Related videos</div></div></div>
+          <ytd-comments id="comments">Comments</ytd-comments>
+        </ytd-watch-flexy>
+      </div>
+    </ytd-app>`;
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>${host}${pathname}</title>
+  </head>
+  <body>
+    <h1 data-testid="test-site-heading">${host}</h1>
+    <p data-testid="test-site-path">${pathname}</p>
+    ${isYouTube ? youtubeBody : ''}
+  </body>
+</html>`;
+}
+
+/**
+ * ローカル HTTPS サーバを起動する
+ *
+ * ポートは 0 を指定して OS に選ばせる。並列ワーカーごとに 1 台起動しても
+ * 衝突しない。
+ */
+export async function startTestServer(): Promise<TestServer> {
+  const { key, cert } = createSelfSignedCert();
+
+  const server = https.createServer({ key, cert }, (req, res) => {
+    const host = (req.headers.host ?? 'unknown').replace(/:\d+$/, '');
+    const pathname = req.url ?? '/';
+
+    res.writeHead(200, {
+      'content-type': 'text/html; charset=utf-8',
+      // ブロック判定はページの内容に依存しないため、キャッシュは無効にしておく
+      'cache-control': 'no-store'
+    });
+    res.end(renderPage(host, pathname));
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const port = (server.address() as AddressInfo).port;
+
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      })
+  };
+}

--- a/tests/e2e/helpers/pages.ts
+++ b/tests/e2e/helpers/pages.ts
@@ -127,3 +127,34 @@ export async function openExternalSite(
   await page.waitForLoadState('domcontentloaded');
   return page;
 }
+
+/**
+ * ブロックルール（declarativeNetRequest の動的ルール）が反映されるまで待つ
+ *
+ * ルールの更新は storage の変更を受けた background が非同期に行うため、
+ * 固定時間の sleep では足りないことがある。実際のルールを見て待つ。
+ *
+ * @param page - 拡張機能のページ（chrome API が使えるもの）
+ * @param domains - ルールに含まれているべきドメイン
+ */
+export async function waitForBlockRules(
+  page: Page,
+  domains: string[],
+  timeout = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    const filters = await page.evaluate(async () => {
+      const rules = await chrome.declarativeNetRequest.getDynamicRules();
+      return rules.map((rule) => rule.condition.urlFilter ?? '');
+    });
+
+    if (domains.every((d) => filters.some((f) => f.includes(d)))) return;
+    await page.waitForTimeout(100);
+  }
+
+  throw new Error(
+    `ブロックルールが反映されない: ${domains.join(', ')} を待っていた`
+  );
+}

--- a/tests/e2e/helpers/storage.ts
+++ b/tests/e2e/helpers/storage.ts
@@ -56,6 +56,22 @@ export async function setSessionStorageData(
 }
 
 /**
+ * chrome.storage.session からデータを取得する
+ *
+ * lastBlockedDomain のように、拡張機能が session 領域に置く値は
+ * local を読んでも取れない（@plasmohq/storage も経由しないため生の値）。
+ */
+export async function getSessionStorageData<T = unknown>(
+  page: Page,
+  key: string
+): Promise<T | null> {
+  return await page.evaluate(async (key) => {
+    const result = await chrome.storage.session.get(key);
+    return (result[key] ?? null) as T;
+  }, key);
+}
+
+/**
  * chrome.storage.local からデータを取得する
  *
  * @param page - Playwright Page オブジェクト
@@ -210,6 +226,86 @@ export function makePreset(
  *
  * @param overrides - 上書きする値
  */
+/**
+ * settings を「欠けたフィールドのない完全な形」で書き込む
+ *
+ * 部分的な settings を直接書くと、実装側が `settings.schedules` などを
+ * 前提にしている箇所で処理が止まる。ブロックルールの再計算が丸ごと
+ * 失敗しても E2E からは「なぜかブロックされない」としか見えないため、
+ * settings の書き込みは必ずこのヘルパー経由にする。
+ */
+export async function setSettings(
+  page: Page,
+  overrides: Record<string, unknown> = {}
+): Promise<void> {
+  await setStorageData(page, 'settings', makeSettings(overrides));
+}
+
+/** 拡張機能のページを開いて settings を書き込む（完全な形で書く） */
+export async function setSettingsFromExtension(
+  context: BrowserContext,
+  extensionId: string,
+  overrides: Record<string, unknown> = {}
+): Promise<void> {
+  await setStorageDataFromExtension(
+    context,
+    extensionId,
+    'settings',
+    makeSettings(overrides)
+  );
+}
+
+/**
+ * YouTube 設定を「欠けたフィールドのない完全な形」で作る
+ *
+ * 実装は保存された youtube 設定をスキーマ検証しており、フィールドが欠けていると
+ * 検証に失敗して既定値（enabled: false）にフォールバックする。その結果
+ * コンテンツスクリプトが CSS を一切注入せず、テストからは「設定したのに
+ * 効かない」としか見えない。
+ */
+export function makeYouTubeSettings(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    enabled: true,
+    blockAccess: false,
+    hideShorts: false,
+    hideRecommendations: false,
+    hideComments: false,
+    hideSidebar: false,
+    hideHomeFeed: false,
+    timeLimit: null,
+    ...overrides
+  };
+}
+
+/**
+ * Time Limit の使用実績を作る
+ *
+ * 実装は `analytics.timeLimitUsage[domain]` に
+ * `{ domain, dailyUsedSeconds, hourlyUsedSeconds, lastDailyReset, lastHourlyReset }`
+ * の形で持つ。トップレベルの `timeLimitUsage` キーや
+ * `{ daily: { used, resetAt } }` という形は実装に存在しない。
+ */
+export function makeTimeLimitUsage(
+  domain: string,
+  used: { daily?: number; hourly?: number } = {},
+  now: Date = new Date()
+): Record<string, unknown> {
+  const todayKey = now.toISOString().slice(0, 10);
+  const hourKey = `${todayKey}-${String(now.getHours()).padStart(2, '0')}`;
+
+  return {
+    [domain]: {
+      domain,
+      dailyUsedSeconds: used.daily ?? 0,
+      hourlyUsedSeconds: used.hourly ?? 0,
+      lastDailyReset: todayKey,
+      lastHourlyReset: hourKey
+    }
+  };
+}
+
 export function makeSettings(
   overrides: Record<string, unknown> = {}
 ): Record<string, unknown> {

--- a/tests/e2e/interaction.spec.ts
+++ b/tests/e2e/interaction.spec.ts
@@ -1,8 +1,13 @@
 import { test, expect } from './fixtures/extension';
-import { openExternalSite, openPopup } from './helpers/pages';
+import {
+  openExternalSite,
+  openPopup,
+  waitForBlockRules
+} from './helpers/pages';
 import {
   clearStorageFromExtension,
   setStorageDataFromExtension,
+  setSettingsFromExtension,
   getStorageDataFromExtension
 } from './helpers/storage';
 import { TEST_DOMAINS } from './helpers/constants';
@@ -23,7 +28,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     extensionId
   }) => {
     // Pause 有効 + Time Limit 超過
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: true, // Pause 有効
       blockList: [
@@ -34,8 +39,8 @@ test.describe('Interaction - 機能間相互作用', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 1,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 1
           }
         }
       ]
@@ -75,7 +80,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     const currentDay = now.getDay();
 
     // Pause 有効 + Schedule でブロック有効化時間帯
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: true, // Pause 有効
       blockList: [
@@ -124,7 +129,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     const currentDay = now.getDay();
 
     // Time Limit 未超過 + Schedule でブロック有効化時間帯
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       blockList: [
@@ -135,8 +140,8 @@ test.describe('Interaction - 機能間相互作用', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60
           }
         }
       ],
@@ -186,7 +191,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     const currentDay = now.getDay();
 
     // Pause 有効 + Time Limit 超過 + Schedule 有効
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: true, // Pause が最優先
       blockList: [
@@ -197,8 +202,8 @@ test.describe('Interaction - 機能間相互作用', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 1,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 1
           }
         }
       ],
@@ -245,7 +250,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     extensionId
   }) => {
     // Opt-Out 状態
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: false, decidedAt: new Date().toISOString() }
@@ -286,7 +291,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     extensionId
   }) => {
     // パスワード保護を有効化
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       password: {
@@ -319,7 +324,7 @@ test.describe('Interaction - 機能間相互作用', () => {
     extensionId
   }) => {
     // パスワード保護を有効化
-    await setStorageDataFromExtension(context, extensionId, 'settings', {
+    await setSettingsFromExtension(context, extensionId, {
       language: 'en',
       paused: false,
       password: {

--- a/tests/e2e/time-limit.spec.ts
+++ b/tests/e2e/time-limit.spec.ts
@@ -7,6 +7,9 @@ import {
 } from './helpers/pages';
 import {
   setStorageData,
+  makeAnalytics,
+  makeTimeLimitUsage,
+  setSettings,
   clearStorage,
   clearStorageFromExtension,
   getStorageData
@@ -31,7 +34,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // Daily Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -42,8 +45,8 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60, // 60秒
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60 // 60秒
           }
         }
       ]
@@ -51,7 +54,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
 
     // 設定が保存されたことを確認
     const settings = (await getStorageData(page, 'settings')) as any;
-    expect(settings.blockList[0].timeLimit.daily).toBe(60);
+    expect(settings.blockList[0].timeLimit.limitSeconds).toBe(60);
 
     await page.close();
   });
@@ -63,7 +66,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // Hourly Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -83,7 +86,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
 
     // 設定が保存されたことを確認
     const settings = (await getStorageData(page, 'settings')) as any;
-    expect(settings.blockList[0].timeLimit.hourly).toBe(30);
+    expect(settings.blockList[0].timeLimit.limitSeconds).toBe(30);
 
     await page.close();
   });
@@ -95,7 +98,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // Time Limit を1秒に設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -106,29 +109,29 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 1, // 1秒
-            hourly: null
+            type: 'daily',
+            limitSeconds: 1 // 1秒
           }
         }
       ]
     });
 
     // 既に使用済みとして記録
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 2, // 1秒を超過
-          resetAt: new Date(Date.now() + 86400000).toISOString()
-        },
-        hourly: null
-      }
-    });
+    // 使用実績は analytics.timeLimitUsage 配下に持つ
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          daily: 2 // 1秒を超過
+        })
+      })
+    );
 
     await page.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // サイトにアクセス
     const blockedPage = await openExternalSite(
       context,
       `https://${TEST_DOMAINS.example}`
@@ -154,7 +157,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -165,28 +168,28 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60
           }
         }
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 70, // 超過していた
-          resetAt: yesterday.toISOString() // 過去のリセット時刻
-        },
-        hourly: null
-      }
-    });
+    // 使用実績は analytics.timeLimitUsage 配下に持つ
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          daily: 70 // 超過していた
+        })
+      })
+    );
 
     await page.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // サイトにアクセス（リセットされているのでアクセス可能）
     const unblockedPage = await openExternalSite(
       context,
       `https://${TEST_DOMAINS.example}`
@@ -210,7 +213,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const oneHourAgo = new Date();
     oneHourAgo.setHours(oneHourAgo.getHours() - 1);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -228,21 +231,20 @@ test.describe('TimeLimit - Time Limit 機能', () => {
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: null,
-        hourly: {
-          used: 40, // 超過していた
-          resetAt: oneHourAgo.toISOString() // 過去のリセット時刻
-        }
-      }
-    });
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          hourly: 40 // 超過していた
+        })
+      })
+    );
 
     await page.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // サイトにアクセス（リセットされているのでアクセス可能）
     const unblockedPage = await openExternalSite(
       context,
       `https://${TEST_DOMAINS.example}`
@@ -262,7 +264,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -273,23 +275,24 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60
           }
         }
       ]
     });
 
     // 30秒使用済み
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 30,
-          resetAt: new Date(Date.now() + 86400000).toISOString()
-        },
-        hourly: null
-      }
-    });
+    // 使用実績は analytics.timeLimitUsage 配下に持つ
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          daily: 30
+        })
+      })
+    );
 
     await page.close();
 
@@ -312,7 +315,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
   }) => {
     const page = await openStoragePage(context, extensionId);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() }
@@ -354,7 +357,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // Pause 有効 + Time Limit 超過状態
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: true, // Pause 有効
       blockList: [
@@ -365,28 +368,28 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 1,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 1
           }
         }
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 10, // 超過
-          resetAt: new Date(Date.now() + 86400000).toISOString()
-        },
-        hourly: null
-      }
-    });
+    // 使用実績は analytics.timeLimitUsage 配下に持つ
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          daily: 10 // 超過
+        })
+      })
+    );
 
     await page.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // サイトにアクセス（Pauseが優先されてアクセス可能）
     const unblockedPage = await openExternalSite(
       context,
       `https://${TEST_DOMAINS.example}`
@@ -412,7 +415,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
       resetTime.setDate(resetTime.getDate() + 1);
     }
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -423,22 +426,23 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60
           }
         }
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 50,
-          resetAt: resetTime.toISOString()
-        },
-        hourly: null
-      }
-    });
+    // 使用実績は analytics.timeLimitUsage 配下に持つ
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          daily: 50
+        })
+      })
+    );
 
     // Date をモックして00:00を再現
     await page.evaluate(() => {
@@ -478,7 +482,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const resetTime = new Date();
     resetTime.setMinutes(59, 0, 0);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -496,15 +500,15 @@ test.describe('TimeLimit - Time Limit 機能', () => {
       ]
     });
 
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: null,
-        hourly: {
-          used: 25,
-          resetAt: resetTime.toISOString()
-        }
-      }
-    });
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: makeTimeLimitUsage(TEST_DOMAINS.example, {
+          hourly: 25
+        })
+      })
+    );
 
     // Date をモックして10:00を再現
     await page.evaluate(() => {
@@ -539,7 +543,7 @@ test.describe('TimeLimit - Time Limit 機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // 2つのサイトに異なる Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       blockList: [
@@ -550,8 +554,8 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 60,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 60
           }
         },
         {
@@ -561,36 +565,29 @@ test.describe('TimeLimit - Time Limit 機能', () => {
           createdAt: new Date().toISOString(),
           enabled: true,
           timeLimit: {
-            daily: 30,
-            hourly: null
+            type: 'daily',
+            limitSeconds: 30
           }
         }
       ]
     });
 
     // example.com は超過、reddit.com は未超過
-    await setStorageData(page, 'timeLimitUsage', {
-      [TEST_DOMAINS.example]: {
-        daily: {
-          used: 70, // 超過
-          resetAt: new Date(Date.now() + 86400000).toISOString()
-        },
-        hourly: null
-      },
-      [TEST_DOMAINS.reddit]: {
-        daily: {
-          used: 10, // 未超過
-          resetAt: new Date(Date.now() + 86400000).toISOString()
-        },
-        hourly: null
-      }
-    });
+    await setStorageData(
+      page,
+      'analytics',
+      makeAnalytics({
+        timeLimitUsage: {
+          ...makeTimeLimitUsage(TEST_DOMAINS.example, { daily: 70 }),
+          ...makeTimeLimitUsage(TEST_DOMAINS.reddit, { daily: 10 })
+        }
+      })
+    );
 
     await page.close();
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
 
-    // example.com はブロック
     const blockedPage = await openExternalSite(
       context,
       `https://${TEST_DOMAINS.example}`

--- a/tests/e2e/youtube.spec.ts
+++ b/tests/e2e/youtube.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from './fixtures/extension';
 import { openExternalSite, openStoragePage } from './helpers/pages';
 import {
   setStorageData,
+  setSettings,
+  makeYouTubeSettings,
   clearStorage,
   clearStorageFromExtension,
   getStorageData
@@ -26,16 +28,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // YouTube Shorts を非表示に設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: true,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: null
-      }
+      })
     });
 
     await page.close();
@@ -49,12 +51,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     await youtubePage.waitForLoadState('domcontentloaded');
 
     // Shorts が非表示になる CSS が適用されているか確認
-    const shortsHidden = await youtubePage.evaluate(() => {
-      const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('[title*="Shorts"]');
-    });
-
-    expect(shortsHidden).toBeTruthy();
+    // コンテンツスクリプトは storage を読んでから style を注入するため、
+    // 注入が終わるまで待つ
+    await expect
+      .poll(() =>
+        youtubePage.evaluate(() => {
+          const style = document.getElementById('vision-focus-youtube-blocker');
+          return style?.textContent?.includes('a[title="Shorts"]');
+        })
+      )
+      .toBeTruthy();
 
     await youtubePage.close();
   });
@@ -65,16 +71,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
   }) => {
     const page = await openStoragePage(context, extensionId);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: true,
         hideComments: false,
         timeLimit: null
-      }
+      })
     });
 
     await page.close();
@@ -89,9 +95,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     // Recommendations が非表示になる CSS が適用されているか確認
     const recsHidden = await youtubePage.evaluate(() => {
       const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes(
-        'ytd-watch-next-secondary-results-renderer'
-      );
+      return style?.textContent?.includes('#secondary-inner #related');
     });
 
     expect(recsHidden).toBeTruthy();
@@ -105,16 +109,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
   }) => {
     const page = await openStoragePage(context, extensionId);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: true,
         timeLimit: null
-      }
+      })
     });
 
     await page.close();
@@ -127,12 +131,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     await youtubePage.waitForLoadState('domcontentloaded');
 
     // Comments が非表示になる CSS が適用されているか確認
-    const commentsHidden = await youtubePage.evaluate(() => {
-      const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('ytd-comments');
-    });
-
-    expect(commentsHidden).toBeTruthy();
+    // コンテンツスクリプトは storage を読んでから style を注入するため、
+    // 注入が終わるまで待つ
+    await expect
+      .poll(() =>
+        youtubePage.evaluate(() => {
+          const style = document.getElementById('vision-focus-youtube-blocker');
+          return style?.textContent?.includes('ytd-comments');
+        })
+      )
+      .toBeTruthy();
 
     await youtubePage.close();
   });
@@ -144,16 +152,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // YouTube を完全ブロック
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: true,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: null
-      }
+      })
     });
 
     await page.close();
@@ -180,24 +188,24 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // YouTube Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: {
-          daily: 120,
-          hourly: null
+          type: 'daily',
+          limitSeconds: 120
         }
-      }
+      })
     });
 
     // 設定が保存されたことを確認
     const settings = (await getStorageData(page, 'settings')) as any;
-    expect(settings.youtube.timeLimit.daily).toBe(120);
+    expect(settings.youtube.timeLimit.limitSeconds).toBe(120);
 
     await page.close();
   });
@@ -209,19 +217,19 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // YouTube Time Limit を設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: {
-          daily: 1, // 1秒
-          hourly: null
+          type: 'daily',
+          limitSeconds: 1 // 1秒
         }
-      }
+      })
     });
 
     // 既に超過（analytics.timeLimitUsage に youtube.com の使用データを設定）
@@ -253,12 +261,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     await youtubePage.waitForLoadState('domcontentloaded');
 
     // 全コンテンツが非表示になる CSS が適用されているか確認
-    const contentHidden = await youtubePage.evaluate(() => {
-      const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('display: none !important');
-    });
-
-    expect(contentHidden).toBeTruthy();
+    // コンテンツスクリプトは storage を読んでから style を注入するため、
+    // 注入が終わるまで待つ
+    await expect
+      .poll(() =>
+        youtubePage.evaluate(() => {
+          const style = document.getElementById('vision-focus-youtube-blocker');
+          return style?.textContent?.includes('display: none !important');
+        })
+      )
+      .toBeTruthy();
 
     await youtubePage.close();
   });
@@ -270,16 +282,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // 最初は Shorts 非表示なし
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: null
-      }
+      })
     });
 
     await page.close();
@@ -294,7 +306,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     // Shorts が表示されていることを確認
     let shortsHidden = await youtubePage.evaluate(() => {
       const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('[title*="Shorts"]');
+      return style?.textContent?.includes('a[title="Shorts"]');
     });
     expect(shortsHidden).toBeFalsy();
 
@@ -302,16 +314,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     // page.evaluate はページのメインワールドで実行されるため、コンテンツ
     // スクリプトと違い chrome.storage を参照できない。拡張機能ページ経由で更新する
     const updatePage = await openStoragePage(context, extensionId);
-    await setStorageData(updatePage, 'settings', {
+    await setSettings(updatePage, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: true, // 有効化
         hideRecommendations: false,
         hideComments: false,
         timeLimit: null
-      }
+      })
     });
     await updatePage.close();
 
@@ -321,7 +333,7 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     // Shorts が非表示になることを確認
     shortsHidden = await youtubePage.evaluate(() => {
       const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('[title*="Shorts"]');
+      return style?.textContent?.includes('a[title="Shorts"]');
     });
     expect(shortsHidden).toBeTruthy();
 
@@ -334,20 +346,20 @@ test.describe('YouTube - YouTube ブロック機能', () => {
   }) => {
     const page = await openStoragePage(context, extensionId);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
       analyticsOptIn: { enabled: true, decidedAt: new Date().toISOString() },
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: {
-          daily: 60,
-          hourly: null
+          type: 'daily',
+          limitSeconds: 60
         }
-      }
+      })
     });
 
     // YouTube を訪問
@@ -381,19 +393,19 @@ test.describe('YouTube - YouTube ブロック機能', () => {
   }) => {
     const page = await openStoragePage(context, extensionId);
 
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: false,
         hideShorts: true, // Shorts 非表示
         hideRecommendations: false,
         hideComments: false,
         timeLimit: {
-          daily: 60,
-          hourly: null
+          type: 'daily',
+          limitSeconds: 60
         }
-      }
+      })
     });
 
     // Time Limit は未超過（analytics.timeLimitUsage に youtube.com の使用データを設定）
@@ -427,14 +439,16 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     // Shorts 非表示の CSS が適用されていることを確認
     const shortsHidden = await youtubePage.evaluate(() => {
       const style = document.getElementById('vision-focus-youtube-blocker');
-      return style?.textContent?.includes('[title*="Shorts"]');
+      return style?.textContent?.includes('a[title="Shorts"]');
     });
     expect(shortsHidden).toBeTruthy();
 
-    // Time Limit 超過の CSS は適用されていないことを確認
+    // Time Limit 超過の CSS は適用されていないことを確認。
+    // style 要素自体は Shorts 非表示のために存在するため、
+    // 超過時だけ入る全体非表示ルールの有無で判定する
     const limitExceeded = await youtubePage.evaluate(() => {
       const style = document.getElementById('vision-focus-youtube-blocker');
-      return style !== null;
+      return style?.textContent?.includes('ytd-app #content');
     });
     expect(limitExceeded).toBeFalsy();
 
@@ -448,19 +462,19 @@ test.describe('YouTube - YouTube ブロック機能', () => {
     const page = await openStoragePage(context, extensionId);
 
     // blockAccess と Time Limit を両方設定
-    await setStorageData(page, 'settings', {
+    await setSettings(page, {
       language: 'en',
       paused: false,
-      youtube: {
+      youtube: makeYouTubeSettings({
         blockAccess: true, // 完全ブロック
         hideShorts: false,
         hideRecommendations: false,
         hideComments: false,
         timeLimit: {
-          daily: 60,
-          hourly: null
+          type: 'daily',
+          limitSeconds: 60
         }
-      }
+      })
     });
 
     // Time Limit は未超過（analytics.timeLimitUsage に youtube.com の使用データを設定）


### PR DESCRIPTION
## 概要

E2E が外部サイト（`youtube.com` / `example.com`）への実アクセスを前提にしていたため、ネットワークのない環境では 27 件が `ERR_NAME_NOT_RESOLVED` で落ちていた。ローカルサーバに差し替え、あわせて実装と乖離していたアサーションを修正する。

Refs #327

## E2E の推移

| | 変更前 | 変更後 |
| --- | --- | --- |
| **pass** | **132** | **151** |
| **fail** | **27** | **9** |
| skip | 3 | 4 |

| spec | 変更前 | 変更後 |
| --- | --- | --- |
| block | 3 pass / 7 fail | 9 pass / 1 skip |
| youtube | 2 pass / 8 fail | **10 pass** |
| analytics | 7 pass / 3 fail | 9 pass / 1 fail |
| interaction | 4 pass / 3 fail | 6 pass / 1 fail |
| time-limit | 5 pass / 6 fail | 4 pass / 7 fail |

残り 9 件は #352、`BLOCK-009` は #351 に切り出しています。

## 1. ローカルテストサーバ

`tests/e2e/fixtures/testServer.ts` を追加し、Chromium の `--host-resolver-rules=MAP * 127.0.0.1:<port>` で全ホストをそこへ向けます。拡張機能側は `declarativeNetRequest` の `||domain` でスキーム非依存に判定するため、**実サイトと同じ経路を通ります**。

**HTTPS で待ち受けている理由**: `youtube.com` は HSTS プリロード済みで、`http://` でアクセスしても Chromium が `https://` に内部昇格させます。平文 HTTP では接続が成立しないため、実行時に自己署名証明書を生成し（リポジトリには含めない）、ブラウザ側は `--ignore-certificate-errors` で受け入れます。

サーバはワーカー単位で 1 台、ポートは OS 任せ（`listen(0)`）なので並列実行でも衝突しません。

## 2. 見つかった実装の問題

**`isAnyScheduleActive(undefined)` が例外を投げ、ブロックルールの再計算が丸ごと止まる。**

`settings.schedules` が欠けた状態（旧バージョンの設定、部分的なインポート）だと `schedules.length` で TypeError になり、`getActiveBlockedDomains()` が例外で抜けるため **DNR ルールが 1 件も作られず、ブロックが一切効きません**。前後の処理（ブロック回数の加算）は成功するので、外からは「なぜかブロックされない」としか見えない状態でした。未設定は「常時有効」として扱うよう修正し、回帰テストを追加しています。

E2E がネットワークで落ちていたためにこれまで検出できていませんでした。

## 3. fixture のヘルパー化

fixture のフィールドが欠けると実装側のスキーマ検証に落ち、**既定値（`enabled: false`）にフォールバックして何も起きません**。YouTube 設定で `hideSidebar` / `hideHomeFeed` を省いていたために CSS が一切注入されず、8 件が落ちていたのが実例です。

`makeYouTubeSettings()` / `makeTimeLimitUsage()` / `setSettings()` を追加し、完全な形しか作れないようにしました。

## 4. 実装と乖離していたアサーション

| テストが見ていたもの | 実装 |
| --- | --- |
| `analytics.siteStats[domain].blockCount` | `analytics.siteBlockCounts[domain].count` |
| `unblockHistory.entries` (配列) | `unblockHistory.sites` (ドメインキーのオブジェクト) |
| `timeLimit: { daily, hourly }` | `timeLimit: { type, limitSeconds }` |
| トップレベルの `timeLimitUsage` | `analytics.timeLimitUsage` |
| `chrome.storage.local` の `lastBlockedDomain` | `chrome.storage.session` |

`AN-002` は `if (await button.isVisible())` で囲まれた**要素が無ければ何も検証しない構造**だったため、長押しによる解除フローの実テストに書き換えました。YouTube の CSS 注入待ちは即時 `evaluate` から `expect.poll` に変更しています。

## レビュー観点

- ローカルサーバへの差し替えで「実サイトでは動くがテストでは動かない/その逆」が起きないか（DNR は URL 一致なので影響しないと判断）
- 自己署名証明書を実行時生成にした判断（リポジトリに鍵を置かない）
- `isAnyScheduleActive` の修正が「未設定＝常時有効」で妥当か

## 確認

- ユニットテスト 782 件パス（回帰テスト 1 件追加）
- `pnpm lint` エラー 0 / `pnpm type-check` パス / `pnpm format:check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAehqhEfJ6LcTZwmi7CXPv