### PR TITLE
fix: Storybook で Plasmo の import スキームを解決できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,32 @@ jobs:
       - name: Build
         run: pnpm build
 
+  # 並列実行: Storybook ビルド
+  # Plasmo 独自の import スキームなど、本体ビルドでは通るのに Storybook では
+  # 壊れる差分を検知するために独立して実行する（#356）
+  build-storybook:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+
   # 全ジョブ完了確認（ブランチ保護ルール用）
   check:
     runs-on: ubuntu-latest
@@ -197,7 +223,8 @@ jobs:
         test-unit-hooks,
         test-unit-background,
         coverage,
-        build
+        build,
+        build-storybook
       ]
     steps:
       - name: All checks passed

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
+import { plasmoSchemePlugin } from './plasmoSchemePlugin';
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
@@ -15,6 +17,9 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     return {
       ...config,
+      // Plasmo 独自の import スキーム（data-base64: 等）を解決する。
+      // これがないと Header / options のストーリーがビルドできない
+      plugins: [...(config.plugins ?? []), plasmoSchemePlugin(process.cwd())],
       resolve: {
         ...config.resolve,
         alias: {

--- a/.storybook/plasmoSchemePlugin.ts
+++ b/.storybook/plasmoSchemePlugin.ts
@@ -1,0 +1,90 @@
+import fs from 'fs';
+import path from 'path';
+import type { Plugin } from 'vite';
+
+/**
+ * Plasmo の import スキームを Storybook（vite）で解決するプラグイン
+ *
+ * Plasmo は `data-base64:assets/icon.png` のような独自スキームで
+ * アセットを取り込む。これは Plasmo のバンドラが処理するため、素の vite で
+ * ビルドする Storybook では「解決できない import」として失敗する。
+ *
+ * 対応スキーム（https://docs.plasmo.com/framework/import）:
+ *
+ * | スキーム      | 返すもの                          |
+ * | ------------- | --------------------------------- |
+ * | `data-base64:` | base64 データ URI                 |
+ * | `data-text:`   | ファイルの中身（文字列）          |
+ * | `raw:`         | ファイルの中身（文字列）          |
+ * | `url:`         | Storybook から参照できる URL      |
+ *
+ * パスはプロジェクトルート起点で解決する（Plasmo と同じ扱い）。
+ */
+
+const SCHEMES = ['data-base64:', 'data-text:', 'raw:', 'url:'] as const;
+
+const MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon'
+};
+
+function matchScheme(id: string): { scheme: string; filePath: string } | null {
+  for (const scheme of SCHEMES) {
+    if (id.startsWith(scheme)) {
+      return { scheme, filePath: id.slice(scheme.length) };
+    }
+  }
+  return null;
+}
+
+export function plasmoSchemePlugin(projectRoot: string): Plugin {
+  const PREFIX = '\0plasmo-scheme:';
+
+  return {
+    name: 'plasmo-import-scheme',
+
+    resolveId(id) {
+      const matched = matchScheme(id);
+      if (!matched) return null;
+
+      // vite に「解決済みの仮想モジュール」として扱わせる
+      return PREFIX + id;
+    },
+
+    load(id) {
+      if (!id.startsWith(PREFIX)) return null;
+
+      const matched = matchScheme(id.slice(PREFIX.length));
+      if (!matched) return null;
+
+      const { scheme, filePath } = matched;
+      const absolutePath = path.resolve(projectRoot, filePath);
+
+      if (!fs.existsSync(absolutePath)) {
+        throw new Error(
+          `Plasmo スキームのファイルが見つからない: ${scheme}${filePath}`
+        );
+      }
+
+      if (scheme === 'data-base64:') {
+        const ext = path.extname(absolutePath).toLowerCase();
+        const mime = MIME_TYPES[ext] ?? 'application/octet-stream';
+        const base64 = fs.readFileSync(absolutePath).toString('base64');
+        return `export default ${JSON.stringify(`data:${mime};base64,${base64}`)};`;
+      }
+
+      if (scheme === 'data-text:' || scheme === 'raw:') {
+        const text = fs.readFileSync(absolutePath, 'utf8');
+        return `export default ${JSON.stringify(text)};`;
+      }
+
+      // url: は vite の通常のアセット解決に委ねる
+      return `import url from ${JSON.stringify(absolutePath + '?url')};\nexport default url;`;
+    }
+  };
+}


### PR DESCRIPTION
## 概要

`pnpm build-storybook` が失敗して Storybook をビルドできない状態を解消する。

Closes #356

## 原因

`data-base64:assets/icon.png` は **Plasmo 独自の import スキーム**（アセットを base64 データ URI として埋め込む）で、Plasmo のバンドラが処理する。素の vite でビルドする Storybook はこのスキームを知らないため、`Rollup failed to resolve import` で落ちていた。

`pnpm build`（本体）は通るので**プロダクション成果物には影響しない**。Storybook だけの問題。

## 対応

**`.storybook/plasmoSchemePlugin.ts`** を追加しました。個別の alias ではなく汎用プラグインにしたのは、Plasmo のスキームが今後増えても対応できるようにするためです（Issue の備考どおり）。

| スキーム | 返すもの |
| --- | --- |
| `data-base64:` | base64 データ URI |
| `data-text:` / `raw:` | ファイルの中身（文字列） |
| `url:` | vite の通常のアセット解決に委譲 |

**CI に `build-storybook` ジョブを追加**しました。これが本題の再発防止です。本体ビルドでは通るのに Storybook では壊れる、という今回の差分は専用ジョブがないと検知できません。`check` の `needs` にも追加済みなので、ブランチ保護の gate に入ります。

## 確認

- `pnpm build-storybook` 成功（Preview built 4.39s）
- ビルド成果物の `Header-*.js` に `data:image/png;base64,...` が埋め込まれていることを確認（アイコンが実際に解決されている）
- `pnpm lint` エラー 0 / `pnpm type-check` パス / `pnpm format:check` パス

## レビュー観点

- 汎用プラグインの実装が Plasmo の挙動と一致しているか（`data-base64:` のパス解決はプロジェクトルート起点）
- `url:` を vite に委譲している判断（Storybook から参照できる URL を返す必要があるため）
- CI ジョブ追加による所要時間の増加（Storybook ビルドは約 5 秒 + 依存インストール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAehqhEfJ6LcTZwmi7CXPv