### PR TITLE
fix(ci): claude-review workflow に permissions を追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# 呼び出し先（claude-review-shared.yml）が要求する権限を明示的に付与する。
+# 再利用ワークフローでは呼び出し元がこれを宣言しないと起動前に拒否される。
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   review:
     uses: machina-gg/trillion-game/.github/workflows/claude-review-shared.yml@develop


### PR DESCRIPTION
## 概要
claude-review.yml が呼び出す再利用ワークフロー(`machina-gg/trillion-game/.github/workflows/claude-review-shared.yml@develop`)が要求する permissions を、呼び出し元 workflow に明示的に付与する。

## 背景
再利用ワークフローでは、呼び出し元が permissions を宣言しないと GITHUB_TOKEN の権限がデフォルト(read-only 等)に絞られ、起動前に拒否(startup_failure)される場合がある。trillion-game リポの claude-review.yml で #294 にて同様の修正が行われており、本 PR は同等の修正を vision-focus に展開するもの。

## 変更内容
`.github/workflows/claude-review.yml` に以下を追加:
```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
```

Refs machina-gg/trillion-game#423