### PR TITLE
test: E2E のセレクタから文言依存を排除し、言語テストを安定化する

### DIFF
--- a/src/components/options/HelpSettingsBackup.tsx
+++ b/src/components/options/HelpSettingsBackup.tsx
@@ -183,6 +183,7 @@ export function HelpSettingsBackup({
               </p>
             </div>
             <Button
+              data-testid="settings-export-button"
               onClick={handleExport}
               disabled={exportStatus === 'loading'}
               size="sm"
@@ -225,6 +226,7 @@ export function HelpSettingsBackup({
             </div>
             <div>
               <input
+                data-testid="settings-import-input"
                 ref={fileInputRef}
                 type="file"
                 accept=".json"
@@ -232,6 +234,7 @@ export function HelpSettingsBackup({
                 className="hidden"
               />
               <Button
+                data-testid="settings-import-button"
                 onClick={handleImportClick}
                 disabled={importStatus === 'loading'}
                 size="sm"

--- a/tests/e2e/helpers/constants.ts
+++ b/tests/e2e/helpers/constants.ts
@@ -212,10 +212,9 @@ export const SELECTORS = {
     passwordFormSubmit: '[data-testid="password-form-submit"]',
     passwordFormCancel: '[data-testid="password-form-cancel"]',
     analyticsOptInToggle: '[data-testid="analytics-optin-toggle"]',
-    exportSettingsButton:
-      'button:has-text("エクスポート"), button:has-text("Export")',
-    importSettingsButton:
-      'button:has-text("選択"), button:has-text("Select File")',
+    exportSettingsButton: '[data-testid="settings-export-button"]',
+    importSettingsButton: '[data-testid="settings-import-button"]',
+    importSettingsInput: '[data-testid="settings-import-input"]',
     importResultMessage: '[data-testid="import-result-message"]',
     faqItem: '[data-testid="help-faq-item"]'
   }

--- a/tests/e2e/helpers/storage.ts
+++ b/tests/e2e/helpers/storage.ts
@@ -374,17 +374,25 @@ export function makeSiteBlockCounts(
  * @param page - Playwright Page オブジェクト
  * @param options - テストオプション
  */
-export async function setupTestStorage(
-  page: Page,
-  options: {
-    withGoal?: boolean;
-    withBlockList?: boolean;
-    withPassword?: boolean;
-    withAnalyticsOptIn?: boolean;
-    withSchedule?: boolean;
-    language?: 'en' | 'ja';
-  } = {}
-): Promise<void> {
+export interface TestStorageOptions {
+  withGoal?: boolean;
+  withBlockList?: boolean;
+  withPassword?: boolean;
+  withAnalyticsOptIn?: boolean;
+  withSchedule?: boolean;
+  language?: 'en' | 'ja';
+}
+
+/**
+ * テスト用の storage データを組み立てる（書き込みは行わない）
+ *
+ * AppSettings の必須フィールドを欠くと、実装側で settings.blockList.length の
+ * ような参照が例外になる（アプリはストレージに保存済みの値をそのまま使う）。
+ * 実装のスキーマと同じ形を必ず満たすこと。
+ */
+export function makeTestStorage(
+  options: TestStorageOptions = {}
+): Record<string, unknown> {
   const {
     withGoal = true,
     withBlockList = false,
@@ -394,11 +402,7 @@ export async function setupTestStorage(
     language = 'en'
   } = options;
 
-  // デフォルト設定。
-  // AppSettings の必須フィールドを欠くと、実装側で settings.blockList.length の
-  // ような参照が例外になる（アプリはストレージに保存済みの値をそのまま使う）。
-  // 実装のスキーマと同じ形を必ず満たすこと
-  const defaultSettings = {
+  const settings: Record<string, unknown> = {
     blockList: [],
     schedules: [],
     language,
@@ -427,7 +431,7 @@ export async function setupTestStorage(
   // パスワード保護は enabled と passwordHash の両方が必要
   // （src/hooks/usePopupActions.ts の isPasswordProtected）
   if (withPassword) {
-    defaultSettings['password'] = {
+    settings.password = {
       enabled: true,
       passwordHash: TEST_DATA.password.validHash
     };
@@ -436,7 +440,7 @@ export async function setupTestStorage(
   // 週間カレンダーはスケジュールが 1 件以上ないと描画されない
   // （WeeklyCalendar は schedules.length === 0 で null を返す）
   if (withSchedule) {
-    defaultSettings['schedules'] = [
+    settings.schedules = [
       {
         id: 'schedule-1',
         name: 'Work Hours',
@@ -449,10 +453,10 @@ export async function setupTestStorage(
     ];
   }
 
-  // ブロックリストは settings.blockList に保持される（トップレベルの
-  // blockList キーではない）
+  // ブロックリストは settings.blockList に保持される
+  // （トップレベルの blockList キーではない）
   if (withBlockList) {
-    defaultSettings['blockList'] = [
+    settings.blockList = [
       {
         id: '1',
         domain: 'example.com',
@@ -463,7 +467,7 @@ export async function setupTestStorage(
     ];
   }
 
-  await setStorageData(page, 'settings', defaultSettings);
+  const data: Record<string, unknown> = { settings };
 
   // Vision 設定（目標テキスト）。
   // DashboardDisplaySettings / DashboardPreset の全フィールドを満たすこと。
@@ -479,7 +483,7 @@ export async function setupTestStorage(
       customBackgroundData: null,
       fontSettings: { family: 'system', size: 'lg', weight: 'bold' }
     };
-    const defaultVision = {
+    data.vision = {
       defaultSettings: displaySettings,
       presets: [
         {
@@ -491,6 +495,26 @@ export async function setupTestStorage(
       ],
       activePresetId: 'default'
     };
-    await setStorageData(page, 'vision', defaultVision);
+  }
+
+  return data;
+}
+
+/**
+ * テスト用の storage データをページ経由で書き込む
+ *
+ * 注意: 拡張機能のページを開いた状態で書くため、アプリの hydration が
+ * state を書き戻して上書きすることがある。言語設定のように「アプリが
+ * 読み込んで描画に使う」値を確実に置きたい場合は、SW 経由の
+ * `setupTestStorageViaSW` を使う。
+ */
+export async function setupTestStorage(
+  page: Page,
+  options: TestStorageOptions = {}
+): Promise<void> {
+  const data = makeTestStorage(options);
+
+  for (const [key, value] of Object.entries(data)) {
+    await setStorageData(page, key, value);
   }
 }

--- a/tests/e2e/helpers/sw.ts
+++ b/tests/e2e/helpers/sw.ts
@@ -1,5 +1,7 @@
 import type { BrowserContext, Worker } from '@playwright/test';
 
+import { makeTestStorage, type TestStorageOptions } from './storage';
+
 /**
  * Service Worker（background）経由の操作ヘルパー
  *
@@ -27,20 +29,32 @@ export async function getServiceWorker(
  */
 export async function setupStorageViaSW(
   context: BrowserContext,
-  data: Record<string, unknown>
+  data: Record<string, unknown>,
+  options: { clear?: boolean } = {}
 ): Promise<void> {
   const sw = await getServiceWorker(context);
+  const { clear = true } = options;
 
-  await sw.evaluate(async (payload: string) => {
-    const entries = JSON.parse(payload) as Record<string, unknown>;
-    await chrome.storage.local.clear();
+  await sw.evaluate(
+    async (payload: string) => {
+      const { entries, clear } = JSON.parse(payload) as {
+        entries: Record<string, unknown>;
+        clear: boolean;
+      };
 
-    const stringified: Record<string, string> = {};
-    for (const [key, value] of Object.entries(entries)) {
-      stringified[key] = JSON.stringify(value);
-    }
-    await chrome.storage.local.set(stringified);
-  }, JSON.stringify(data));
+      // 拡張機能のページが開いている状態で clear すると、アプリが自分の
+      // state を書き戻して上書きすることがある。開いたまま書き換える
+      // 場合は clear: false を指定する
+      if (clear) await chrome.storage.local.clear();
+
+      const stringified: Record<string, string> = {};
+      for (const [key, value] of Object.entries(entries)) {
+        stringified[key] = JSON.stringify(value);
+      }
+      await chrome.storage.local.set(stringified);
+    },
+    JSON.stringify({ entries: data, clear })
+  );
 }
 
 /** 現在の動的ブロックルールの urlFilter 一覧を取得する */
@@ -138,4 +152,18 @@ export async function getStorageViaSW<T = unknown>(
     if (raw === undefined) return null;
     return typeof raw === 'string' ? JSON.parse(raw) : raw;
   }, key);
+}
+
+/**
+ * テスト用の storage データを SW 経由で書き込む
+ *
+ * アプリに上書きされないため、言語設定のように「アプリが読み込んで描画に
+ * 使う」値を確実に置きたいときはこちらを使う。
+ */
+export async function setupTestStorageViaSW(
+  context: BrowserContext,
+  options: TestStorageOptions & { clear?: boolean } = {}
+): Promise<void> {
+  const { clear, ...storageOptions } = options;
+  await setupStorageViaSW(context, makeTestStorage(storageOptions), { clear });
 }

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures/extension';
 import { openPopup, openNewTab, openOptions } from './helpers/pages';
-import { clearStorageFromExtension, setupTestStorage } from './helpers/storage';
+import { clearStorageFromExtension } from './helpers/storage';
+import { setupTestStorageViaSW } from './helpers/sw';
 import { SELECTORS } from './helpers/constants';
 
 /**
@@ -19,9 +20,8 @@ test.describe('i18n - 多言語対応', () => {
     extensionId
   }) => {
     // 英語に設定
-    const setupPage = await openPopup(context, extensionId);
-    await setupTestStorage(setupPage, { language: 'en' });
-    await setupPage.close();
+    // 言語設定は描画に直結するため、アプリに上書きされない SW 経由で置く
+    await setupTestStorageViaSW(context, { language: 'en' });
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -40,9 +40,8 @@ test.describe('i18n - 多言語対応', () => {
     extensionId
   }) => {
     // 日本語に設定
-    const setupPage = await openPopup(context, extensionId);
-    await setupTestStorage(setupPage, { language: 'ja' });
-    await setupPage.close();
+    // 言語設定は描画に直結するため、アプリに上書きされない SW 経由で置く
+    await setupTestStorageViaSW(context, { language: 'ja' });
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -60,9 +59,8 @@ test.describe('i18n - 多言語対応', () => {
     extensionId
   }) => {
     // 最初は英語
-    const setupPage = await openPopup(context, extensionId);
-    await setupTestStorage(setupPage, { language: 'en' });
-    await setupPage.close();
+    // 言語設定は描画に直結するため、アプリに上書きされない SW 経由で置く
+    await setupTestStorageViaSW(context, { language: 'en' });
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -87,9 +85,8 @@ test.describe('i18n - 多言語対応', () => {
     extensionId
   }) => {
     // 日本語に設定
-    const setupPage = await openPopup(context, extensionId);
-    await setupTestStorage(setupPage, { language: 'ja' });
-    await setupPage.close();
+    // 言語設定は描画に直結するため、アプリに上書きされない SW 経由で置く
+    await setupTestStorageViaSW(context, { language: 'ja' });
 
     // Popup を開く
     const popupPage = await openPopup(context, extensionId);
@@ -121,9 +118,8 @@ test.describe('i18n - 多言語対応', () => {
     extensionId
   }) => {
     // 最初は英語
-    const setupPage = await openOptions(context, extensionId);
-    await setupTestStorage(setupPage, { language: 'en' });
-    await setupPage.close();
+    // 言語設定は描画に直結するため、アプリに上書きされない SW 経由で置く
+    await setupTestStorageViaSW(context, { language: 'en' });
 
     // Options を開く
     const optionsPage = await openOptions(context, extensionId);
@@ -131,10 +127,10 @@ test.describe('i18n - 多言語対応', () => {
       'VisionFocus Dashboard'
     );
 
-    // 言語を日本語に変更する（ヘルパー経由で完全な設定を書き込む）
-    const updatePage = await openOptions(context, extensionId);
-    await setupTestStorage(updatePage, { language: 'ja' });
-    await updatePage.close();
+    // 言語を日本語に変更する。
+    // options ページを開いたまま clear すると、アプリが state を書き戻して
+    // 英語に戻してしまうため、clear せず上書きする
+    await setupTestStorageViaSW(context, { language: 'ja', clear: false });
 
     // リロードで反映されることを確認
     await optionsPage.reload();


### PR DESCRIPTION
## 概要

#327 の受け入れ条件「`SELECTORS` が文言・Tailwind クラス名に依存しなくなっている」を満たし、Issue を閉じます。

Closes #327

## 1. 最後の文言依存を除去

残っていたのは 2 個でした。

```diff
-    exportSettingsButton:
-      'button:has-text("エクスポート"), button:has-text("Export")',
-    importSettingsButton:
-      'button:has-text("選択"), button:has-text("Select File")',
+    exportSettingsButton: '[data-testid="settings-export-button"]',
+    importSettingsButton: '[data-testid="settings-import-button"]',
+    importSettingsInput: '[data-testid="settings-import-input"]',
```

**これで `SELECTORS` は全 124 個が `data-testid` ベースになりました。** 文言変更や Tailwind のクラス調整で E2E が壊れる構造がなくなっています。

## 2. 言語テストの不安定さを解消

`i18n.spec.ts` は通し実行でまれに落ちていました（毎回ではなく、I18N-004 / I18N-005 が時々）。原因は #352 で見つけたものと同じで、**ページ経由で settings を書くとアプリの hydration が state を書き戻し、`language` が既定値に戻る**ことでした。

- `setupTestStorage` のデータ構築を `makeTestStorage()` に切り出し
- SW 経由で書く `setupTestStorageViaSW()` を追加し、i18n.spec をこれに切り替え
- `setupStorageViaSW` に `clear` オプションを追加

`clear` オプションが必要だった理由: **拡張機能のページを開いたまま `chrome.storage.local.clear()` すると、アプリがそれを検知して自分の state を書き戻す**ため、直後の書き込みが消えます。I18N-005 は「options を開いたまま言語を変える」テストなので `clear: false` で上書きします。

検証: `--repeat-each=4`（i18n 20 回）で I18N-005 は安定。I18N-004 は 1 回 flaky（リトライで通過）まで改善しました。

念のため「画面を開くと `language` が失われるのでは」という仮説を実機で 3 周検証しましたが、**設定は保持されていました**。実装のバグではありません。

## 確認

- E2E: 154 passed / 0 failed / 5 skipped
- `pnpm lint` エラー 0 / `pnpm type-check` パス / `pnpm format:check` パス

## レビュー観点

- `makeTestStorage` の切り出しで既存 12 spec の挙動が変わっていないか（データ構築は完全に同一、書き込み方法だけ選べるようにした）
- `clear: false` の使い分けが分かる形になっているか

## 別途対応するもの

**ローカル実行時にカーソルが奪われる問題**を検証し、`channel: 'chromium'` + `headless: true`（新ヘッドレス）で**拡張機能をロードしたまま完全ヘッドレス実行が可能**であることを確認しました。155 件すべて通り、実行時間も 1.7 分 → 1.4 分に短縮します。この PR とは分けて出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAehqhEfJ6LcTZwmi7CXPv