### PR TITLE
ci: E2E をナイトリーで自動実行し、失敗を Issue に残す

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,12 +1,23 @@
 name: E2E Tests
 
+# PR ごとには実行しない。
+# 拡張機能の E2E は headless 非対応で 3 並列の Chromium を立てるため重く、
+# PR のリードタイムを損なう（CI 全体 約40秒 → 数分）。
+# ナイトリーとリリース前の手動実行で担保する。
 on:
+  schedule:
+    # 毎日 18:00 UTC = 03:00 JST
+    - cron: '0 18 * * *'
   workflow_dispatch:
     inputs:
       branch:
         description: 'テスト対象ブランチ'
         required: false
         default: 'develop'
+
+# 既定は読み取りのみ。Issue 起票が必要なジョブで個別に付与する
+permissions:
+  contents: read
 
 jobs:
   e2e:
@@ -15,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || 'develop' }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -38,5 +49,72 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: E2E tests
-        timeout-minutes: 10
+        timeout-minutes: 20
         run: xvfb-run --auto-servernum -- pnpm test:e2e
+
+      # 失敗時の調査用。スクリーンショットと動画が入っている
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+
+  # 失敗を放置しないための通知。
+  # ナイトリーは誰も見ていない時間に走るため、Issue を立てて残す
+  notify-failure:
+    if: failure() && github.event_name == 'schedule'
+    needs: e2e
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update an issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- e2e-nightly-failure -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // 既に起票済みなら重複させずコメントを足す
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'e2e-nightly'
+            });
+
+            const body = [
+              marker,
+              '',
+              'ナイトリーの E2E が失敗した。',
+              '',
+              `- 実行: ${runUrl}`,
+              `- 対象: \`develop\` (${context.sha.slice(0, 7)})`,
+              '',
+              'Playwright のレポート（スクリーンショット・動画）は実行結果の artifact から取得できる。',
+              '',
+              '失敗が実装のバグなら別 Issue に切り出し、テスト側の問題なら修正して閉じる。'
+            ].join('\n');
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'test: ナイトリーの E2E が失敗している',
+              labels: ['e2e-nightly'],
+              body
+            });


### PR DESCRIPTION
## 概要

E2E が `workflow_dispatch`（手動）のみで、誰も回さなければ 154 件のテストが存在しないのと同じ状態だった。ナイトリー実行を追加する。

Closes #310

## PR ごとには実行しない

実測値です。

| | 時間 |
| --- | --- |
| 現在の CI 全体（並列） | **約 40 秒** |
| E2E（ローカル 3 並列） | 約 1 分 36 秒 |
| E2E（CI 想定） | 3〜6 分（依存インストール + ビルド + Chromium DL + xvfb 込み） |

PR gate にすると CI が 10 倍近くになります。加えて E2E はリトライで並列競合を吸収している状態なので、gate にすると無関係な PR が揺れで止まります。Issue でもユーザー判断済みの方針です。

## 構成

| トリガー | 対象 | 用途 |
| --- | --- | --- |
| `schedule`（毎日 18:00 UTC = 03:00 JST） | `develop` | 気づかないうちに壊れるのを防ぐ |
| `workflow_dispatch` | 任意ブランチ | リリース前チェック（従来どおり） |

**失敗の検知**が要件だったので、ナイトリー失敗時に Issue を起票します（`e2e-nightly` ラベル）。既に起票済みならコメントを足すだけにして、毎晩 Issue が増えないようにしています。深夜に走るので GitHub の通知だけでは埋もれる前提です。

失敗時は Playwright のレポート（スクリーンショット・動画）を artifact に 14 日保存します。

## セキュリティ

#347 で入った最小権限の方針に合わせ、既定を `contents: read` にし、Issue 起票のジョブにのみ `issues: write` を付与しています。

## レビュー観点

- 03:00 JST という時刻（他のワークフローと衝突しないか）
- Issue 起票の重複防止がラベル検索で足りるか
- `timeout-minutes: 20`（ローカル 1.6 分に対して十分な余裕。CI の遅さとリトライを見込む）

## 確認

- YAML の構文とジョブ構成を検証済み（`jobs: e2e, notify-failure` / `triggers: schedule, workflow_dispatch`）
- `pnpm format:check` パス
- マージ後に `workflow_dispatch` で 1 回手動実行し、CI 環境で 154 件が通ることを確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAehqhEfJ6LcTZwmi7CXPv